### PR TITLE
Release @asmlift/core and @asmlift/cli 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ asmlift: [score] unsigned: 0 (match)
 | [`apps/web`](apps/web/README.md)                                                                            | The webapp including the **Playground** and the **Benchmark**             |
 | [`apps/benchmark`](apps/benchmark/README.md)                                                                | The asmlift and m2c harness                                               |
 
+## Releasing
+
+`@asmlift/core` and `@asmlift/cli` are the two public packages — see [`docs/releasing.md`](docs/releasing.md)
+for the gates (including the two that hosted CI cannot run) and the publish order.
+
 ## License
 
 **MIT** ([`LICENSE`](LICENSE)) for the whole monorepo, with two carve-outs:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,70 @@
+# Releasing `@asmlift/core` + `@asmlift/cli`
+
+These are the only two public packages. Everything else in the workspace is `private: true`
+(`packages/toolchains`, `packages/bench-schema`, `apps/*`), so a workspace-wide publish can only
+ever touch these two.
+
+## Build shape (it differs per package)
+
+| package         | build                                                                  | ships                                                                  |
+| --------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `@asmlift/core` | **none** — raw TS source (`exports` → `./src/*.ts`)                    | `src/`                                                                 |
+| `@asmlift/cli`  | esbuild → `dist/asmlift.mjs` (the `bin`), also run by `prepublishOnly` | `dist/` **and** `src/`, so `@asmlift/cli/score` importers keep working |
+
+## The gates
+
+Run all of these from a clean tree on `main`, and read the **exit status**, not the tail of a
+pipeline — `cmd | tail` reports `tail`'s status, which is how a failing suite has already been
+mistaken for a passing one.
+
+1. `pnpm run typecheck`
+2. `pnpm run lint` — 0 errors (warnings are pre-existing)
+3. `pnpm run format:check`
+4. `pnpm run test:offline`
+5. **`pnpm test` — the FULL suite, including the toolchain-backed matching tests.**
+6. `pnpm bench run && pnpm bench merge && pnpm bench regression` — 0 lost, 0 missing.
+
+### Why gate 5 is on this list
+
+Gate 5 is the one hosted CI cannot run: `.github/workflows/ci.yml` stops at `test:offline`,
+because the matching suite compiles real ARM/MIPS/PPC through toolchains that GitHub runners do
+not have. That gap is not theoretical. Two match regressions reached `main` with every hosted gate
+green, and both were still there when 0.4.0 was being prepared:
+
+- `b43b71c` (#11) — `branch-shortcircuit` fusion destroyed the CFG signal `raise/retsink.ts`
+  gates on, so `if (a && b) return X; return Y;` stopped matching byte-exact;
+- `4a85b70` (#24) — `divpow2` legitimately absorbed `modpow2`'s diamond, leaving the
+  `/regcopy` end-to-end pin asserting a route that no longer exists.
+
+Neither moved a benchmark row, so gate 6 would not have caught them either. Run gate 5 locally.
+
+### Why gate 6 is on this list, separately
+
+`pnpm bench regression` **only compares two `results.json` files** — it does not run anything. Run
+`bench run` and `bench merge` first, or it will cheerfully compare the committed results against
+themselves and report "0 lost, 0 gained" without having executed a single row.
+
+## Steps
+
+1. Bump `version` in `packages/core/package.json` and `packages/cli/package.json`.
+2. Keep cli's dependency on core at `workspace:^` — it publishes as `^<version>`.
+3. `pnpm install` to sync the lockfile (CI runs `--frozen-lockfile`).
+4. Verify the tarballs: `pnpm pack` in each package, and inspect `package/package.json`'s deps.
+5. Publish **core first, cli second** — cli depends on core:
+
+   ```
+   pnpm --filter @asmlift/core publish --access public --otp=<code>
+   pnpm --filter @asmlift/cli  publish --access public --otp=<code>
+   ```
+
+6. `git tag -a vX.Y.Z <release-commit>` and push the tag.
+
+### 2FA
+
+The npm account has publish-2FA, so a bare `pnpm publish` fails with `EOTP`. Each publish needs its
+own **fresh, single-use** `--otp=<code>`; that is a credential, so a human runs these two commands.
+`EOTP` halts before upload, so a rejected OTP is never a partial publish.
+
+The private `@asmlift/toolchains` (v0.0.0) is a devDependency of cli. `workspace:*` resolves to
+`0.0.0` in the published metadata — harmless, since consumers skip devDeps, and it does not block
+the publish.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asmlift/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "type": "module",
   "description": "The asmlift command line: decompile one function to C/Pascal from the terminal",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asmlift/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "type": "module",
   "description": "Match decompile an assembly function to C or Pascal",


### PR DESCRIPTION
Bumps both public packages to 0.4.0, and adds the release procedure to the repo.

> **Stacked on #26** (the `&&` short-circuit return fix), which is what 0.4.0 is being cut to ship. This PR targets that branch — merge #26 first, and this one's diff becomes just the bump + docs.

## The bump

`@asmlift/core` and `@asmlift/cli` both go to 0.4.0. cli's dependency on core stays `workspace:^`, so it publishes as `^0.4.0`; the lockfile needs no change, since a workspace protocol records no version.

Verified by packing both tarballs and installing them into a scratch project as a real consumer would — `@asmlift/cli@0.4.0` resolves `@asmlift/core: ^0.4.0`, ships `dist/` + `src/`, and decompiles correctly through the installed `bin`.

## `docs/releasing.md`

This did not exist — the steps lived only in one person's head. It documents the build-shape difference (core ships raw TS with no build; cli bundles via esbuild and ships both `dist/` and `src/`), the publish order, the 2FA handoff, and in particular **the two gates hosted CI cannot run**, because both of them mattered for this exact release:

- **`pnpm test`, the full toolchain-backed suite.** `ci.yml` stops at `test:offline`, since the matching tests compile real ARM/MIPS/PPC through toolchains GitHub runners lack. Two match regressions had reached `main` with every hosted gate green, and both were still there when 0.4.0 was cut — one is #26, the other was a stale pin from #24.
- **`bench run && bench merge` BEFORE `bench regression`.** The regression gate only *compares* two `results.json` files. Run on its own it cheerfully compares the committed results against themselves and reports "0 lost, 0 gained" without having executed a single row. That happened while preparing this release.

It also records the habit that hid the first failure: read the **exit status**, not the tail of a pipeline. `cmd | tail` reports `tail`'s status, and a failing suite looked like a passing one for exactly that reason.

Linked from the README.

## Publishing

Left to a human, because the npm account has publish-2FA and each publish needs its own fresh single-use OTP. Core first, cli second:

```sh
pnpm --filter @asmlift/core publish --access public --otp=<code>
pnpm --filter @asmlift/cli  publish --access public --otp=<code>
```

Then `git tag -a v0.4.0 <release-commit>` and push the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)