### PR TITLE
thumb: recognise the legacy LDM/LDSH spellings, and fix two LDM/STM semantics they exposed

### DIFF
--- a/packages/core/src/frontend/opaque.ts
+++ b/packages/core/src/frontend/opaque.ts
@@ -7,6 +7,37 @@
 // This module owns only the POLICY (which token is the destination, which are register sources).
 // The frontend still owns the SSA plumbing (how to `read` a source and `write`/emit the result),
 // because that is block-local state the policy must not touch.
+//
+// ─── A NOTE ON ALTERNATIVE MNEMONIC SPELLINGS ──────────────────────────────────────────────────
+//
+// Every ISA here accepts more than one spelling for some instructions, and the frontends handle
+// that in two DIFFERENT ways on purpose. Which one is right is decided by the operands, not by
+// taste:
+//
+//   * PURE SYNONYM — same operands, same semantics, different name. Normalise it in a name→name
+//     table at the parse site, so every consumer of the mnemonic sees one name. Thumb does this
+//     for `ldsh`/`ldrsh`, `ldsb`/`ldrsb`, `ldm`/`ldmfd`/`ldmia`, `stm`/`stmea`/`stmia`, which
+//     ARM DDI 0029G Figure 1-6 gives a single encoding apiece.
+//
+//     The table is the right shape THERE because the mnemonic is read by more than the decode
+//     switch — Thumb's `classifyXfer` matches it to tell a return from an indirect jump, the
+//     `storeClass` below matches it to decide whether an unmodelled op may be skipped, and the
+//     instruction-size walk tests it for `bl`. An alias arm on one `case` fixes one of those.
+//
+//   * EXTENDED MNEMONIC / PSEUDO-INSTRUCTION — different operand GRAMMAR, so no rename can
+//     express it. Give it its own decode arm. MIPS `move rD,rS` (2 operands) is `addu rD,rS,zero`
+//     (3); PPC `mr rD,rS` is `or rD,rS,rS`; PPC `slwi rD,rS,n` (3) is `rlwinm rD,rS,n,mb,me` (5,
+//     with mask fields computed from n). Routing these through a table would be a category error.
+//
+// There is deliberately NO shared alias helper. As of writing, MIPS and PPC have no pure-synonym
+// gap at all — every `unmodelled instruction` decline they produce across the whole benchmark is
+// a genuinely unmodelled opcode (`lwc1`, `fmuls`, `fctiwz`, `subfe`, …), not a spelling — so such
+// a helper would have exactly one caller. The bar for extracting one is the bar this module itself
+// met: several frontends hand-copying the same policy AND observed drift between the copies.
+//
+// One thing that IS shared, and should stay shared: `display` below. A frontend that normalises
+// spellings must still REPORT the one its input actually used, or a decline sends the reader
+// looking for an instruction their disassembly does not contain.
 import { FrontendUnsupportedError } from './errors';
 
 export interface OpaquePolicy {

--- a/packages/core/src/frontend/opaque.ts
+++ b/packages/core/src/frontend/opaque.ts
@@ -27,6 +27,11 @@ export interface OpaquePolicy {
   storeClass?: RegExp;
   /** attribution for thrown declines: the function being lifted (optionally "+ site"). */
   context?: string;
+  /** How to SPELL the mnemonic in messages, when that differs from the name used to classify it.
+   *  A frontend that normalises legacy spellings (Thumb `ldsh` -> `ldrsh`) classifies on the
+   *  canonical name but must report the one the input file actually contains — otherwise a decline
+   *  names an instruction the reader cannot find in their own .s. Defaults to `mnemonic`. */
+  display?: string;
   /** Mnemonics PROVABLY effect-free — or deliberately transparent (Thumb push/pop frame ops) —
    *  in this ISA: the ONLY unmodelled no-destination instructions that may be skipped. Any other
    *  no-destination unmodelled instruction THROWS: a side-effect-only instruction (swi, syscall,
@@ -54,13 +59,14 @@ export interface OpaqueDest {
  *  reaches structuring as the sentinel `?` and trips `assertResolved` — the loud failure the
  *  contract requires, instead of a stale/absent value surfacing as confidently-wrong source. */
 export function opaqueDest(mnemonic: string, ops: string[], policy: OpaquePolicy): OpaqueDest | null {
+  const shown = policy.display ?? mnemonic;
   if (policy.storeClass?.test(mnemonic)) {
     // `context` names the function (and, where the ISA has addresses, the site) — this message
     // lands verbatim in annotate-mode stub headers, where an un-attributed decline is
     // unactionable in a multi-function run.
     const where = policy.context ? `cannot lift '${policy.context}': ` : '';
     throw new FrontendUnsupportedError(
-      `${where}unmodelled store-class instruction '${mnemonic}' — a memory write cannot be skipped or degraded to a register opaque`,
+      `${where}unmodelled store-class instruction '${shown}' — a memory write cannot be skipped or degraded to a register opaque`,
     );
   }
   const norm = policy.normalize ?? ((s) => s);
@@ -71,7 +77,7 @@ export function opaqueDest(mnemonic: string, ops: string[], policy: OpaquePolicy
     } // explicitly transparent for this ISA
     const where = policy.context ? `cannot lift '${policy.context}': ` : '';
     throw new FrontendUnsupportedError(
-      `${where}unmodelled effect instruction '${mnemonic}' — no register destination to degrade, and skipping it would silently delete its effect`,
+      `${where}unmodelled effect instruction '${shown}' — no register destination to degrade, and skipping it would silently delete its effect`,
     );
   }
   if (policy.isZero?.(dst)) {

--- a/packages/core/src/frontend/thumb.ts
+++ b/packages/core/src/frontend/thumb.ts
@@ -67,13 +67,9 @@ interface AsmBlock {
 // byte load — and `ldm` 12 / `stm` 34 against `ldmia` 0 / `stmia` 0. The UAL names this frontend
 // cased for the multiple forms never appear in that corpus at all.
 //
-// WHY A TABLE HERE, rather than alias arms on each decode `case` (which is how mips.ts and ppc.ts
-// handle their extended mnemonics): the mnemonic is read by more consumers than the decode switch.
-// `classifyXfer` matches it to decide return-vs-indirect, `opaquePolicy.storeClass` matches it to
-// decide whether an unmodelled op may be skipped, and the instruction-size walk tests it for `bl`.
-// An alias arm fixes exactly one of those. The PPC/MIPS idiom is right where the two spellings need
-// DIFFERENT lowering because their operand grammars differ (`slwi rD,rS,n` vs `rlwinm rD,rS,n,mb,me`);
-// these take identical operands, so the table is the cheaper shape.
+// These are PURE SYNONYMS — identical operands — which is why they belong in a table here rather
+// than in decode arms like MIPS's `move` or PPC's `slwi`. That distinction, and why there is no
+// shared alias helper across the three frontends, is written up once in ./opaque.ts.
 //
 // The LOAD aliases matter more than the store ones, and the asymmetry is worth knowing: an
 // unrecognised `stm*` matches `opaquePolicy.storeClass` and fails LOUD, but an unrecognised `ldm*`

--- a/packages/core/src/frontend/thumb.ts
+++ b/packages/core/src/frontend/thumb.ts
@@ -30,8 +30,14 @@ import { opaqueDest } from './opaque';
 import { abiSortEntryParams, fallbackArgc, makeSsaBuilder } from './ssa';
 
 interface Instr {
+  /** the CANONICAL spelling — legacy names are normalised (see LEGACY_MNEMONICS) so that every
+   *  consumer matches one name. */
   mnemonic: string;
   ops: string[];
+  /** the spelling the input file actually used, present only when normalisation changed it.
+   *  Messages must use this: a decline naming `ldrsh` for a file containing `ldsh` sends the
+   *  reader looking for an instruction that is not there. */
+  asWritten?: string;
 }
 interface AsmBlock {
   label: string;
@@ -41,28 +47,40 @@ interface AsmBlock {
 // Pre-UAL mnemonic spellings, normalised at the single point where an instruction enters the IR.
 //
 // These are not "similar" instructions — each pair is the SAME instruction with two accepted
-// spellings, and GNU `as` assembles either to identical bytes. The decode switch below, `isReturn`,
-// and the flag-setting tables are all written against the UAL name, so a disassembler that emits
-// the legacy one produces a decline rather than a lift.
-//
-// Normalising here rather than adding alias arms to each `case` is deliberate: `isReturn` reads the
-// mnemonic too, and it lists `ldmia`/`ldmfd` but not bare `ldm` — so a per-case fix would have left
-// `ldm rN!, {…, pc}` undetected as a return. One table, every consumer.
+// spellings, and GNU `as` assembles either to identical bytes (verified across 14 operand shapes:
+// with and without `!`, base in the register list, multi-register lists).
 //
 // Measured on the Klonoa: Empire of Dreams disassembly (luvdis, 469 .s files): `ldsh` 292 and
 // `ldsb` 180 against `ldrsh` 0 and `ldrsb` 12 — the same tool emits both spellings for the signed
 // byte load — and `ldm` 12 / `stm` 34 against `ldmia` 0 / `stmia` 0. The UAL names this frontend
 // cases for the multiple forms never appear in that corpus at all.
 //
-// Deliberately NOT included: `ldmfd`/`stmfd`. `ldmfd` is indeed `ldmia`, but `stmfd` is `stmdb`,
-// which Thumb-1 does not have (it is spelled `push`) — so the pair is not symmetric, and neither
-// occurs in any corpus measured here. Adding them would be an untested guess.
-const LEGACY_MNEMONICS: Readonly<Record<string, string>> = {
+// WHY A TABLE HERE, rather than alias arms on each decode `case` (which is how mips.ts and ppc.ts
+// handle their extended mnemonics): the mnemonic is read by more consumers than the decode switch.
+// `classifyXfer` matches it to decide return-vs-indirect, `opaquePolicy.storeClass` matches it to
+// decide whether an unmodelled op may be skipped, and the instruction-size walk tests it for `bl`.
+// An alias arm fixes exactly one of those. The PPC/MIPS idiom is right where the two spellings need
+// DIFFERENT lowering because their operand grammars differ (`slwi rD,rS,n` vs `rlwinm rD,rS,n,mb,me`);
+// these four take identical operands, so the table is the cheaper shape.
+//
+// `ldmfd` is included because leaving it out is not a decline but a SILENT one: `ldmfd rN, {rD}`
+// (no writeback) reaches opaqueDest, which takes ops[0] — the BASE — as the destination, so the
+// opaque is dead, DCE removes it, and the load simply vanishes. Measured: `ldmfd r1, {r0}; bx lr`
+// lifted to `return a0;` where the correct answer is `return *a0;`.
+//
+// `stmfd` is deliberately absent, and the asymmetry is real rather than an oversight: `stmfd` is
+// `stmdb`, and ARMv4T Thumb has neither — `as` rejects both with "selected processor does not
+// support ... in Thumb mode". There is nothing to normalise it TO.
+//
+// Null-prototype so that an inherited key (`constructor`, `toString`) cannot be mistaken for an
+// entry. Unreachable from real assembly, but the lookup should not depend on that.
+const LEGACY_MNEMONICS: Readonly<Record<string, string>> = Object.assign(Object.create(null), {
   ldsh: 'ldrsh',
   ldsb: 'ldrsb',
   ldm: 'ldmia',
+  ldmfd: 'ldmia',
   stm: 'stmia',
-};
+});
 
 function canonicalMnemonic(mn: string): string {
   return LEGACY_MNEMONICS[mn] ?? mn;
@@ -377,7 +395,14 @@ function decode(name: string, asm: string): { blocks: AsmBlock[]; dataWords: Map
       continue;
     }
     dataLabel = null; // a real instruction ends a data run
-    flat.push({ instr: { mnemonic: canonicalMnemonic(m[1]), ops: m[2] ? splitOperands(m[2]) : [] } });
+    const canon = canonicalMnemonic(m[1]);
+    flat.push({
+      instr: {
+        mnemonic: canon,
+        ops: m[2] ? splitOperands(m[2]) : [],
+        ...(canon === m[1] ? {} : { asWritten: m[1] }),
+      },
+    });
   }
   if (
     armLabels.has(name) ||
@@ -1201,7 +1226,7 @@ export function lift(
     // adjustments have no low-register data destination, so they fall through harmlessly;
     // terminators are handled in the terminator section below.
     const isThumbReg = (s: string | undefined): s is string => /^r\d+$/.test(s ?? '');
-    const emitOpaqueDest = (ins: { mnemonic: string; ops: string[] }) => {
+    const emitOpaqueDest = (ins: { mnemonic: string; ops: string[]; asWritten?: string }) => {
       // storeClass: unmodelled Thumb stores are str*/stm* — `stmia rN!, {…}`'s dest token `r0!`
       // fails isReg, so without this it would be skipped as "no reg dest", silently deleting the
       // memory writes AND the base writeback. push/pop stay transparent frame ops (they don't match).
@@ -1213,6 +1238,7 @@ export function lift(
         storeClass: /^(str|stm)/,
         skipSafe: /^(push|pop|nop)$/,
         context: name,
+        display: ins.asWritten,
       });
       if (!od) {
         return;
@@ -1220,7 +1246,7 @@ export function lift(
       const operands = od.srcRegs.map((r) => readVar(r, bi));
       const res = mkValue(T.unk(32));
       // carry the mnemonic so annotate mode can name the gap (`ASMLIFT_ERROR("unmodelled 'rsb'")`)
-      irb.ops.push(mkOp('opaque', { operands, results: [res], attrs: { mnemonic: ins.mnemonic } }));
+      irb.ops.push(mkOp('opaque', { operands, results: [res], attrs: { mnemonic: ins.asWritten ?? ins.mnemonic } }));
       writeVar(od.dst, bi, res);
     };
     // 2-operand ALU form `op rD, op2` (rD = rD ⟨op⟩ op2). `op2` is an immediate (`#N`) or a

--- a/packages/core/src/frontend/thumb.ts
+++ b/packages/core/src/frontend/thumb.ts
@@ -44,16 +44,28 @@ interface AsmBlock {
   instrs: Instr[];
 }
 
-// Pre-UAL mnemonic spellings, normalised at the single point where an instruction enters the IR.
+// Alternative mnemonic spellings, normalised at the single point where an instruction enters the
+// IR. Each maps to a name the decode switch below already handles.
 //
-// These are not "similar" instructions — each pair is the SAME instruction with two accepted
-// spellings, and GNU `as` assembles either to identical bytes (verified across 14 operand shapes:
-// with and without `!`, base in the register list, multi-register lists).
+// These are not "similar" instructions — each pair is ONE instruction with two accepted spellings.
+// The ARM7TDMI Technical Reference Manual (ARM DDI 0029G) gives a single encoding for each:
+// Figure 1-6 "Thumb instruction set formats" lists Format 08 "Load and store sign-extended byte and
+// halfword" (0101 H S 1 Ro Rb Rd) and Format 15 "Multiple load and store" (1100 L Rb Rlist), and
+// Table 1-7 "Thumb instruction set summary" spells them `LDRSH Rd, [Rb, Ro]`, `LDRSB Rd, [Rb, Ro]`,
+// `LDMIA Rb!, <reglist>` and `STMIA Rb!, <reglist>`. Older ARM7TDMI documentation used LDSH/LDSB,
+// which is where the short spellings come from; the stack-suffix forms (FD, EA) are the same
+// instructions named after the stack discipline they implement.
+//
+// Confirmed with this project's own toolchain — same encoding, and gba-kit executes them with the
+// same architectural effect (sign extension, transfers, base writeback):
+//
+//     ldsh  / ldrsh        885e / 885e        ldm   / ldmia / ldmfd   01c9 / 01c9 / 01c9
+//     ldsb  / ldrsb        8856 / 8856        stm   / stmia / stmea   01c1 / 01c1 / 01c1
 //
 // Measured on the Klonoa: Empire of Dreams disassembly (luvdis, 469 .s files): `ldsh` 292 and
 // `ldsb` 180 against `ldrsh` 0 and `ldrsb` 12 — the same tool emits both spellings for the signed
 // byte load — and `ldm` 12 / `stm` 34 against `ldmia` 0 / `stmia` 0. The UAL names this frontend
-// cases for the multiple forms never appear in that corpus at all.
+// cased for the multiple forms never appear in that corpus at all.
 //
 // WHY A TABLE HERE, rather than alias arms on each decode `case` (which is how mips.ts and ppc.ts
 // handle their extended mnemonics): the mnemonic is read by more consumers than the decode switch.
@@ -61,12 +73,15 @@ interface AsmBlock {
 // decide whether an unmodelled op may be skipped, and the instruction-size walk tests it for `bl`.
 // An alias arm fixes exactly one of those. The PPC/MIPS idiom is right where the two spellings need
 // DIFFERENT lowering because their operand grammars differ (`slwi rD,rS,n` vs `rlwinm rD,rS,n,mb,me`);
-// these four take identical operands, so the table is the cheaper shape.
+// these take identical operands, so the table is the cheaper shape.
 //
-// `ldmfd` is included because leaving it out is not a decline but a SILENT one: `ldmfd rN, {rD}`
-// (no writeback) reaches opaqueDest, which takes ops[0] — the BASE — as the destination, so the
-// opaque is dead, DCE removes it, and the load simply vanishes. Measured: `ldmfd r1, {r0}; bx lr`
-// lifted to `return a0;` where the correct answer is `return *a0;`.
+// The LOAD aliases matter more than the store ones, and the asymmetry is worth knowing: an
+// unrecognised `stm*` matches `opaquePolicy.storeClass` and fails LOUD, but an unrecognised `ldm*`
+// does not — it reaches opaqueDest, which takes ops[0] (the BASE) as the destination, so the opaque
+// is dead, DCE removes it, and the load silently vanishes. Measured: `ldmfd r1, {r0}; bx lr` lifted
+// to `return a0;` where the answer is `return *a0;`. Every load spelling ARMv4T Thumb accepts is
+// therefore listed. (`ldmed`/`ldmea` are NOT: they mean IB/DB, which Thumb-1 does not have, and
+// `as` rejects them — so they cannot appear.)
 //
 // `stmfd` is deliberately absent, and the asymmetry is real rather than an oversight: `stmfd` is
 // `stmdb`, and ARMv4T Thumb has neither — `as` rejects both with "selected processor does not
@@ -80,6 +95,7 @@ const LEGACY_MNEMONICS: Readonly<Record<string, string>> = Object.assign(Object.
   ldm: 'ldmia',
   ldmfd: 'ldmia',
   stm: 'stmia',
+  stmea: 'stmia',
 });
 
 function canonicalMnemonic(mn: string): string {
@@ -1430,14 +1446,18 @@ export function lift(
           // rejoin below also tolerates a split list defensively. Thumb-1 LDMIA skips the
           // writeback when rN is itself in the list (the loaded value wins) — modelled; any
           // malformed shape degrades to the loud opaque.
-          // There is NO no-writeback form in Thumb-1. `ldmia rN, {…}` without the `!` assembles
-          // to the SAME halfword as with it (`ldm r1,{r0}` and `ldm r1!,{r0}` are both 0xc901) and
-          // GNU as warns "this instruction will write back the base register"; gba-kit executes
-          // both with the base advanced. GBATEK: "Both STM and LDM are incrementing the Base
-          // Register." An earlier version of this comment called the `!`-less spelling "the valid
+          // There is NO no-writeback form in Thumb-1, so the `!` is decoration and must not drive
+          // the model. Four sources agree:
+          //   * ARM DDI 0029G Table 1-7 gives the canonical syntax as `LDMIA Rb!, <reglist>` and
+          //     `STMIA Rb!, <reglist>` — the `!` is part of the mnemonic, not an option, and
+          //     Figure 1-6 Format 15 has no bit that could encode its absence;
+          //   * GNU as assembles `ldm r1,{r0}` and `ldm r1!,{r0}` to the same halfword, 0xc901,
+          //     and warns "this instruction will write back the base register";
+          //   * gba-kit executes both with the base advanced by 4;
+          //   * GBATEK, THUMB.15: "Both STM and LDM are incrementing the Base Register".
+          // An earlier version of this comment called the `!`-less spelling "the valid
           // no-writeback form — same transfers, base unchanged", which is false, and the code
-          // below acted on it. Writeback is now driven by the architecture, not by the syntax.
-          // A missing register list is malformed → loud opaque.
+          // below acted on it. A missing register list is malformed → loud opaque.
           const baseTok = a;
           const writeback = !!baseTok?.endsWith('!');
           if (baseTok === undefined || b === undefined || !b.startsWith('{')) {

--- a/packages/core/src/frontend/thumb.ts
+++ b/packages/core/src/frontend/thumb.ts
@@ -38,6 +38,36 @@ interface AsmBlock {
   instrs: Instr[];
 }
 
+// Pre-UAL mnemonic spellings, normalised at the single point where an instruction enters the IR.
+//
+// These are not "similar" instructions — each pair is the SAME instruction with two accepted
+// spellings, and GNU `as` assembles either to identical bytes. The decode switch below, `isReturn`,
+// and the flag-setting tables are all written against the UAL name, so a disassembler that emits
+// the legacy one produces a decline rather than a lift.
+//
+// Normalising here rather than adding alias arms to each `case` is deliberate: `isReturn` reads the
+// mnemonic too, and it lists `ldmia`/`ldmfd` but not bare `ldm` — so a per-case fix would have left
+// `ldm rN!, {…, pc}` undetected as a return. One table, every consumer.
+//
+// Measured on the Klonoa: Empire of Dreams disassembly (luvdis, 469 .s files): `ldsh` 292 and
+// `ldsb` 180 against `ldrsh` 0 and `ldrsb` 12 — the same tool emits both spellings for the signed
+// byte load — and `ldm` 12 / `stm` 34 against `ldmia` 0 / `stmia` 0. The UAL names this frontend
+// cases for the multiple forms never appear in that corpus at all.
+//
+// Deliberately NOT included: `ldmfd`/`stmfd`. `ldmfd` is indeed `ldmia`, but `stmfd` is `stmdb`,
+// which Thumb-1 does not have (it is spelled `push`) — so the pair is not symmetric, and neither
+// occurs in any corpus measured here. Adding them would be an untested guess.
+const LEGACY_MNEMONICS: Readonly<Record<string, string>> = {
+  ldsh: 'ldrsh',
+  ldsb: 'ldrsb',
+  ldm: 'ldmia',
+  stm: 'stmia',
+};
+
+function canonicalMnemonic(mn: string): string {
+  return LEGACY_MNEMONICS[mn] ?? mn;
+}
+
 // Map a Thumb conditional-branch mnemonic to the icmp opcode for "branch taken". The signed forms
 // (`blt`/`ble`/`bgt`/`bge`) follow a signed `cmp`; the UNSIGNED forms carry the carry/borrow sense:
 // `bhi` = unsigned > (higher), `bls` = unsigned <= (lower-or-same), `bcc`/`blo` = unsigned <
@@ -347,7 +377,7 @@ function decode(name: string, asm: string): { blocks: AsmBlock[]; dataWords: Map
       continue;
     }
     dataLabel = null; // a real instruction ends a data run
-    flat.push({ instr: { mnemonic: m[1], ops: m[2] ? splitOperands(m[2]) : [] } });
+    flat.push({ instr: { mnemonic: canonicalMnemonic(m[1]), ops: m[2] ? splitOperands(m[2]) : [] } });
   }
   if (
     armLabels.has(name) ||

--- a/packages/core/src/frontend/thumb.ts
+++ b/packages/core/src/frontend/thumb.ts
@@ -1465,13 +1465,22 @@ export function lift(
             break;
           }
           // An STM whose base is in its own list, but is not the LOWEST entry, stores a value this
-          // frontend must not guess. ARM calls it UNPREDICTABLE ("the stored value cannot be
-          // relied upon"); GNU as warns "value stored for r4 is UNKNOWN"; and GBATEK records that
-          // the answer is architecture-version specific — "Store OLD base if Rb is FIRST entry in
-          // Rlist, otherwise store NEW base (STM/ARMv4), always store OLD base (STM/ARMv5)".
-          // This frontend targets ARMv4T, and it was storing the OLD base — the ARMv5 rule, i.e.
-          // silently wrong for its own target. Declining is the contract: unmodelled ⇒ loud.
-          // (One site in the Klonoa corpus, in unreachable code after a `pop`/`bx`.)
+          // frontend must not guess — because the available references DISAGREE about what it is.
+          //
+          //   ARM:      UNPREDICTABLE, "the stored value cannot be relied upon".
+          //   GNU as:   warns "value stored for rN is UNKNOWN".
+          //   GBATEK:   version-specific — "Store OLD base if Rb is FIRST entry in Rlist,
+          //             otherwise store NEW base (STM/ARMv4), always store OLD base (STM/ARMv5)".
+          //   mGBA:     stores the OLD base unconditionally, on an ARMv4T core — its STM_LOOP
+          //             reads gprs[i] during the loop and the writeback runs after it.
+          //
+          // So GBATEK's ARMv4 rule and the reference emulator's behaviour do not agree, and no
+          // hardware test result was found either way. This frontend used to emit the old base,
+          // i.e. it silently picked one side of that disagreement. Declining is the contract:
+          // where the architecture declines to define a value, so do we.
+          //
+          // (One site in the Klonoa corpus, in unreachable code after a `pop`/`bx`, and it already
+          // declines for an unrelated pc-relative-pool reason — so this costs nothing today.)
           if (ins.mnemonic === 'stmia' && list.some((r) => reg(r) === baseReg) && reg(list[0]) !== baseReg) {
             throw new FrontendUnsupportedError(
               `cannot lift '${name}': stm with the base register in its own list, not as the lowest ` +

--- a/packages/core/src/frontend/thumb.ts
+++ b/packages/core/src/frontend/thumb.ts
@@ -1430,9 +1430,14 @@ export function lift(
           // rejoin below also tolerates a split list defensively. Thumb-1 LDMIA skips the
           // writeback when rN is itself in the list (the loaded value wins) — modelled; any
           // malformed shape degrades to the loud opaque.
-          // `!` = writeback (`ldmia rN!, {…}`); its absence is the valid no-writeback form
-          // (`ldmia rN, {…}` — same transfers, base unchanged). A missing register list is
-          // malformed → loud opaque.
+          // There is NO no-writeback form in Thumb-1. `ldmia rN, {…}` without the `!` assembles
+          // to the SAME halfword as with it (`ldm r1,{r0}` and `ldm r1!,{r0}` are both 0xc901) and
+          // GNU as warns "this instruction will write back the base register"; gba-kit executes
+          // both with the base advanced. GBATEK: "Both STM and LDM are incrementing the Base
+          // Register." An earlier version of this comment called the `!`-less spelling "the valid
+          // no-writeback form — same transfers, base unchanged", which is false, and the code
+          // below acted on it. Writeback is now driven by the architecture, not by the syntax.
+          // A missing register list is malformed → loud opaque.
           const baseTok = a;
           const writeback = !!baseTok?.endsWith('!');
           if (baseTok === undefined || b === undefined || !b.startsWith('{')) {
@@ -1459,6 +1464,21 @@ export function lift(
             emitOpaqueDest(ins);
             break;
           }
+          // An STM whose base is in its own list, but is not the LOWEST entry, stores a value this
+          // frontend must not guess. ARM calls it UNPREDICTABLE ("the stored value cannot be
+          // relied upon"); GNU as warns "value stored for r4 is UNKNOWN"; and GBATEK records that
+          // the answer is architecture-version specific — "Store OLD base if Rb is FIRST entry in
+          // Rlist, otherwise store NEW base (STM/ARMv4), always store OLD base (STM/ARMv5)".
+          // This frontend targets ARMv4T, and it was storing the OLD base — the ARMv5 rule, i.e.
+          // silently wrong for its own target. Declining is the contract: unmodelled ⇒ loud.
+          // (One site in the Klonoa corpus, in unreachable code after a `pop`/`bx`.)
+          if (ins.mnemonic === 'stmia' && list.some((r) => reg(r) === baseReg) && reg(list[0]) !== baseReg) {
+            throw new FrontendUnsupportedError(
+              `cannot lift '${name}': stm with the base register in its own list, not as the lowest ` +
+                `entry — the value stored for that register is UNPREDICTABLE and differs between ` +
+                `ARMv4 (new base) and ARMv5 (old base)`,
+            );
+          }
           // SNAPSHOT the base ONCE: hardware performs every transfer from the ORIGINAL base, but
           // a base-in-list ldmia overwrites that register mid-list — re-reading it per iteration
           // loaded the siblings from the freshly-loaded value instead (silent wrong addresses,
@@ -1475,10 +1495,12 @@ export function lift(
               irb.ops.push(mkOp('store', { operands: [base0, readData(reg(r), bi)], attrs: { off: 4 * i, width: 4 } }));
             }
           });
-          // Writeback advances the base by 4×count — SUPPRESSED when there is no `!`, or (ldmia)
-          // when the base is itself in the list (the loaded value wins, ARMv4T).
+          // Writeback advances the base by 4×count. It is suppressed ONLY for an ldmia whose base
+          // is in its own list — the loaded value wins. GBATEK, THUMB.15: "no writeback
+          // (LDM/ARMv4/ARMv5; at this point, THUMB opcodes work different than ARM opcodes)".
+          // The `!` is NOT what decides it: see above, there is no encoding without writeback.
           const wroteBase = ins.mnemonic === 'ldmia' && list.some((r) => reg(r) === baseReg);
-          if (writeback && !wroteBase) {
+          if (!wroteBase) {
             const adv = mkValue(T.unk(32));
             irb.ops.push(mkOp('add', { operands: [base0, constVal(4 * list.length, bi)], results: [adv] }));
             writeVar(baseReg, bi, adv);

--- a/packages/core/test/thumb-frontend.test.ts
+++ b/packages/core/test/thumb-frontend.test.ts
@@ -126,6 +126,7 @@ describe('pre-UAL mnemonic spellings', () => {
     ['ldmfd', '\tldmfd\tr1!, {r0}\n\tbx\tlr\n', '\tldmia\tr1!, {r0}\n\tbx\tlr\n'],
     ['stm', '\tstm\tr1!, {r0}\n\tbx\tlr\n', '\tstmia\tr1!, {r0}\n\tbx\tlr\n'],
     ['stm base lowest', '\tstm\tr0!, {r0, r1}\n\tbx\tlr\n', '\tstmia\tr0!, {r0, r1}\n\tbx\tlr\n'],
+    ['stmea', '\tstmea\tr1!, {r0}\n\tbx\tlr\n', '\tstmia\tr1!, {r0}\n\tbx\tlr\n'],
   ];
 
   test.each(pairs)('%s lifts, and identically to its UAL spelling', (_mn, legacyAsm, ualAsm) => {

--- a/packages/core/test/thumb-frontend.test.ts
+++ b/packages/core/test/thumb-frontend.test.ts
@@ -106,3 +106,40 @@ describe('the return register cannot be both the return ADDRESS and the return v
     expect(src).toContain('return 5;');
   });
 });
+
+describe('pre-UAL mnemonic spellings', () => {
+  // Each pair below is ONE instruction with two accepted spellings, not two instructions. GNU `as`
+  // assembles either to identical bytes, so a disassembler is free to emit whichever it likes --
+  // and luvdis emits the legacy one. Before these were normalised, `ldsh` fell through the decode
+  // switch to the loud `opaque` and the function declined with "unmodelled instruction 'ldsh'":
+  // a lift refused over a spelling, on 14 functions of one real ROM.
+  const legacy: ReadonlyArray<[string, string, string]> = [
+    ['ldsh', '\tldsh\tr0, [r0, r1]\n\tbx\tlr\n', '\tldrsh\tr0, [r0, r1]\n\tbx\tlr\n'],
+    ['ldsb', '\tldsb\tr0, [r0, r1]\n\tbx\tlr\n', '\tldrsb\tr0, [r0, r1]\n\tbx\tlr\n'],
+    ['ldm', '\tldm\tr1!, {r0}\n\tbx\tlr\n', '\tldmia\tr1!, {r0}\n\tbx\tlr\n'],
+    ['stm', '\tstm\tr1!, {r0}\n\tbx\tlr\n', '\tstmia\tr1!, {r0}\n\tbx\tlr\n'],
+  ];
+
+  test.each(legacy)('%s lifts, and identically to its UAL spelling', (_mn, legacyAsm, ualAsm) => {
+    expect(dc('f', legacyAsm).source).toBe(dc('f', ualAsm).source);
+  });
+
+  test('the legacy spellings no longer decline as unmodelled', () => {
+    // The pre-fix symptom, pinned so it cannot come back as a decline rather than as wrong output.
+    for (const [, legacyAsm] of legacy) {
+      expect(() => dc('f', legacyAsm)).not.toThrow();
+    }
+  });
+
+  test('`ldm rN!, {…, pc}` is recognised as a return, not as an indirect jump', () => {
+    // isReturn is why this is normalised at the parse site rather than with alias arms on each
+    // decode `case`: it reads the mnemonic too, and its list carries `ldmia`/`ldmfd` but not bare
+    // `ldm`. A per-case fix would have lifted the load and still mis-classified the control flow.
+    expect(dc('f', '\tldm\tsp!, {r4, pc}\n').source).toBe(dc('f', '\tldmia\tsp!, {r4, pc}\n').source);
+  });
+
+  test('a mnemonic that merely STARTS with a legacy name is untouched', () => {
+    // The table is keyed on the whole mnemonic, so nothing rewrites a prefix of a longer name.
+    expect(() => dc('f', '\tldmxyz\tr1!, {r0}\n\tbx\tlr\n')).toThrow();
+  });
+});

--- a/packages/core/test/thumb-frontend.test.ts
+++ b/packages/core/test/thumb-frontend.test.ts
@@ -108,38 +108,57 @@ describe('the return register cannot be both the return ADDRESS and the return v
 });
 
 describe('pre-UAL mnemonic spellings', () => {
-  // Each pair below is ONE instruction with two accepted spellings, not two instructions. GNU `as`
-  // assembles either to identical bytes, so a disassembler is free to emit whichever it likes --
-  // and luvdis emits the legacy one. Before these were normalised, `ldsh` fell through the decode
-  // switch to the loud `opaque` and the function declined with "unmodelled instruction 'ldsh'":
-  // a lift refused over a spelling, on 14 functions of one real ROM.
-  const legacy: ReadonlyArray<[string, string, string]> = [
+  // Each pair below is ONE instruction with two accepted spellings, not two instructions: GNU `as`
+  // assembles either to identical bytes (checked across 14 operand shapes). A disassembler is free
+  // to emit whichever it likes, and luvdis emits the legacy one 472 times against 12 UAL in one
+  // real ROM. Before normalisation `ldsh` fell through the decode switch to the loud `opaque` and
+  // the function declined with "unmodelled instruction 'ldsh'" — a lift refused over a spelling.
+  //
+  // Pinned as EQUIVALENCE (legacy output === UAL output) rather than against expected source, so
+  // the test cannot rot into asserting whatever the frontend happens to emit. Both corpus operand
+  // shapes are covered: multi-register lists and a base that appears in its own list.
+  const pairs: ReadonlyArray<[string, string, string]> = [
     ['ldsh', '\tldsh\tr0, [r0, r1]\n\tbx\tlr\n', '\tldrsh\tr0, [r0, r1]\n\tbx\tlr\n'],
     ['ldsb', '\tldsb\tr0, [r0, r1]\n\tbx\tlr\n', '\tldrsb\tr0, [r0, r1]\n\tbx\tlr\n'],
     ['ldm', '\tldm\tr1!, {r0}\n\tbx\tlr\n', '\tldmia\tr1!, {r0}\n\tbx\tlr\n'],
+    ['ldm multi', '\tldm\tr0!, {r5, r6, r7}\n\tbx\tlr\n', '\tldmia\tr0!, {r5, r6, r7}\n\tbx\tlr\n'],
+    ['ldm no-writeback', '\tldm\tr1, {r0}\n\tbx\tlr\n', '\tldmia\tr1, {r0}\n\tbx\tlr\n'],
+    ['ldmfd', '\tldmfd\tr1!, {r0}\n\tbx\tlr\n', '\tldmia\tr1!, {r0}\n\tbx\tlr\n'],
     ['stm', '\tstm\tr1!, {r0}\n\tbx\tlr\n', '\tstmia\tr1!, {r0}\n\tbx\tlr\n'],
+    ['stm base-in-list', '\tstm\tr4!, {r0, r2, r4}\n\tbx\tlr\n', '\tstmia\tr4!, {r0, r2, r4}\n\tbx\tlr\n'],
   ];
 
-  test.each(legacy)('%s lifts, and identically to its UAL spelling', (_mn, legacyAsm, ualAsm) => {
+  test.each(pairs)('%s lifts, and identically to its UAL spelling', (_mn, legacyAsm, ualAsm) => {
     expect(dc('f', legacyAsm).source).toBe(dc('f', ualAsm).source);
   });
 
-  test('the legacy spellings no longer decline as unmodelled', () => {
-    // The pre-fix symptom, pinned so it cannot come back as a decline rather than as wrong output.
-    for (const [, legacyAsm] of legacy) {
-      expect(() => dc('f', legacyAsm)).not.toThrow();
-    }
+  test('`ldmfd rN, {rD}` loads — it used to be deleted outright', () => {
+    // The reason ldmfd is in the table. Without it the op reaches opaqueDest, which takes ops[0] —
+    // the BASE — as the destination; the opaque is then dead, DCE removes it, and the load simply
+    // vanishes. That is a SILENT wrong answer, not a decline: it lifted to `return a0;`.
+    expect(dc('f', '\tldmfd\tr1, {r0}\n\tbx\tlr\n').source).toContain('*a0');
   });
 
-  test('`ldm rN!, {…, pc}` is recognised as a return, not as an indirect jump', () => {
-    // isReturn is why this is normalised at the parse site rather than with alias arms on each
-    // decode `case`: it reads the mnemonic too, and its list carries `ldmia`/`ldmfd` but not bare
-    // `ldm`. A per-case fix would have lifted the load and still mis-classified the control flow.
-    expect(dc('f', '\tldm\tsp!, {r4, pc}\n').source).toBe(dc('f', '\tldmia\tsp!, {r4, pc}\n').source);
+  test('a decline names the spelling the INPUT used, not the canonical one', () => {
+    // Normalising must not send a reader looking for an instruction their .s does not contain.
+    // `ldsh r0` is malformed (one operand), so it degrades to the loud opaque and is reported.
+    expect(() => dc('f', '\tldsh\tr0\n\tbx\tlr\n')).toThrow(/'ldsh'/);
+    expect(() => dc('f', '\tldsh\tr0\n\tbx\tlr\n')).not.toThrow(/'ldrsh'/);
   });
 
   test('a mnemonic that merely STARTS with a legacy name is untouched', () => {
-    // The table is keyed on the whole mnemonic, so nothing rewrites a prefix of a longer name.
-    expect(() => dc('f', '\tldmxyz\tr1!, {r0}\n\tbx\tlr\n')).toThrow();
+    // The table is keyed on the whole mnemonic, so no prefix of a longer name is rewritten.
+    // A prefix-keyed table would make this lift instead of declining.
+    expect(() => dc('f', '\tldmxyz\tr1!, {r0}\n\tbx\tlr\n')).toThrow(/ldmxyz/);
+  });
+
+  test('an inherited Object key is not treated as an entry', () => {
+    // The table is null-prototype. With a plain object literal, `LEGACY_MNEMONICS['constructor']`
+    // resolves to Object's own constructor and the mnemonic becomes the string
+    // "function Object() { [native code] }". Unreachable from real assembly — no assembler emits
+    // `constructor` — so the property to pin is the absence of that leak, not which error fires.
+    const run = () => dc('f', '\tconstructor\tr0, r1\n\tbx\tlr\n');
+    expect(run).toThrow();
+    expect(run).not.toThrow(/native code|function Object/);
   });
 });

--- a/packages/core/test/thumb-frontend.test.ts
+++ b/packages/core/test/thumb-frontend.test.ts
@@ -122,10 +122,10 @@ describe('pre-UAL mnemonic spellings', () => {
     ['ldsb', '\tldsb\tr0, [r0, r1]\n\tbx\tlr\n', '\tldrsb\tr0, [r0, r1]\n\tbx\tlr\n'],
     ['ldm', '\tldm\tr1!, {r0}\n\tbx\tlr\n', '\tldmia\tr1!, {r0}\n\tbx\tlr\n'],
     ['ldm multi', '\tldm\tr0!, {r5, r6, r7}\n\tbx\tlr\n', '\tldmia\tr0!, {r5, r6, r7}\n\tbx\tlr\n'],
-    ['ldm no-writeback', '\tldm\tr1, {r0}\n\tbx\tlr\n', '\tldmia\tr1, {r0}\n\tbx\tlr\n'],
+    ['ldm no-!', '\tldm\tr1, {r0}\n\tbx\tlr\n', '\tldmia\tr1, {r0}\n\tbx\tlr\n'],
     ['ldmfd', '\tldmfd\tr1!, {r0}\n\tbx\tlr\n', '\tldmia\tr1!, {r0}\n\tbx\tlr\n'],
     ['stm', '\tstm\tr1!, {r0}\n\tbx\tlr\n', '\tstmia\tr1!, {r0}\n\tbx\tlr\n'],
-    ['stm base-in-list', '\tstm\tr4!, {r0, r2, r4}\n\tbx\tlr\n', '\tstmia\tr4!, {r0, r2, r4}\n\tbx\tlr\n'],
+    ['stm base lowest', '\tstm\tr0!, {r0, r1}\n\tbx\tlr\n', '\tstmia\tr0!, {r0, r1}\n\tbx\tlr\n'],
   ];
 
   test.each(pairs)('%s lifts, and identically to its UAL spelling', (_mn, legacyAsm, ualAsm) => {
@@ -137,6 +137,29 @@ describe('pre-UAL mnemonic spellings', () => {
     // the BASE — as the destination; the opaque is then dead, DCE removes it, and the load simply
     // vanishes. That is a SILENT wrong answer, not a decline: it lifted to `return a0;`.
     expect(dc('f', '\tldmfd\tr1, {r0}\n\tbx\tlr\n').source).toContain('*a0');
+  });
+
+  test('Thumb-1 has no no-writeback LDM: the `!`-less spelling still advances the base', () => {
+    // `ldm r1,{r0}` and `ldm r1!,{r0}` assemble to the SAME halfword (0xc901); GNU as warns "this
+    // instruction will write back the base register", gba-kit executes both with the base
+    // advanced, and GBATEK says "Both STM and LDM are incrementing the Base Register". The
+    // frontend used to drive writeback off the `!`, which is syntax, not architecture.
+    expect(dc('f', '\tldm\tr1, {r0}\n\tbx\tlr\n').source).toBe(dc('f', '\tldm\tr1!, {r0}\n\tbx\tlr\n').source);
+  });
+
+  test('an LDM whose base is in its own list does NOT write back', () => {
+    // GBATEK, THUMB.15: "no writeback (LDM/ARMv4/ARMv5; at this point, THUMB opcodes work
+    // different than ARM opcodes)". The loaded value wins.
+    expect(dc('f', '\tldm\tr1, {r1, r2}\n\tbx\tlr\n').source).toContain('return a0;');
+  });
+
+  test('an STM storing its own base, not lowest, DECLINES rather than guessing', () => {
+    // ARM calls the stored value UNPREDICTABLE and GNU as warns "value stored for r4 is UNKNOWN";
+    // GBATEK records that it is version-specific — new base on ARMv4, old base on ARMv5. This
+    // frontend targets ARMv4T and used to emit the ARMv5 answer silently.
+    expect(() => dc('f', '\tstm\tr4!, {r0, r2, r4}\n\tbx\tlr\n')).toThrow(/UNPREDICTABLE/);
+    // …but the LOWEST-entry case is defined (old base) and must still lift.
+    expect(dc('f', '\tstm\tr0!, {r0, r1}\n\tbx\tlr\n').source).toContain('*a0 = a0;');
   });
 
   test('a decline names the spelling the INPUT used, not the canonical one', () => {


### PR DESCRIPTION
Three defects in the Thumb frontend's handling of load/store-multiple and sign-extending loads. The first is a vocabulary gap; the other two are semantic, were found while verifying the first against ARM's own documentation, and are the reason this PR grew.

**Net effect, measured over all 46 functions in the Klonoa: Empire of Dreams corpus that contain any affected mnemonic: 13 gained (declined → scoring), 0 lost, 32 unchanged.**

---

## 1. The legacy mnemonic spellings were not recognised

`ldsh`, `ldsb`, `ldm`, `stm` and `ldmfd` are not *similar* instructions to `ldrsh`, `ldrsb`, `ldmia` and `stmia` — they are the **same instructions with two accepted spellings**. The frontend cased only the UAL names, so a disassembler emitting the legacy ones got a decline.

Corpus counts (luvdis, 469 `.s` files):

| legacy | count | UAL | count |
|---|---:|---|---:|
| `ldsh` | **292** | `ldrsh` | 0 |
| `ldsb` | **180** | `ldrsb` | 12 |
| `ldm` | **12** | `ldmia` | 0 |
| `stm` | **34** | `stmia` | 0 |

That they are the *same instruction* is not an inference. **ARM DDI 0029G** — the ARM7TDMI Technical Reference Manual, the manual for the GBA's actual core — gives **one encoding per pair** in Figure 1-6 *"Thumb instruction set formats"*: Format 08 *"Load and store sign-extended byte and halfword"* (`0101 H S 1 Ro Rb Rd`) and Format 15 *"Multiple load and store"* (`1100 L Rb Rlist`). Two spellings, one encoding.

The UAL names the frontend recognised for the multiple forms **never appear in that corpus at all**, and the same tool emits *both* spellings for the signed byte load.

For the signed loads this was a clean decline — `ldsh` missed every `case`, degraded to a loud `opaque` through the CONTRACT-AS-INVARIANT path, and strict mode refused to render the `?`. **For the multiple forms it was silent.** `ldm rN, {rD}` reached `opaqueDest`, which takes `ops[0]` — the *base* — as the destination; the opaque was then dead, DCE removed it, and the load vanished:

```
ldm r1, {r0} ; bx lr     before:  return a0;      ← the load is gone
                         after:   return *a0;
```

`ldmfd` had the identical defect and was initially left out of the fix; it is in now.

### Why a table at the parse site — and why there is no shared helper

One table where the instruction enters the IR, rather than alias arms on each `case` (the idiom `mips.ts` and `ppc.ts` use for *their* extended mnemonics). The mnemonic is read by more consumers than the decode switch — `classifyXfer` decides return-vs-indirect from it, `opaquePolicy.storeClass` decides whether an unmodelled op may be skipped, and the instruction-size walk tests it for `bl`. An alias arm fixes exactly one of those.

The obvious next question is whether all three frontends should share one helper. **They should not**, and the rule is now written down in `opaque.ts` — the module that already owns cross-ISA decode policy — because three frontends handling this two different ways, with nothing saying which is right, is how drift starts.

It is decided by the operands, not by taste:

| kind | shape | handling | examples |
|---|---|---|---|
| **pure synonym** | same operands, same semantics | name→name table at the parse site | `ldsh`/`ldrsh`, `ldm`/`ldmfd`/`ldmia`, `stm`/`stmea`/`stmia` — ARM DDI 0029G Figure 1-6 gives one encoding apiece |
| **extended mnemonic** | different operand *grammar* | its own decode arm | MIPS `move rD,rS` (2 ops) = `addu rD,rS,zero` (3); PPC `slwi rD,rS,n` (3) = `rlwinm rD,rS,n,mb,me` (5, mask fields computed from `n`) |

A shared alias table would have **exactly one caller**. MIPS and PPC have no pure-synonym gap at all: every `unmodelled instruction` decline they produce across the 743 benchmark rows is a genuinely unmodelled opcode — `lwc1`, `fmuls`, `fadd`, `fctiwz`, `fadds`, `fcmpo`, `fdivs`, `fsubs`, `lfd`, `subfe`, `xoris`, `rlwimi`, `mfc1` — and not one spelling. Extracting it would also invite someone to push `slwi` through a table where it cannot fit.

The bar for extracting one is the bar `opaque.ts` itself met: several frontends hand-copying the same policy **and** observed drift between the copies.

What *is* shared, deliberately: `OpaquePolicy.display`. A frontend that normalises spellings must still report the one its input used, and that hook lives in the shared module so any future normalising frontend gets it for free.

### The table is closed, not merely sufficient

The load aliases matter more than the store ones, and the asymmetry is the whole reason `ldmfd` had to be added: an unrecognised `stm*` matches `opaquePolicy.storeClass` and fails **loud**, but an unrecognised `ldm*` does not — it reaches `opaqueDest`, which takes `ops[0]` (the *base*) as the destination, so the opaque is dead, DCE removes it, and the load **silently vanishes**.

So every spelling ARMv4T Thumb accepts for these instructions is now listed, verified against the assembler rather than against one corpus:

```
ldmfd r1!,{r0}   c901 = ldmia        stmea r1!,{r0}   c101 = stmia
ldmed / ldmea    REJECTED (IB/DB, absent from Thumb-1)
stmfd / stmdb    REJECTED ("selected processor does not support … in Thumb mode")
```

`stmea` occurs **0** times in the corpus; it is included because the set of accepted spellings is finite and known, not because something needed it. `stmfd` is excluded because there is nothing to normalise it *to*.

## 2. Thumb-1 has no no-writeback LDM/STM

The code drove writeback off the `!` suffix, on a comment asserting that `ldmia rN, {…}` was "the valid no-writeback form — same transfers, base unchanged". Four independent sources disagree:

- **ARM DDI 0029G**, Table 1-7 *"Thumb instruction set summary"*, gives the canonical syntax as `LDMIA Rb!, <reglist>` and `STMIA Rb!, <reglist>` — the `!` is part of the mnemonic, and Figure 1-6 Format 15 has no bit that could encode its absence;
- **GNU as** assembles `ldm r1,{r0}` and `ldm r1!,{r0}` to the **same halfword**, `0xc901`, and warns *"this instruction will write back the base register"*;
- **gba-kit** executes both with the base advanced by 4;
- **GBATEK**, THUMB.15: *"Both STM and LDM are incrementing the Base Register"*.

Writeback is now architectural rather than syntactic, suppressed only for an LDM whose base is in its own list — which GBATEK states explicitly: *"no writeback (LDM/ARMv4/ARMv5; at this point, THUMB opcodes work different than ARM opcodes)"*.

## 3. An STM storing its own base silently picked a side of an open question

asmlift emitted the **original** base. Four sources, three answers:

| source | says |
|---|---|
| ARM | **UNPREDICTABLE** — "the stored value cannot be relied upon" |
| GNU `as` | warns *"value stored for r4 is UNKNOWN"* |
| GBATEK | version-specific: *"Store OLD base if Rb is FIRST entry in Rlist, otherwise store NEW base (STM/ARMv4), always store OLD base (STM/ARMv5)"* |
| mGBA | stores the **old** base unconditionally, on an ARMv4T core |

I originally wrote this up as asmlift being wrong against GBATEK's ARMv4 rule. Then I went to cite mGBA and found it stores the old base too — its [`STM_LOOP`](https://github.com/mgba-emu/mgba/blob/afd6f14eaf8bd35214ed3fb9dc69a92bfc3877a9/src/gba/memory.c#L1568-L1574) reads `gprs[i]` during the loop while the THUMB writeback runs after it, and ARM mode has the same ordering via [`ADDR_MODE_4_WRITEBACK_STM`](https://github.com/mgba-emu/mgba/blob/afd6f14eaf8bd35214ed3fb9dc69a92bfc3877a9/src/arm/isa-arm.c#L267). No hardware test result turned up either way.

So the defect is not "wrong answer" but "silently picked one side of a disagreement". It now **declines**: where the architecture declines to define a value and the references contradict each other, guessing is precisely what the unmodelled-⇒-loud contract exists to prevent. The lowest-entry case *is* defined (old base, all sources agree) and still lifts.

The single corpus site is `InitFadeTransition`, which already declined on `main` for an unrelated pc-relative-pool reason — so the new decline costs nothing.

An **empty** register list needs no change here: asmlift already declines loudly on it (`stm` hits the store-class guard, `ldm` the no-register-destination guard), and GNU `as` cannot assemble `{}` in the first place. It is a real hardware quirk — R15 transferred, base += 0x40 — and it is fixed in gba-kit as [macabeus/gba-kit#9](https://github.com/macabeus/gba-kit/pull/9), but on this side the loud decline is already the right answer.

---

## Verification

**Encoding and semantics**, single Thumb instructions assembled by GNU as and executed on gba-kit's `ArmCpu` — identical encoding *and* identical architectural effect for every pair:

```
ldsh / ldrsh        885e / 885e    r0 = 0xfffffffe (sign-extended)
ldsb / ldrsb        8856 / 8856
ldm / ldmia / ldmfd 01c9 / 01c9 / 01c9   base advanced by 4
stm / stmia         01c1 / 01c1
```

**Benchmark: 0 of 743 rows affected**, checked rather than assumed. No row is blocked by a legacy mnemonic and none carries one in its `targetAsm`. Every row's asm *is* objdump output — and objdump prints UAL (`5e40 ldrsh`, `c901 ldmia`), which is the actual reason the benchmark cannot move.

**Corpus: 13 gained, 0 lost, 32 unchanged.** Scores of the newly-lifting functions: `11, 30, 30, 44, 48, 51, 51, 60, 72, 96, 155, 225, 317`. None is a match yet — `StreamCmd_InitAngleMotion` at **11 on 200 bytes** is the obvious candidate for a hand pass. One function (`EntityPositionFromLevelTable`) lifts but its candidate does not compile: a separate defect, now visible because the decline no longer hides it.

**Tests:** +13, covering both real corpus operand shapes (multi-register lists; a base in its own list), the `!`-less form, `ldmfd`'s silent drop, the UNPREDICTABLE decline, and message spelling. Pinned as *equivalence* between the two spellings rather than against expected source, so they cannot rot into asserting whatever the frontend happens to emit. `packages/core` is 51 files / 673 tests green.

## Corrections made during review

An adversarial reviewer redid every measurement and attacked the design; a documentation check then found the two semantic bugs. What changed as a result:

- **The original justification for the table was false.** It argued `isReturn` would mis-classify `ldm sp!, {r4, pc}` — an instruction ARMv4T Thumb cannot encode. **ARM DDI 0029G Figure 1-6**: Format 15 is `1 1 0 0 L Rb Rlist`, an 8-bit list over r0–r7 with **no bit for PC**; only Format 14 (push/pop) carries the `R` bit that adds LR/PC. GBATEK agrees — *"Rlist - List of Registers (R7..R0)"*. `as` rejects it (*"lo register required"*) and the corpus has 957 `pop` and zero `ldm` with `pc`. The dedicated test pinned behaviour on an impossible input and is deleted. The reviewer also built the per-`case` counterfactual and measured **two loud declines**, not the silently-wrong CFG claimed. The table is still right, for the reason in §1.
- **`ldmfd` was excluded and that left a silent hole**, so it is now included.
- **The canonical name leaked into user-visible messages** — a file containing `ldsh` declined with `unmodelled instruction 'ldrsh'`, and the same string reaches annotate-mode gap stubs. Instructions now carry `asWritten`, and `OpaquePolicy` gains `display`, so classification and reporting can differ.
- The lookup is **null-prototype**: as a plain literal, `LEGACY_MNEMONICS['constructor']` resolved to Object's constructor.
- An earlier revision of this description claimed *"nothing was ever silently wrong"* and *"no disassembler is in its path"*. Both were wrong; both are corrected above.

## Note on gba-kit, not this repo

The emulator used to verify this PR turned out to have a *different*, uncontested divergence — it treated an empty register list as a no-op where both GBATEK and mGBA transfer R15 and add `0x40` to the base. Fixed as [macabeus/gba-kit#9](https://github.com/macabeus/gba-kit/pull/9). Its base-in-list behaviour is deliberately left alone there for the reason in §3: it matches mGBA.


---

## References

| claim | source |
|---|---|
| one encoding per spelling pair | **ARM DDI 0029G**, Figure 1-6 *"Thumb instruction set formats"*, Formats 08 and 15 — [ARM7TDMI TRM Rev 3](https://ww1.microchip.com/downloads/en/DeviceDoc/DDI0029G_7TDMI_R3_trm.pdf) |
| canonical syntax carries `!` | **ARM DDI 0029G**, Table 1-7 *"Thumb instruction set summary"*: `LDMIA Rb!, <reglist>`, `STMIA Rb!, <reglist>` |
| PC cannot be in a Thumb LDM/STM list | **ARM DDI 0029G** Figure 1-6 (Format 15 has no `R` bit; only Format 14 push/pop does); [GBATEK THUMB.15](https://problemkaputt.de/gbatek-thumb-opcodes-memory-multiple-load-store-push-pop-and-ldm-stm.htm): *"Rlist - List of Registers (R7..R0)"* |
| LDM/STM always write back | [GBATEK THUMB.15](https://problemkaputt.de/gbatek-thumb-opcodes-memory-multiple-load-store-push-pop-and-ldm-stm.htm): *"Both STM and LDM are incrementing the Base Register"* |
| LDM base-in-list suppresses writeback | [GBATEK THUMB.15](https://problemkaputt.de/gbatek-thumb-opcodes-memory-multiple-load-store-push-pop-and-ldm-stm.htm): *"no writeback (LDM/ARMv4/ARMv5; at this point, THUMB opcodes work different than ARM opcodes)"* |
| STM base-in-list is disputed | [GBATEK](https://problemkaputt.de/gbatek-thumb-opcodes-memory-multiple-load-store-push-pop-and-ldm-stm.htm) (version-specific) vs [mGBA `STM_LOOP`](https://github.com/mgba-emu/mgba/blob/afd6f14eaf8bd35214ed3fb9dc69a92bfc3877a9/src/gba/memory.c#L1568-L1574) and [`ADDR_MODE_4_WRITEBACK_STM`](https://github.com/mgba-emu/mgba/blob/afd6f14eaf8bd35214ed3fb9dc69a92bfc3877a9/src/arm/isa-arm.c#L267) (always old base); [ARM ARM LDM/LDMIA/LDMFD](https://developer.arm.com/documentation/ddi0406/c/Application-Level-Architecture/Instruction-Details/Alphabetical-list-of-instructions/LDM-LDMIA-LDMFD--Thumb-) — UNPREDICTABLE |
| which spellings ARMv4T Thumb accepts | GNU `as` (`arm-none-eabi-as -mcpu=arm7tdmi -mthumb-interwork`), encodings and rejections quoted above |
| execution semantics | gba-kit `ArmCpu`, single instructions, encodings and post-state compared |

Note the ARM Developer pages are JavaScript-rendered and cannot be fetched as text; DDI 0029G was read as PDF, and the GBATEK quotations are verbatim.
