### PR TITLE
Fix the && short-circuit return regression

### DIFF
--- a/packages/cli/test/matching/regspell-candidate.test.ts
+++ b/packages/cli/test/matching/regspell-candidate.test.ts
@@ -1,21 +1,36 @@
 // The register-copy lever's GATE (mirrors branch-sense-candidate.test.ts): the offline pins call
 // registerishSpellings directly, so a wiring regression in rank.ts's respell seam (a contract
 // change rejecting the SFn, an emit throw) would silently drop the candidate with every offline
-// test green. This pins the END-TO-END win: the ranked path must produce the byte-exact regcopy
-// candidate and it must WIN. agbcc-native (no Docker). The modpow2 shape is the synthetic
-// benchmark row this lever flipped; the label pin catches a silently-dropped candidate.
+// test green. This pins the seam END-TO-END: the ranked path must actually produce the regcopy
+// candidates, and the ranked best must still match byte-exact. agbcc-native (no Docker).
+//
+// WHY THE VEHICLE IS `recip` AND NOT `modpow2`: this test used to run on `a % 8`, where the
+// regcopy spelling was what matched. Commit 4a85b70 ("Recover branching signed /2^k division")
+// taught divpow2 to fold the branching signed-division diamond, so `modpow2` now lifts straight
+// to `a0 - (a0 / 8 << 3)` and matches at score 0 by itself — R1 has no diamond left to re-spell,
+// so no regcopy candidate is emitted for it at all. That is an improvement, not a regression, but
+// it cost this file its subject. `recip` fires the lever through R2 (const-expression staging)
+// instead, which keeps the seam covered.
+//
+// SCOPE, stated so it is not mistaken for more than it is: this pins that the candidates are
+// ENUMERATED and that ranking still lands on a byte-exact spelling. It does NOT pin a shape where
+// the regcopy spelling is the one that WINS — the measured winners are real ROM functions
+// (kleod MultiplyQ8/Q4, ReciprocalQ8/Q4, pokeemerald MathUtil_Mul16, see l3/regspell.ts), whose
+// register pressure has no synthetic reproduction here. The benchmark is what covers the win.
 import { enumerateCandidates, rankBy } from '@asmlift/core/rank';
 import { ARMV4T_AGBCC } from '@asmlift/core/target';
 import { assembleTarget, compileTargetAsm, scoreC } from '@asmlift/toolchains';
 import { expect, test } from 'vitest';
 
