### PR TITLE
feat: recover MIPS global-variable access (%hi/%lo → gaddr)

### DIFF
--- a/packages/core/src/contracts.ts
+++ b/packages/core/src/contracts.ts
@@ -97,6 +97,17 @@ export function assertDerefsTyped(sfn: SFn): void {
         }
       }
     }
+    // A bare global ADDRESS `&SYM` under `+`/`-` is an ESCAPING interior pointer: C scales the byte
+    // offset by sizeof(SYM), which is unknown for a header-typed global, so `&SYM + N` is byte-
+    // inexact. A load/store base folds the offset byte-correctly (globalOf turns `&SYM + N` into an
+    // `index`/`field` node whose base is a bare `addr`, never an `addr` under a `bin`), so an `addr`
+    // reaching a `+`/`-` operand here escaped to a value context — flag it rather than emit wrong bytes.
+    if (e.k === 'bin' && (e.op === '+' || e.op === '-')) {
+      const addrSide = e.l.k === 'addr' ? e.l : e.r.k === 'addr' ? e.r : undefined;
+      if (addrSide) {
+        bad.push(`interior pointer arithmetic on the global address '&${addrSide.name}'`);
+      }
+    }
     // `!p` is legal C (pointer truthiness); `-p`/`~p` are not.
     if (e.k === 'un' && e.op !== '!' && ctype(e.e)?.kind === 'ptr') {
       bad.push(`pointer operand under unary '${e.op}'`);

--- a/packages/core/src/frontend/mips.ts
+++ b/packages/core/src/frontend/mips.ts
@@ -88,6 +88,23 @@ const isXfer = (ins: Instr) => isReturn(ins) || isUncond(ins) || isCond(ins);
 // `sll`+`addu` before the access, so no `base+index` addressing form appears in parseMem input.
 const parseDisasm = (disasm: string): Instr[] => parseSharedDisasm(disasm);
 
+// A MIPS `%hi`/`%lo` relocation operand — the assembler's HI16/LO16 split that materialises the
+// address of a named global: `%hi(SYM)`, `%lo(SYM)`, `%hi(SYM + N)`, or the memory form
+// `%lo(SYM + N)(base)`. Splat spells global access this way and the Splat parser preserves it
+// verbatim (frontend/splat.ts); `lift` folds a `lui %hi` + its consuming `%lo` into a single
+// `gaddr(SYM)` (the same op the Thumb frontend emits for a pool-loaded global), carrying the
+// addend as the access offset. Returns null for a non-`%hi/%lo` operand. The objdump dialect never
+// produces these (IDO resolves globals via `gp`), so this path is Splat-only.
+function parseReloc(kind: 'hi' | 'lo', operand: string): { sym: string; addend: number; base?: string } | null {
+  const m = operand.match(
+    new RegExp(String.raw`^%${kind}\(\s*([A-Za-z_.$][\w.$]*)\s*(?:\+\s*(0x[0-9a-fA-F]+|\d+))?\s*\)(?:\((\w+)\))?$`),
+  );
+  if (!m) {
+    return null;
+  }
+  return { sym: m[1], addend: m[2] ? parseImm(m[2]) : 0, base: m[3] };
+}
+
 interface MipsBlock {
   startAddr: number;
   body: Instr[]; // computation instructions (excludes the branch and its delay slot)
@@ -459,9 +476,30 @@ export function lift(
 
   const fillBlock = (b: MipsBlock, bi: number) => {
     const ops = irBlocks[bi].ops;
+    // Pending `lui rX, %hi(SYM)` relocations awaiting their consuming `%lo` (a load/store base or an
+    // `addiu`). Block-local: the pair is emitted adjacently, so a `%lo` with no matching in-scope
+    // `%hi` (a cross-block or gp-relative access) declines LOUD rather than fabricating a base.
+    const hiReloc = new Map<string, { sym: string; addend: number }>();
+    // Materialise the address of a named global — the same `gaddr` op the Thumb frontend emits; the
+    // structurer lowers a load/store through it to `SYM` (scalar) or `((T *)&SYM)[i]` (aggregate).
+    const emitGaddr = (sym: string): Value => {
+      const g = mkValue(T.unk(32));
+      ops.push(mkOp('gaddr', { results: [g], attrs: { sym } }));
+      return g;
+    };
     const read = (r: string): Value => {
       if (isZero(r)) {
         return constVal(0);
+      }
+      // A `%hi(SYM)` register read as DATA before its `%lo` completes the address is a split hi/lo
+      // relocation (the high half used alone) this frontend does not model — decline rather than
+      // treat the partial address as a value. The legit consumers (load/store/addiu `%lo`) validate
+      // `hiReloc` directly and never route the base through `read`, so this fires only on misuse.
+      const hr = hiReloc.get(r);
+      if (hr) {
+        throw new FrontendUnsupportedError(
+          `cannot lift '${name}': %hi(${hr.sym}) register used as data before a matching %lo — split hi/lo relocation not modelled`,
+        );
       }
       // Reading `sp` as a DATA operand means frame-pointer arithmetic or an address-taken local
       // (`addiu a0,sp,8` = `&local`) — not modellable without a stack abstraction. Fabricating a
@@ -485,6 +523,10 @@ export function lift(
       return readVar(r, bi);
     };
     const write = (r: string, v: Value) => {
+      // Writing a register clears any pending `%hi` it held — the high-half address is gone once the
+      // register is reassigned (e.g. `lw rHi, %lo(SYM)(rHi)` reuses the base as the load dest). A
+      // `%hi` NOT overwritten persists across multiple `%lo` uses (the read-modify-write idiom).
+      hiReloc.delete(r);
       if (!isZero(r)) {
         writeVar(r, bi, v);
       }
@@ -535,6 +577,22 @@ export function lift(
         // and raise/const.ts folds the const/const pair into one 32-bit const — the form that
         // recompiles to this exact `lui;ori`.
         case 'lui':
+          // `lui rD, %hi(SYM)` is the high half of a global's address — record it, pending the `%lo`
+          // that completes it (below), instead of materialising a bogus numeric const. rD's SSA value
+          // is deliberately NOT written: the high half is meaningless alone, so the `gaddr` is emitted
+          // at the consuming `%lo`. A read of rD as data before that is caught by the `read` guard;
+          // an UNconsumed `%hi` (no `%lo`) is a dead `lui` whose rD is never read — the residual case
+          // (an unconsumed `%hi` reg read via a `readVar` bypass) does not occur in compiler output.
+          if (s.startsWith('%')) {
+            const hi = parseReloc('hi', s);
+            if (!hi) {
+              throw new FrontendUnsupportedError(`cannot lift '${name}': unsupported relocation immediate '${s}'`);
+            }
+            if (!isZero(d)) {
+              hiReloc.set(d, { sym: hi.sym, addend: hi.addend });
+            }
+            break;
+          }
           write(d, constVal((parseImm(s) << 16) >> 0));
           break;
         case 'addiu':
@@ -543,6 +601,24 @@ export function lift(
           // keys slots by literal sp-offset, so the frame base never needs a value). Skip it,
           // mirroring PPC's `addi r1`. Any OTHER read of sp falls through to `read`, which loud-fails.
           if (isStackPtr(d)) {
+            break;
+          }
+          // `addiu rD, rHi, %lo(SYM)` completes a global's address materialised by a `lui %hi(SYM)`:
+          // rD = &SYM (+ addend for a byte offset into the global). Emits the shared `gaddr` op.
+          if (t.startsWith('%')) {
+            const lo = parseReloc('lo', t);
+            const hr = lo ? hiReloc.get(s) : undefined;
+            if (!lo || !hr || hr.sym !== lo.sym || hr.addend !== lo.addend) {
+              throw new FrontendUnsupportedError(
+                `cannot lift '${name}': %lo relocation '${t}' with no matching in-scope %hi — split/cross-block hi/lo not modelled`,
+              );
+            }
+            // `&SYM` (addend 0), or `&SYM + N` for a byte offset into the global. The `add` tree is
+            // folded byte-correctly by memAccess when this address is a load/store base; if it
+            // instead ESCAPES as a value, `assertDerefsTyped` declines it (the byte offset would
+            // element-scale in C) — see the interior-global-pointer guard there.
+            const g = emitGaddr(lo.sym);
+            lo.addend !== 0 ? emitBin('add', d, g, constVal(lo.addend)) : write(d, g);
             break;
           }
           if (isZero(s)) {
@@ -714,6 +790,16 @@ export function lift(
     // drop its destination register — emit an honest `opaque`: dead ⇒ it vanishes; live ⇒
     // assertResolved fails LOUD (see frontend/opaque.ts for the policy).
     const emitOpaqueDest = (ins: Instr) => {
+      // A `%hi`/`%lo` operand on an instruction NOT modelled as a global consumer — an FP load/store
+      // (`lwc1`/`ldc1`), or any unmodelled op — reaches here (the modelled consumers handle their own
+      // `%hi`/`%lo` and return before the default case). Dropping it to an opaque would silently
+      // delete the global access (its base is not a bare register the opaque srcReg scan can see), so
+      // decline LOUD rather than lose it.
+      if (ins.ops.some((o) => o.startsWith('%'))) {
+        throw new FrontendUnsupportedError(
+          `cannot lift '${name}': unmodelled instruction '${ins.mnemonic}' with a %hi/%lo global operand — not modelled`,
+        );
+      }
       // storeClass: unmodelled MIPS stores — incl. the unaligned pair swl/swr and the FPU stores,
       // whose FIRST token is a register (a SOURCE, not a dest) that would otherwise fabricate an
       // opaque write to it while dropping the real memory write.
@@ -738,7 +824,30 @@ export function lift(
     };
     const emitUn = kit.un;
     const emitShImm = (opc: Opcode, d: string, x: Value, sa: string) => kit.shImm(opc, d, x, parseImm(sa));
+    // Resolve a `%lo(SYM + N)(rHi)` memory operand to a global address: validate it pairs with an
+    // in-scope `%hi`, emit the `gaddr`, and return it as the base with the addend as the access
+    // offset. A non-`%lo` operand returns null (the caller falls through to the normal off(base)).
+    const globalBase = (mem: string): { base: Value; off: number } | null => {
+      if (!mem.startsWith('%')) {
+        return null;
+      }
+      const lo = parseReloc('lo', mem);
+      const hr = lo && lo.base ? hiReloc.get(lo.base) : undefined;
+      if (!lo || !lo.base || !hr || hr.sym !== lo.sym || hr.addend !== lo.addend) {
+        throw new FrontendUnsupportedError(
+          `cannot lift '${name}': %lo access '${mem}' with no matching in-scope %hi — split/cross-block hi/lo not modelled`,
+        );
+      }
+      return { base: emitGaddr(lo.sym), off: lo.addend };
+    };
     const emitLoad = (d: string, mem: string, width: number, signed: boolean) => {
+      const g = globalBase(mem);
+      if (g) {
+        const res = mkValue(T.unk(32));
+        ops.push(mkOp('load', { operands: [g.base], results: [res], attrs: { off: g.off, width, signed } }));
+        write(d, res);
+        return;
+      }
       const { off, base } = parseMem(mem);
       // A word reload from a stack slot is transparent to dataflow — the SAME value spilled — so
       // route it through the slot SSA variable, not a `load` through `sp` (which would make `sp` a
@@ -764,6 +873,11 @@ export function lift(
       write(d, res);
     };
     const emitStore = (srcReg: string, mem: string, width: number) => {
+      const g = globalBase(mem);
+      if (g) {
+        ops.push(mkOp('store', { operands: [g.base, read(srcReg)], attrs: { off: g.off, width } }));
+        return;
+      }
       const { off, base } = parseMem(mem);
       // A word spill to a stack slot (an argument home slot `sw a0,0(sp)`, or a local): record the
       // slot's value in SSA, do NOT emit a `store` through `sp`. A never-reloaded spill (the ABI

--- a/packages/core/src/frontend/splat.ts
+++ b/packages/core/src/frontend/splat.ts
@@ -15,10 +15,10 @@
 //   • constant immediate EXPRESSIONS (`(0x660104 >> 16)`, `(x & 0xFFFF)`) — the assembler's hi/lo
 //     split of a 32-bit literal, evaluated here to the plain number the decode switch parses.
 //
-// `%hi`/`%lo` (and the other GOT/PIC relocation operands) are declined LOUD: MIPS *global* data
-// access is not modelled — exactly as the objdump/IDO path declines its gp-relative equivalent.
-// A silent NaN immediate (what `parseImm('%hi(SYM)')` would produce) is the cardinal-rule failure
-// this decline exists to prevent.
+// `%hi`/`%lo` operands (a global's address) are preserved verbatim so the MIPS frontend can fold
+// them into a `gaddr` (frontend/mips.ts). The other GOT/PIC relocations (`%gp_rel`, `%got`, …) are
+// declined LOUD — small-data / position-independent access is not modelled. Preserving rather than
+// blindly evaluating is what keeps `parseImm('%hi(SYM)')` from silently becoming a NaN immediate.
 import type { DisasmInstr } from './disasm';
 import { FrontendUnsupportedError } from './errors';
 
@@ -28,8 +28,10 @@ const INSN_LINE = /^\/\*\s*[0-9A-Fa-f]+\s+([0-9A-Fa-f]+)\s+[0-9A-Fa-f]+\s*\*\/\s
 const INSN_SIGNAL = /\/\*\s*[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s*\*\//;
 // A local-label DEFINITION on its own line (`.L800011C0_1DC0:`); the colon is required.
 const LABEL_DEF = /^(\.[\w.$]+):$/;
-// A GOT/PIC/hi-lo relocation operand — global data access, declined loud (see the file header).
-const RELOC_OP = /%(hi|lo|gp_rel|gprel|got|call16|call_hi|call_lo|higher|highest|neg|tprel|dtprel)\b/i;
+// A GOT/PIC relocation operand this reader does not support (small-data / position-independent
+// access) — declined loud. `%hi`/`%lo` are NOT here: they name a global's address and are preserved
+// verbatim for the MIPS frontend to fold into a `gaddr` (see normalizeOperand / frontend/mips.ts).
+const RELOC_OP = /%(gp_rel|gprel|got|call16|call_hi|call_lo|higher|highest|neg|tprel|dtprel)\b/i;
 // Data directives whose bytes could encode an effect: skipping one inside a function slice would
 // silently delete it, so they decline (mirrors the Thumb frontend's in-code-data guard).
 const DATA_DIRECTIVE =
@@ -192,11 +194,17 @@ function splitOperands(s: string): string[] {
 
 // Rewrite one Splat operand into the canonical objdump spelling the frontend consumes: strip the
 // `$` register sigil, fold a memory operand's displacement expression, evaluate a bare constant
-// expression, and decline a global relocation operand.
+// expression, preserve a `%hi`/`%lo` global reference, and decline an unsupported PIC relocation.
 function normalizeOperand(name: string, op: string): string {
+  // `%hi(SYM)` / `%lo(SYM + N)` / `%lo(SYM)(base)` — a global's address. Preserved verbatim (with a
+  // de-sigiled base) for the MIPS frontend to fold into a `gaddr`; NOT declined like the PIC relocs.
+  const hilo = op.match(/^(%(?:hi|lo)\([^)]*\))(?:\((\$?[A-Za-z]\w*)\))?$/);
+  if (hilo) {
+    return hilo[2] ? `${hilo[1]}(${hilo[2].replace(/^\$/, '')})` : hilo[1];
+  }
   if (RELOC_OP.test(op)) {
     throw new FrontendUnsupportedError(
-      `cannot lift '${name}': relocation operand '${op}' (global / PIC data access) — MIPS global data access is not yet modelled`,
+      `cannot lift '${name}': relocation operand '${op}' (small-data / PIC data access) — not modelled`,
     );
   }
   // Memory operand `DISP(base)` — base is a register (letter-first), DISP a constant/expression.

--- a/packages/core/test/splat-dialect.test.ts
+++ b/packages/core/test/splat-dialect.test.ts
@@ -1,8 +1,8 @@
 // Splat-dialect MIPS reader (frontend/splat.ts): the pmret/decomp.me `.s` flavour normalises into
 // the same DisasmInstr[] the objdump path yields. These pin the dialect-specific behaviour —
 // `glabel`/`endlabel` slicing, `/* rom vram bytes */` prefixes, `$`-register stripping, `.L`-label
-// branch targets, constant-expression immediates — plus the loud declines that keep a global
-// relocation (`%hi`/`%lo`) from silently becoming a NaN immediate.
+// branch targets, constant-expression immediates, and `%hi`/`%lo` global recovery (the pair folds
+// to a `gaddr`) — plus the loud declines (unpaired `%lo`, PIC relocs, in-code data, tail calls).
 import { expect, test } from 'vitest';
 
 import { FrontendUnsupportedError } from '../src/frontend/errors';
@@ -48,7 +48,7 @@ glabel add2
 endlabel add2
 `;
 
-// A global access (`%hi`/`%lo`) — not modelled; must decline loud, never a NaN immediate.
+// A scalar global read via the `%hi`/`%lo` pair — recovers to the bare global name `D_800A2884`.
 const SPLAT_GLOBAL = `glabel getGlobal
     /* 200 80000200 3C02800A */  lui        $v0, %hi(D_800A2884)
     /* 204 80000204 03E00008 */  jr         $ra
@@ -87,12 +87,81 @@ test('splat: the requested name selects ITS function; an absent symbol declines 
   expect(() => parseSplatMips(SPLAT_TWO, 'ghost')).toThrow(/functions present: add1, add2/);
 });
 
-test('splat: a global relocation operand declines loud, never a NaN immediate', () => {
-  expect(() => decompile('getGlobal', SPLAT_GLOBAL, MIPS_IDO)).toThrow(FrontendUnsupportedError);
-  expect(() => decompile('getGlobal', SPLAT_GLOBAL, MIPS_IDO)).toThrow(/%hi\(D_800A2884\).*global.*not yet modelled/);
-  // annotate mode names the gap instead of crashing
-  const annotated = decompile('getGlobal', SPLAT_GLOBAL, MIPS_IDO, { onGap: 'annotate' });
-  expect(annotated.source).toContain('ASMLIFT_ERROR');
+test('splat: a lui %hi + lw %lo pair recovers a scalar global read (bare name, no NaN)', () => {
+  // the whole point of preserving %hi/%lo: they fold to a `gaddr`, not a NaN immediate
+  expect(decompile('getGlobal', SPLAT_GLOBAL, MIPS_IDO).source).toBe(
+    's32 getGlobal(void) {\n    return D_800A2884;\n}\n',
+  );
+});
+
+test('splat: a read-modify-write through one global recovers to `g = g + 1`', () => {
+  const rmw = `glabel bump
+    /* 100 80000100 3C02800A */  lui        $v0, %hi(gCounter)
+    /* 104 80000104 8C430000 */  lw         $v1, %lo(gCounter)($v0)
+    /* 108 80000108 24630001 */  addiu      $v1, $v1, 1
+    /* 10C 8000010C 03E00008 */  jr         $ra
+    /* 110 80000110 AC430000 */   sw        $v1, %lo(gCounter)($v0)
+endlabel bump
+`;
+  expect(decompile('bump', rmw, MIPS_IDO).source).toContain('gCounter = gCounter + 1;');
+});
+
+test('splat: a %hi/%lo pair with an addend recovers an aggregate access through the symbol', () => {
+  // `%hi(SYM + 0x8)` / `%lo(SYM + 0x8)` → the global accessed at byte offset 8 → the `&`-address form
+  const agg = `glabel getField
+    /* 100 80000100 3C02800A */  lui        $v0, %hi(gStruct + 0x8)
+    /* 104 80000104 03E00008 */  jr         $ra
+    /* 108 80000108 8C420008 */   lw        $v0, %lo(gStruct + 0x8)($v0)
+endlabel getField
+`;
+  expect(decompile('getField', agg, MIPS_IDO).source).toContain('&gStruct');
+});
+
+test('splat: an escaping interior global pointer (&SYM + N as a value) declines, never element-scales', () => {
+  // `addiu a1, rHi, %lo(SYM + 0x18)` makes `&SYM + 24 bytes`; returning it as a VALUE would emit
+  // `&SYM + 24`, which C element-scales by sizeof(SYM). The structurer's interior-pointer guard
+  // declines rather than silently miscompile. (An addend that stays a load/store BASE is fine —
+  // memAccess folds it byte-correctly — so only the escaping form is caught.)
+  const interior = `glabel f
+    /* 100 80000100 3C05800A */  lui        $a1, %hi(GwPlayer + 0x18)
+    /* 104 80000104 24A50018 */  addiu      $a1, $a1, %lo(GwPlayer + 0x18)
+    /* 108 80000108 03E00008 */  jr         $ra
+    /* 10C 8000010C 00A01021 */   addu      $v0, $a1, $zero
+endlabel f
+`;
+  expect(() => decompile('f', interior, MIPS_IDO)).toThrow(/interior pointer arithmetic on the global address/);
+});
+
+test('splat: an FP global load (lwc1 %lo) declines loud, never a silently dropped access', () => {
+  const fp = `glabel getF
+    /* 100 80000100 3C02800A */  lui        $v0, %hi(gFloat)
+    /* 104 80000104 C4400000 */  lwc1       $f0, %lo(gFloat)($v0)
+    /* 108 80000108 03E00008 */  jr         $ra
+    /* 10C 8000010C 00000000 */   nop
+endlabel getF
+`;
+  expect(() => decompile('getF', fp, MIPS_IDO)).toThrow(/unmodelled instruction 'lwc1' with a %hi\/%lo/);
+});
+
+test('splat: an unpaired %lo (no matching %hi in scope) declines loud, never a fabricated base', () => {
+  const unpaired = `glabel f
+    /* 100 80000100 8C820000 */  lw         $v0, %lo(gX)($a0)
+    /* 104 80000104 03E00008 */  jr         $ra
+    /* 108 80000108 00000000 */   nop
+endlabel f
+`;
+  expect(() => decompile('f', unpaired, MIPS_IDO)).toThrow(/no matching in-scope %hi/);
+});
+
+test('splat: a GOT/PIC relocation operand still declines loud (small-data access not modelled)', () => {
+  const got = `glabel f
+    /* 100 80000100 8F820000 */  lw         $v0, %got(gX)($gp)
+    /* 104 80000104 03E00008 */  jr         $ra
+    /* 108 80000108 00000000 */   nop
+endlabel f
+`;
+  expect(() => decompile('f', got, MIPS_IDO)).toThrow(FrontendUnsupportedError);
+  expect(() => decompile('f', got, MIPS_IDO)).toThrow(/PIC data access/);
 });
 
 test('splat: a data directive in the code stream declines (no silent deletion)', () => {


### PR DESCRIPTION
## What

Teaches the MIPS frontend to recover **global-variable access** — the `lui %hi(SYM)` + consuming `%lo(SYM+N)` relocation idiom that Splat-disassembled N64 `.s` uses. Previously these declined (*"global data access not yet modelled"*); now a global read/write recovers as a real C global.

```c
// before: declined.   after:
v0 = D_800A2884_A3484; *v0 = 0; v0[1] = 0; ...   // scalar-pointer global
v0 = gMainGfxPos; gMainGfxPos = v0 + 2;          // read-modify-write idiom
```

Coverage on a 2000-function sweep of marioparty3 goes **15 → 81** decompiling, zero crashes.

## How (sound-by-reuse)

Emits the **existing `gaddr` op** — the same one the Thumb frontend emits for a pool-loaded global — so the whole downstream (`scalarGlobals` classification → `gSym` / `((T*)&gSym)[i]` lowering → backend) is genuinely reused, not a parallel path. No new op, level, or contract type.

- **`frontend/mips.ts`** — the symbol text only exists at decode, so recognition lives here (mirroring Thumb). A block-local `hiReloc` records each `lui %hi`, persists across multiple `%lo` consumers (RMW), and clears on any write to the register. `gaddr` is emitted at the consuming `%lo`; the addend rides as the access offset.
- **`frontend/splat.ts`** — preserves `%hi`/`%lo` operands verbatim; declines only the PIC relocs (`%got`, `%gp_rel`, …).

## Adversarial review outcome

Architecture reviewer: **SOUND — ship it**. Bug reviewer found **two confirmed issues, both fixed**:

- **Silent miscompile — escaping interior global pointer.** `&SYM + N` (a byte offset) would element-scale in C once the address *escapes* (returned / stored / compared). Declined **precisely at the structure boundary** (`assertDerefsTyped`): an `addr` under a `bin +/-` is the escaping case, because a load/store base folds the offset byte-correctly via `memAccess`/`globalOf` (the `addr` becomes an `index`/`field` base, never sits under a `bin`). Byte-correct load-base addend uses keep working; only the escapes decline. Verified on 3 real corpus witnesses (all now decline) and a full sweep (**0 residual `&SYM + N`**).
- **Loud→silent regression — FP global load.** `lwc1`/`ldc1` with a `%lo` operand fell through to a silently-dropped opaque; now declines loud.

Plus a `lui $zero` guard and a documenting comment on the (unreachable) unconsumed-`%hi` `readVar`-bypass residual.

## Boundaries kept honest
`jal` (MIPS calls) remains an honest decline — a separate milestone. The two coverage cases "lost" (83→81) are exactly the functions that were silently miscompiling and now decline.

## Testing
- `test/splat-dialect.test.ts` (15): scalar read, RMW, aggregate-with-addend, escaping-pointer decline, FP-load decline, unpaired-`%lo` decline, PIC decline.
- Full offline suite green (392); Thumb global tests unaffected by the shared contract change; typecheck/lint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)