### PR TITLE
fix(cli): register gcc2.7.2 as a --target

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,30 +8,30 @@ byte-compared with the community `objdiff` engine. Exit 0 means byte-exact match
 
 ## Features
 
-| Feature                   |                                                                                                                                                                                                              |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Decompile one function    | from compiler `.s` text, `objdump -d` text, or an ELF `.o`                                                                                                                                                   |
-| Verify byte-exactness     | `--score-against target.o` (the original object file — the 'target object') recompiles the output and objdiff-scores it — with **your** project's compiler                                                   |
-| Ranked candidates         | genuinely ambiguous choices (e.g. signedness) become candidates; the byte-diff picks the winner                                                                                                              |
-| `decomp.yaml` integration | inside a configured project, no flags needed — target and compiler come from [decomp_settings](https://github.com/ethteck/decomp_settings)                                                                   |
-| Honest failure            | what asmlift can't lift faithfully is annotated in-source (`ASMLIFT_ERROR`) or declined with a typed reason — never plausible wrong code                                                                     |
-| Four supported targets    | agbcc (GBA), IDO 7.1 (N64), KMC GCC (N64), CodeWarrior (GameCube) — the compiler families asmlift understands (calibration toolchains live in the repo's private `packages/toolchains`, not in this package) |
+| Feature                   |                                                                                                                                                                                                                               |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Decompile one function    | from compiler `.s` text, `objdump -d` text, or an ELF `.o`                                                                                                                                                                    |
+| Verify byte-exactness     | `--score-against target.o` (the original object file — the 'target object') recompiles the output and objdiff-scores it — with **your** project's compiler                                                                    |
+| Ranked candidates         | genuinely ambiguous choices (e.g. signedness) become candidates; the byte-diff picks the winner                                                                                                                               |
+| `decomp.yaml` integration | inside a configured project, no flags needed — target and compiler come from [decomp_settings](https://github.com/ethteck/decomp_settings)                                                                                    |
+| Honest failure            | what asmlift can't lift faithfully is annotated in-source (`ASMLIFT_ERROR`) or declined with a typed reason — never plausible wrong code                                                                                      |
+| Multiple targets          | agbcc (GBA), IDO 7.1 (N64), KMC GCC (N64), GCC 2.7.2 (N64), CodeWarrior (GameCube) — the compiler families asmlift understands (calibration toolchains live in the repo's private `packages/toolchains`, not in this package) |
 
 ## Inputs
 
-| Input                                | Accepted for                           |
-| ------------------------------------ | -------------------------------------- |
-| Compiler `.s` text                   | All targets                            |
-| `objdump -d --no-show-raw-insn` text | `ido7.1`, `gcc2.7.2kmc`, `mwcc_242_81` |
-| ELF object file (`.o`)               | MIPS/PPC targets                       |
-| `-` (stdin)                          | text formats only                      |
+| Input                                | Accepted for                                       |
+| ------------------------------------ | -------------------------------------------------- |
+| Compiler `.s` text                   | All targets                                        |
+| `objdump -d --no-show-raw-insn` text | `ido7.1`, `gcc2.7.2kmc`, `gcc2.7.2`, `mwcc_242_81` |
+| ELF object file (`.o`)               | MIPS/PPC targets                                   |
+| `-` (stdin)                          | text formats only                                  |
 
 If the file includes multi-functions, pass the `--name` flag.
 
 ## CLI reference
 
 ```
-usage: asmlift <file.s|file.asm|file.o|-> [--target <agbcc|ido7.1|gcc2.7.2kmc|mwcc_242_81>]
+usage: asmlift <file.s|file.asm|file.o|-> [--target <agbcc|ido7.1|gcc2.7.2kmc|gcc2.7.2|mwcc_242_81>]
                 [--name <symbol>] [--backend <c|pascal>] [--strict]
                 [--config <decomp.yaml>] [--score-against <target.o>]
                 [--asm-data <dump.txt>] [--proto <proto.json>]
@@ -58,7 +58,7 @@ All asmlift settings live in a spec-compliant `tools.asmlift` block:
 
 | Field      | Meaning                                                                                                                                              |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `target`   | asmlift target key — needed when the `platform` maps to several compilers (`n64` → `ido7.1` or `gcc2.7.2kmc`)                                        |
+| `target`   | asmlift target key — needed when the `platform` maps to several compilers (`n64` → `ido7.1`, `gcc2.7.2kmc` or `gcc2.7.2`)                            |
 | `compiler` | Candidate-compile command template: source file in, relocatable object out. Runs via `sh` with the decomp.yaml's directory as cwd                    |
 | `objdump`  | Host objdump binary for `.o` input (overrides the PATH/env-resolved default: `mips-linux-gnu-objdump` / `powerpc-eabi-objdump`)                      |
 | `prelude`  | Prepend asmlift's `s32`/`u32`… typedefs to candidates (default `true`; set `false` if your command injects project headers that already define them) |

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -5,7 +5,7 @@
 // spec-compliant `tools.asmlift` block. Loader shape: upward walk trying decomp.yaml AND
 // decomp.yml, an explicit path short-circuits, `null` when absent — the config is an
 // enhancement, never required. One deliberate choice: on an ambiguous platform
-// (n64 ⇒ ido7.1 or gcc2.7.2kmc) asmlift DECLINES naming the candidates instead of falling back
+// (n64 ⇒ ido7.1, gcc2.7.2kmc or gcc2.7.2) asmlift DECLINES naming the candidates instead of falling back
 // to a generic default — per the cardinal rule, a guessed compiler mis-scores candidates.
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -13,7 +13,7 @@ import YAML from 'yaml';
 
 /** asmlift's payload inside `tools.asmlift` (arbitrary tool blocks are part of the spec). */
 export interface AsmliftToolConfig {
-  /** the asmlift target key (agbcc | ido7.1 | gcc2.7.2kmc | mwcc_242_81) — disambiguates
+  /** the asmlift target key (agbcc | ido7.1 | gcc2.7.2kmc | gcc2.7.2 | mwcc_242_81) — disambiguates
    *  platforms that map to several compilers */
   target?: string;
   /** candidate-compile command template ({{inputPath}}/{{outputPath}}/{{symbol}}) — the
@@ -87,7 +87,7 @@ function readConfig(path: string): LoadedConfig {
 // `tools.asmlift.target` to disambiguate (resolveTarget declines, listing these).
 const PLATFORM_TARGETS: Record<string, string[]> = {
   gba: ['agbcc'],
-  n64: ['ido7.1', 'gcc2.7.2kmc'],
+  n64: ['ido7.1', 'gcc2.7.2kmc', 'gcc2.7.2'],
   gc: ['mwcc_242_81'],
   gamecube: ['mwcc_242_81'],
   wii: ['mwcc_242_81'],

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,6 +1,6 @@
 // asmlift — the command-line entry point. Decompile one function's assembly to source:
 //
-//   asmlift <file.s|file.asm|file.o|-> --target <agbcc|ido7.1|gcc2.7.2kmc|mwcc_242_81> [options]
+//   asmlift <file.s|file.asm|file.o|-> --target <agbcc|ido7.1|gcc2.7.2kmc|gcc2.7.2|mwcc_242_81> [options]
 //
 // Reads GNU-as text (agbcc), objdump -d text (IDO/KMC-GCC/mwcc), or an ELF OBJECT FILE — an
 // object is disassembled with the target's own objdump (objfile.ts), and its jump-table
@@ -39,6 +39,7 @@ const TARGETS: Record<string, TargetDescription> = {
   agbcc: ARMV4T_AGBCC,
   'ido7.1': MIPS_IDO,
   'gcc2.7.2kmc': MIPS_GCC,
+  'gcc2.7.2': MIPS_GCC,
   mwcc_242_81: PPC_MWCC,
 };
 


### PR DESCRIPTION
`gcc2.7.2` (Mario Party 3's mainline GCC 2.7.2, added to the benchmark in #5) was a valid asmlift toolchain, but the **CLI never listed it** — a stale spot found while prepping the `@asmlift/cli` 0.2.0 release. `--target gcc2.7.2` was rejected (not in the `TARGETS` map), and the auto-generated usage string advertised only `<agbcc|ido7.1|gcc2.7.2kmc|mwcc_242_81>`.

## Changes

**Functional**
- `main.ts` — add `'gcc2.7.2': MIPS_GCC` to `TARGETS`. This both accepts the flag and regenerates the usage string (built from `Object.keys(TARGETS)`).
- `config.ts` — add `gcc2.7.2` to `PLATFORM_TARGETS.n64`, so an n64 `decomp.yaml` with no explicit `tools.asmlift.target` lists it among the candidates it asks you to disambiguate.

**Docs (ship in the npm tarball)**
- `README.md` + header comments: usage block, input table (`gcc2.7.2` takes objdump text), the `n64` note, and "Four supported targets" → **"Five"** (GCC 2.7.2 / N64).

`gcc2.7.2` and `gcc2.7.2kmc` share the `MIPS_GCC` `TargetDescription` (same frontend); they differ only in the project's compiler flags, which the CLI never sees.

## Verification
- `--target gcc2.7.2` now decompiles instead of erroring; usage string shows all five targets
- typecheck ✅, format:check ✅, lint 0 errors, CLI offline tests pass (43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)