-test('modpow2: the register-copy candidate exists and wins byte-exact through the ranked path', () => {
-  const c = 'int modpow2(int a){ return a % 8; }';
+test('the register-copy candidates are enumerated and ranked through the ranked path', () => {
+  const c = 'int recip(int a){ return 0x10000 / a; }';
   const asm = compileTargetAsm(c);
   const obj = assembleTarget(asm);
-  const cands = enumerateCandidates('modpow2', asm, ARMV4T_AGBCC, {});
-  expect(cands.some((x) => x.label.includes('regcopy'))).toBe(true); // the lever fired
-  const r = rankBy(cands, 'modpow2', (src) => scoreC(src, 'modpow2', obj));
+  const cands = enumerateCandidates('recip', asm, ARMV4T_AGBCC, {});
+  // the lever fired, and BOTH tails (with/without R3's assign-back) reached the candidate set
+  expect(cands.some((x) => x.label.endsWith('/regcopy'))).toBe(true);
+  expect(cands.some((x) => x.label.endsWith('/regcopy-ret'))).toBe(true);
+  // every regcopy candidate is emittable C, not a shape that throws downstream of the seam
+  const r = rankBy(cands, 'recip', (src) => scoreC(src, 'recip', obj));
   expect(r.best.score.match).toBe(true);
-  expect(r.best.label).toContain('regcopy'); // and it is the regcopy spelling that wins
 });

--- a/packages/cli/test/matching/shortcircuit-retsink.test.ts
+++ b/packages/cli/test/matching/shortcircuit-retsink.test.ts
@@ -12,6 +12,8 @@ import { ARMV4T_AGBCC } from '@asmlift/core/target';
 import { assembleTarget, compileTargetAsm, scoreC } from '@asmlift/toolchains';
 import { describe, expect, test } from 'vitest';
 
+import { decompileRanked } from '../../src/rank';
+
 const match = (sym: string, src: string) => {
   const asm = compileTargetAsm(src);
   const r = decompile(sym, asm, ARMV4T_AGBCC);
@@ -22,8 +24,13 @@ describe('F-CFG return-sinking: && short-circuit returns match byte-exact', () =
   test('if (a && b) return X; return Y — early returns, no merge var', () => {
     const { src, sc } = match('ifand', 'int ifand(int a, int b){ if (a && b) return 42; return 7; }');
     expect(sc.match).toBe(true);
-    expect(src).not.toContain('v0'); // sunk to early returns, not a merge variable
-    expect((src.match(/return/g) ?? []).length).toBeGreaterThanOrEqual(3);
+    expect(src).not.toContain('v0'); // sunk to returns, not a merge variable — the point of the pass
+    // Two returns, not three: `branch-shortcircuit` (raise/shortcircuit.ts) fuses the chain into one
+    // `a0 != 0 && a1 != 0` head BEFORE this pass runs, so the arms are `return 42` / `return 7` rather
+    // than the pre-fusion `if (!a) return 7; if (!b) return 7; return 42`. Both spellings recompile to
+    // the compiler's shared-return diamond; this one is also the more faithful source.
+    expect((src.match(/return/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect(src).toContain('&&'); // the fused connective, not a re-expanded chain
   });
 
   test('chained a && b && c returns match', () => {
@@ -43,5 +50,21 @@ describe('F-CFG return-sinking gate: simple value-selects are NOT sunk (kept as 
   test('select (c ? x : y) keeps its match', () => {
     const { sc } = match('sel', 'int sel(int a, int x, int y){ return a ? x : y; }');
     expect(sc.match).toBe(true);
+  });
+
+  // `return a || b` — the VALUE form. It reaches this pass as a `cond_br` on a `logic_or` too (the
+  // value fold in shortcircuit.ts declines it: its const-1 arm has two predecessors), so the
+  // connective alone would sink it. It must NOT be: one edge runs from the head straight into the
+  // merge, the merge variable is what byte-matches, and a first cut of the fused-shape gate cost
+  // this exact row its match on the benchmark (synthetic:lor:agbcc).
+  //
+  // Scored through the RANKED path, because that is where this row's match lives: single-shot
+  // `decompile` emits the if/else merge variable and scores 4 — it is the `/defsite` candidate
+  // (`v0 = 0; if (…) v0 = 1;`) that is byte-exact, both before this gate existed and after.
+  test('lor (return a || b) keeps its match — a value-merge, not a two-armed diamond', () => {
+    const asm = compileTargetAsm('int lor(int a, int b){ return a || b; }');
+    const r = decompileRanked('lor', asm, ARMV4T_AGBCC, assembleTarget(asm));
+    expect(r.best.score.match).toBe(true);
+    expect(r.best.source).toContain('v0'); // still the merge variable, not sunk to returns
   });
 });

--- a/packages/core/src/raise/retsink.ts
+++ b/packages/core/src/raise/retsink.ts
@@ -21,15 +21,20 @@
 //
 // This does NOT recover the boolean-VALUE form `return a && b` — that is shortcircuit.ts's job
 // (the `logic_and`/`logic_or` connective plus agbcc's `(-b|b)>>31` = `b!=0` normalisation).
-import { Block, Fn, mkOp, predecessors } from '../ir/core';
+import { Block, Fn, defOpMap, mkOp, predecessors } from '../ir/core';
+
+/** The fused short-circuit connectives (raise/shortcircuit.ts). A `cond_br` on one of these is the
+ *  post-fusion record of the ≥2 conditions that used to reach a shared arm. */
+const CONNECTIVES = new Set(['logic_and', 'logic_or']);
 
 /** Tail-duplicate a return-only merge block into its unconditional-branch predecessors, but ONLY in the
- *  short-circuit shape (some branch-pred is shared). Returns whether anything changed. A "return-only"
- *  block is exactly one `ret` whose operands are all its own block-params, so each predecessor already
- *  carries the returned value as a successor arg. */
+ *  short-circuit shape (some branch-pred is shared, or the arms are selected by a fused connective).
+ *  Returns whether anything changed. A "return-only" block is exactly one `ret` whose operands are all
+ *  its own block-params, so each predecessor already carries the returned value as a successor arg. */
 export function sinkReturns(fn: Fn): boolean {
   let changed = false;
   const preds = predecessors(fn);
+  const defs = defOpMap(fn);
   const isBrTo = (p: Block, m: Block) => {
     const t = p.ops[p.ops.length - 1];
     return t.opcode === 'br' && t.successors.length === 1 && t.successors[0].block === m;
@@ -52,9 +57,33 @@ export function sinkReturns(fn: Fn): boolean {
     if (brPreds.length === 0) {
       continue;
     }
-    // SHORT-CIRCUIT GATE: at least one branch-pred must be a shared block (≥2 preds of its own). A simple
-    // single-condition select has only single-pred arms and is left as a merge variable (which matches).
-    if (!brPreds.some((p) => (preds.get(p)?.length ?? 0) >= 2)) {
+    // SHORT-CIRCUIT GATE, in two shapes — the chain must be visible in the CFG or in the value domain.
+    //
+    //   (a) UNFUSED: at least one branch-pred is a shared block (≥2 preds of its own) — the common
+    //       early-exit reached from every condition of the chain.
+    //   (b) FUSED: `branch-shortcircuit` (raise/shortcircuit.ts) rewrites the head's condition into a
+    //       `logic_and`/`logic_or` and collapses the second condition block into it. That leaves both
+    //       arms single-pred, so (a) cannot see the chain any more — but the CONNECTIVE is now the
+    //       record of the ≥2 conditions the shared arm used to be. That pass runs in pre-recovery,
+    //       i.e. BEFORE this one, so on `ifand`/`and3` shape (b) is the only one that ever fires.
+    //
+    //       The connective ALONE is not enough, and the extra requirement is BOTH arms being real
+    //       blocks (≥2 `br` preds). `return a || b` (synthetic:lor) also ends up as a `cond_br` on a
+    //       `logic_or`, but it is a value-merge: one edge runs from the head STRAIGHT into the merge,
+    //       so the merge has a single `br` pred. Sinking it replaces the merge variable that
+    //       byte-matches — measured, it cost that row its match. A two-armed diamond is what
+    //       distinguishes `if (a && b) return X; return Y;` from every value-merge.
+    //
+    // A simple single-condition select is excluded by both arms of the gate for the same reason:
+    // `clamp0`/`sel` reach their merge on the `cond_br` edge itself, so they too have exactly one
+    // `br` pred, and their condition is a bare icmp rather than a connective.
+    const selectedByConnective = (p: Block) =>
+      (preds.get(p) ?? []).some((q) => {
+        const t = q.ops[q.ops.length - 1];
+        return t.opcode === 'cond_br' && CONNECTIVES.has(defs.get(t.operands[0])?.opcode ?? '');
+      });
+    const fusedDiamond = brPreds.length >= 2 && brPreds.some(selectedByConnective);
+    if (!brPreds.some((p) => (preds.get(p)?.length ?? 0) >= 2) && !fusedDiamond) {
       continue;
     }
     for (const p of brPreds) {


### PR DESCRIPTION
`if (a && b) return X; return Y;` stopped matching byte-exact in `b43b71c` (#11), and has been broken on `main` ever since. Bisected against `v0.3.0`, where it passed.

> **Stacked:** the 0.4.0 version bump was split out into #27, which targets this branch. Merge this one first.

## The regression

`branch-shortcircuit` (`raise/shortcircuit.ts`) rewrites the head's condition into a `logic_and`/`logic_or` and folds the second condition block into it. It runs in pre-recovery — **before** `raise/retsink.ts` — and leaves both arms single-pred, which is precisely the signal `sinkReturns` gated on ("some branch-pred is shared, ≥2 preds of its own"). With the gate dead, the arms lower as a merge variable:

```c
s32 ifand(s32 a0, s32 a1) {        // score 4, was byte-exact at v0.3.0
    s32 v0;
    if (a0 == 0 || a1 == 0) { v0 = 7; } else { v0 = 42; }
    return v0;
}
```

Nothing automatic could have caught this. `ci.yml` stops at `test:offline`, because the matching tests compile real ARM/MIPS/PPC through toolchains GitHub runners lack — and `bench regression` reports 0 lost, because no benchmark row exercises the shape.

## The fix

Accept the fused shape too: the connective **is** the post-fusion record of the ≥2 conditions the shared arm used to represent. `ifand` and `and3` are back to score 0, and the output is better than the pre-#11 spelling — the chain stays fused rather than being re-expanded into three early returns:

```c
s32 ifand(s32 a0, s32 a1) {        // score 0
    if (a0 != 0 && a1 != 0) { return 42; } else { return 7; }
}
```

### The connective alone is not a sufficient gate

The benchmark caught the first cut of this doing real damage. `return a || b` (`synthetic:lor`) also ends up as a `cond_br` on a `logic_or` — the value fold declines it because its const-1 arm has two predecessors — but it is a **value-merge**: one edge runs from the head straight into the merge, so the merge has a single `br` pred. Sinking it replaced the merge variable that byte-matches, and the row lost its match.

Requiring **both arms to be real blocks** (≥2 `br` preds) separates a two-armed diamond from every value-merge, and re-excludes `clamp0`/`sel` for the same structural reason. `lor` is now pinned as a protected shape, scored through the ranked path — that is where its match actually lives (single-shot `decompile` emits the merge variable and scores 4; the `/defsite` candidate is the byte-exact one).

## Two stale pins, re-pointed

Both asserted a *route* rather than an *outcome*, and `4a85b70` (#24) legitimately changed the route:

- **`regspell-candidate`** — `divpow2` now folds `a % 8`'s diamond, so `modpow2` lifts to `a0 - (a0 / 8 << 3)` and matches at score 0 with no regcopy candidate emitted at all. Re-pointed to `recip`, which fires the lever through R2 (const staging). The file now states its scope explicitly: it pins that the candidates are **enumerated**, not that regcopy **wins** — the measured winners are real ROM functions (kleod `MultiplyQ8`/`Q4`, pokeemerald `MathUtil_Mul16`) with no synthetic reproduction here, and the benchmark covers the win.
- **`shortcircuit-retsink`** — the `>= 3 returns` assertion encoded the pre-#11 spelling. The `not.toContain('v0')` assertion already carries the real intent, and `toContain('&&')` now pins the fused form.

## Gates

| gate | result |
| --- | --- |
| `pnpm run typecheck` | pass |
| `pnpm run lint` | 0 errors (41 pre-existing warnings) |
| `pnpm run format:check` | pass |
| `pnpm run test:offline` | 744 passed |
| `pnpm test` (full, toolchain-backed) | 965 + 278 passed |
| `bench run && bench merge && bench regression` | **0 lost, 0 missing, 0 gained, 0 other flips** (743 rows, full toolchain coverage) |

Zero rows move: no benchmark row exercises this shape, which is why the regression survived on `main`.

Benchmark results files are deliberately **not** committed — the re-run is outcome-identical, so its only diff is timestamps, temp-dir names, and a `"dirty": true` provenance stamp from the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)