### PR TITLE
feat: recover MIPS globals from objdump relocations (reloc→gaddr bridge)

### DIFF
--- a/packages/core/src/frontend/mips.ts
+++ b/packages/core/src/frontend/mips.ts
@@ -91,10 +91,11 @@ const parseDisasm = (disasm: string): Instr[] => parseSharedDisasm(disasm);
 // A MIPS `%hi`/`%lo` relocation operand — the assembler's HI16/LO16 split that materialises the
 // address of a named global: `%hi(SYM)`, `%lo(SYM)`, `%hi(SYM + N)`, or the memory form
 // `%lo(SYM + N)(base)`. Splat spells global access this way and the Splat parser preserves it
-// verbatim (frontend/splat.ts); `lift` folds a `lui %hi` + its consuming `%lo` into a single
-// `gaddr(SYM)` (the same op the Thumb frontend emits for a pool-loaded global), carrying the
-// addend as the access offset. Returns null for a non-`%hi/%lo` operand. The objdump dialect never
-// produces these (IDO resolves globals via `gp`), so this path is Splat-only.
+// verbatim (frontend/splat.ts); the objdump dialect hides the symbol in a relocation, which
+// `applyMipsGlobalRelocs` rewrites into the same `%hi`/`%lo` operands. Either way `lift` folds a
+// `lui %hi` + its consuming `%lo` into a single `gaddr(SYM)` (the op the Thumb frontend also emits
+// for a pool-loaded global), carrying the addend as the access offset. Returns null for a
+// non-`%hi/%lo` operand.
 function parseReloc(kind: 'hi' | 'lo', operand: string): { sym: string; addend: number; base?: string } | null {
   const m = operand.match(
     new RegExp(String.raw`^%${kind}\(\s*([A-Za-z_.$][\w.$]*)\s*(?:\+\s*(0x[0-9a-fA-F]+|\d+))?\s*\)(?:\((\w+)\))?$`),
@@ -103,6 +104,81 @@ function parseReloc(kind: 'hi' | 'lo', operand: string): { sym: string; addend: 
     return null;
   }
   return { sym: m[1], addend: m[2] ? parseImm(m[2]) : 0, base: m[3] };
+}
+
+// Bridge objdump global-access relocations into the `%hi`/`%lo` operands `parseReloc` reads, so the
+// gaddr recognition recovers named globals from an object file the same way it does from Splat text.
+// In objdump a global load shows `lui rX,0x0` with the symbol ONLY in the `R_MIPS_HI16`/`LO16`
+// reloc records — without this the base decodes as address 0 and the access reads `*(T *)0`. Using
+// asmData, rewrite each `lui`'s immediate to `%hi(SYM)` and its paired consumer's operand to
+// `%lo(SYM[+N])`. Mirrors the harness's disasmToM2c rewrite, so asmlift and m2c recover the same
+// symbols. NAMED object symbols only — a reloc against a `.rodata`/`.data` SECTION is a jump-table
+// base (Regime B) or section-relative data, left untouched.
+function applyMipsGlobalRelocs(instrs: Instr[], ad: AsmData): void {
+  const byAddr = new Map(instrs.map((ins) => [ins.addr, ins]));
+  const his: { addr: number; sym: string }[] = [];
+  const los = new Map<number, string>(); // LO16 instruction addr → symbol
+  for (const r of ad.relocs) {
+    if (r.section !== '.text' || r.sym.startsWith('.')) {
+      continue; // section-symbol relocs are jump tables / anonymous data — not named globals
+    }
+    if (r.type === 'R_MIPS_HI16') {
+      his.push({ addr: r.offset, sym: r.sym });
+    } else if (r.type === 'R_MIPS_LO16') {
+      los.set(r.offset, r.sym);
+    }
+  }
+  if (his.length === 0) {
+    return;
+  }
+  his.sort((a, b) => a.addr - b.addr);
+  const loAddrs = [...los.keys()].sort((a, b) => a - b);
+  const consumed = new Set<number>();
+  for (const hi of his) {
+    const lui = byAddr.get(hi.addr);
+    if (!lui || lui.mnemonic !== 'lui') {
+      continue;
+    }
+    // Pair with the first not-yet-consumed same-symbol LO16 after the lui (GCC emits the pair with
+    // the base register threaded, so a 1:1 by-symbol-and-order match is the observed shape).
+    const loAddr = loAddrs.find((a) => a > hi.addr && !consumed.has(a) && los.get(a) === hi.sym);
+    const lo = loAddr !== undefined ? byAddr.get(loAddr) : undefined;
+    if (!lo) {
+      continue;
+    }
+    // The addend N rides in the instruction fields, not the reloc record: `(HI16 imm << 16) + the
+    // LO16 instruction's signed immediate`. HI16 imm is 0 in a relocatable object.
+    const rw = rewriteLoReloc(lo, hi.sym, parseImm(lui.ops[1] ?? '0') << 16);
+    if (rw === null) {
+      continue; // an unmodelled consumer (FP load, …) — leave the pair raw; it declines downstream
+    }
+    lui.ops[1] = rw.n === 0 ? `%hi(${hi.sym})` : `%hi(${hi.sym} + 0x${rw.n.toString(16)})`;
+    consumed.add(loAddr!);
+  }
+}
+
+// Rewrite a LO16 consumer's operand to `%lo(SYM[+N])`, returning the addend N, or null when the
+// instruction is not a modelled global consumer (leave it raw). `hiBase` is the HI16 imm << 16.
+function rewriteLoReloc(lo: Instr, sym: string, hiBase: number): { n: number } | null {
+  const macro = (n: number) => (n === 0 ? `%lo(${sym})` : `%lo(${sym} + 0x${n.toString(16)})`);
+  if (lo.mnemonic === 'addiu' || lo.mnemonic === 'addi') {
+    const n = hiBase + parseImm(lo.ops[2] ?? '0');
+    if (n < 0) {
+      return null; // a negative interior offset — unusual; leave raw
+    }
+    lo.ops[2] = macro(n);
+    return { n };
+  }
+  if (/^(lw|lh|lhu|lb|lbu|sw|sh|sb)$/.test(lo.mnemonic)) {
+    const mem = parseMem(lo.ops[lo.ops.length - 1] ?? '');
+    const n = hiBase + mem.off;
+    if (n < 0) {
+      return null;
+    }
+    lo.ops[lo.ops.length - 1] = `${macro(n)}(${mem.base})`;
+    return { n };
+  }
+  return null;
 }
 
 interface MipsBlock {
@@ -405,6 +481,12 @@ export function lift(
   // exempted from the loud-fail below; an UNrecovered `jr <non-ra>` still fails loud.
   const jts = asmData ? recoverMipsJumpTables(instrs, asmData) : new Map<number, MipsJT>();
   const recoveredJr = new Set([...jts.values()].map((j) => j.jrAddr));
+  // Bridge global-access relocations into `%hi`/`%lo` operands (objdump dialect only — Splat text
+  // already carries them). Runs AFTER jump-table recovery so its raw `.rodata` table-base relocs are
+  // read pristine; global rewrites target NAMED symbols and never touch a jump-table base.
+  if (!splat && asmData) {
+    applyMipsGlobalRelocs(instrs, asmData);
+  }
   // TRUSTWORTHINESS: fail LOUD on a control transfer this frontend cannot model — the `opaque`
   // path cannot catch these (implicit or no register destination). `jal`/`jalr` clobber `v0`
   // implicitly, so dropping a call fabricates `v0` from a stale value; a `jr` to anything but `ra`

--- a/packages/core/test/mips-reloc-globals.test.ts
+++ b/packages/core/test/mips-reloc-globals.test.ts
@@ -1,0 +1,62 @@
+// The objdump→gaddr reloc bridge (frontend/mips.ts applyMipsGlobalRelocs): in an object file a
+// global load shows `lui rX,0x0` with the symbol only in the R_MIPS_HI16/LO16 relocations. Given
+// the asmData side-table, the frontend rewrites those into `%hi(SYM)`/`%lo(SYM+N)` operands so the
+// gaddr recognition (shared with the Splat dialect) recovers the named global — instead of reading
+// address 0 as `*(T *)0`. This is what lets asmlift match global access in the benchmark's objdump
+// tier, symmetric with the symbols the harness feeds m2c.
+import { expect, test } from 'vitest';
+
+import type { AsmData } from '../src/frontend/asmdata';
+import { decompile } from '../src/pipeline';
+import { MIPS_GCC } from '../src/target';
+
+// A minimal AsmData carrying only .text relocations (the bridge reads nothing else).
+const relocs = (rs: { off: number; type: string; sym: string }[]): AsmData => ({
+  sections: new Map(),
+  relocs: rs.map((r) => ({ section: '.text', offset: r.off, type: r.type, sym: r.sym, addend: 0 })),
+  symbols: new Map(),
+  bigEndian: true,
+});
+
+test('a scalar global load recovers the named symbol via HI16/LO16 relocs (not *(T *)0)', () => {
+  const asm = '00000000 <getg>:\n   0:\tlui\tv0,0x0\n   4:\tjr\tra\n   8:\tlb\tv0,0(v0)\n';
+  const rs = relocs([
+    { off: 0, type: 'R_MIPS_HI16', sym: 'gByte' },
+    { off: 8, type: 'R_MIPS_LO16', sym: 'gByte' },
+  ]);
+  expect(decompile('getg', asm, MIPS_GCC, { asmData: rs }).source).toContain('return gByte;');
+  // without the relocs the symbol is invisible → the honest raw-address read
+  expect(decompile('getg', asm, MIPS_GCC).source).toContain('*(s8 *)0');
+});
+
+test('a global field access folds the LO16 instruction offset into the gaddr access offset', () => {
+  // `lw v0,8(v0)` under an LO16 reloc → the global at byte offset 8 → element 2 of an s32 aggregate
+  const asm = '00000000 <getf>:\n   0:\tlui\tv0,0x0\n   4:\tjr\tra\n   8:\tlw\tv0,8(v0)\n';
+  const rs = relocs([
+    { off: 0, type: 'R_MIPS_HI16', sym: 'gStruct' },
+    { off: 8, type: 'R_MIPS_LO16', sym: 'gStruct' },
+  ]);
+  expect(decompile('getf', asm, MIPS_GCC, { asmData: rs }).source).toContain('((s32 *)&gStruct)[2]');
+});
+
+test('an addiu-materialised global base + plain-offset access recovers through the symbol', () => {
+  // `lui;addiu %lo` materialises &gArr, then a plain `lw 4(v0)` reads element 1
+  const asm = '00000000 <getm>:\n   0:\tlui\tv0,0x0\n   4:\taddiu\tv0,v0,0\n   8:\tjr\tra\n   c:\tlw\tv0,4(v0)\n';
+  const rs = relocs([
+    { off: 0, type: 'R_MIPS_HI16', sym: 'gArr' },
+    { off: 4, type: 'R_MIPS_LO16', sym: 'gArr' },
+  ]);
+  expect(decompile('getm', asm, MIPS_GCC, { asmData: rs }).source).toContain('&gArr');
+});
+
+test('a section-symbol reloc (jump-table base / anonymous data) is NOT rewritten as a global', () => {
+  // A `.rodata`/`.data` section reloc is a jump-table base or section-relative data — the bridge
+  // leaves it raw so Regime-B recovery owns it; it must not become a bogus `%hi(.rodata)` global.
+  const asm = '00000000 <getg>:\n   0:\tlui\tv0,0x0\n   4:\tjr\tra\n   8:\tlb\tv0,0(v0)\n';
+  const rs = relocs([
+    { off: 0, type: 'R_MIPS_HI16', sym: '.rodata' },
+    { off: 8, type: 'R_MIPS_LO16', sym: '.rodata' },
+  ]);
+  // unchanged from the no-reloc behaviour: the raw address read, never a named global
+  expect(decompile('getg', asm, MIPS_GCC, { asmData: rs }).source).toContain('*(s8 *)0');
+});


### PR DESCRIPTION
Second of the split PRs toward the marioparty3 benchmark tier — the reloc bridge from the plan.

## Problem

When a function is compiled to an object file, a global reference becomes `lui rX,0x0` with the symbol living only in the `R_MIPS_HI16`/`LO16` **relocation records**, not the operand. asmlift's objdump path read the base as address 0 and emitted `*(T *)0`. The harness already feeds **m2c** the symbol (via `disasmToM2c`'s `%hi/%lo` rewrite), so asmlift was at an artificial disadvantage on every global access.

## Fix

The MIPS frontend now bridges those relocations into the `%hi(SYM)`/`%lo(SYM+N)` operands the **existing gaddr recognition** already reads (the Splat dialect produces them directly). It pairs each `lui` with its consuming `%lo` instruction and folds that instruction's immediate into the addend — mirroring `disasmToM2c`, so asmlift and m2c recover the same symbols. Named object symbols only; a `.rodata`/`.data` **section** reloc is a jump-table base (Regime B) and is left untouched.

No new op or machinery — it reuses the `gaddr` path shipped in #2.

## Verified (GCC 2.7.2, end-to-end)

| source | before | after |
|---|---|---|
| `return Gb;` | `return *(s8 *)0;` | `return Gb;` |
| `return Gs.c;` | `((s32 *)0)[2]` | `((s32 *)&Gs)[2]` |
| `Gs.b = Gs.b + 1;` | `*(s32 *)4 …` | `((s32 *)&Gs)[1] = … + 1` |

## Benchmark impact

- **No match lost, no regression** (regression gate: `0 lost, 0 missing`).
- **68 MIPS outputs now reference their globals** — the bridge is exercised across the objdump tier.
- Match totals unchanged on the current dataset (its global functions hit two *distinct, still-unmodelled* shapes that now decline **honestly** instead of emitting wrong-but-compiling code):
  1. a **variable-index global array** (`tbl[i][j]` — the `%hi` register carries the index before its `%lo`), and
  2. an **escaping interior pointer** (`&SYM + N` used as a value).
  Both are clear follow-ups, not part of this bridge.

The real payoff is the **marioparty3 tier** (mainline GCC 2.7.2 `-O1`): the spike proved its simpler global functions recover correctly with this bridge in place.

## Testing
- New `mips-reloc-globals.test.ts`: scalar / field / materialised-base recovery + the section-symbol non-rewrite (no bogus `%hi(.rodata)`).
- Full offline suite green. The bridge fires **only** on objdump input carrying `asmData`, so the Splat path and reloc-free objdump paths are unchanged.
- Benchmark `results.json` is refreshed by `benchmark.yml` CI, so this PR is code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)