### PR TITLE
chore(release): @asmlift/core + @asmlift/cli 0.2.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asmlift/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "type": "module",
   "description": "The asmlift command line: decompile one function to C/Pascal from the terminal",
@@ -15,7 +15,7 @@
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
-    "@asmlift/core": "workspace:*",
+    "@asmlift/core": "workspace:^",
     "objdiff-wasm": "3.7.3",
     "yaml": "^2.9.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asmlift/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "type": "module",
   "description": "Match decompile an assembly function to C or Pascal",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
   packages/cli:
     dependencies:
       '@asmlift/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       objdiff-wasm:
         specifier: 3.7.3


### PR DESCRIPTION
Bumps both public packages **0.1.0 → 0.2.0** ahead of the npm release.

## What's in 0.2.0 (since 0.1.0)
- Splat-disassembled MIPS `.s` input for N64 projects (#1)
- MIPS global-variable recovery: `%hi/%lo` → `gaddr` (#2) + objdump reloc→gaddr bridge (#4)
- decomp.me-standard target ids (#3)
- New `gcc2.7.2` target + Mario Party 3 benchmark dataset (#5); CLI `--target gcc2.7.2` (#6)

## Version linkage
- `cli`'s `@asmlift/core` dep: `workspace:*` → `workspace:^` (publishes as `^0.2.0`)

## Verified before publish
- `pnpm publish --dry-run` clean for both; `pnpm pack` confirms resolved deps (`@asmlift/core: ^0.2.0`)
- core ships `src/` (57 files); cli ships bundled `dist/asmlift.mjs` + `src/` (12 files)
- typecheck ✅, the private `@asmlift/toolchains` devDep does not block publish (skipped by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)