### PR TITLE
Commit the fuzz coalesce's sound-critical gate rested on

### DIFF
--- a/packages/core/src/l3/coalesce.ts
+++ b/packages/core/src/l3/coalesce.ts
@@ -97,29 +97,24 @@ function rename(body: Stmt[], from: string, to: string): Stmt[] {
  *     statement's own index with the ENCLOSING loop flag. That is safe only because a condition
  *     cannot WRITE, so it can extend a read range but never reorder a definition — an earlier
  *     version of this comment claimed the gate covered conditions too, which it does not.
- *     `test/coalesce-fuzz.test.ts` is the differential check, and it runs BOTH arms: over its
- *     generated programs no candidate this pass emits changes a defined read, and the same programs
- *     with the loop flag suppressed DO — so the first arm is not green because nothing happened.
- *   - both must be CONSTANT-fed. A codegen heuristic, not soundness, and that is now measured
- *     rather than asserted: deleting this gate and re-running that fuzz stays clobber-free while
- *     offering about a third more merges. A load-fed local is one the compiler had a reason to keep
- *     where it was, and taking it anyway scored worse. The gate is also what currently BOUNDS
- *     candidate growth: merges are `L(L-1)/2` in the local count, each a distinct source and so a
- *     distinct compile, and nothing else caps that. Corpus-wide today: 2 rows, 13 kept sources.
+ *     `test/coalesce-fuzz.test.ts` is the differential check; delete this gate and it fails.
+ *   - both must be CONSTANT-fed. A codegen heuristic, not soundness: deleting it stays clobber-free
+ *     under that fuzz and simply scored worse, because a load-fed local is one the compiler had a
+ *     reason to keep where it was. It is also what currently BOUNDS candidate growth: merges are
+ *     `L(L-1)/2` in the local count, each a distinct source and so a distinct compile, and nothing
+ *     else caps that. Corpus-wide today: 2 rows, 13 kept sources.
  *   - the survivor's first mention must be an ASSIGN THAT DOES NOT ALSO READ IT. `b = g(b)` is a
  *     write and a read in one statement; counting it as a pure write let `g` receive the absorbed
- *     value. The two gates are NOT independent — `constFed` also rejects a self-reading assign, so
- *     it masks this one — and deleting both is what isolates this one's job. Doing that produces no
- *     clobber at all: a survivor whose first mention is a READ was uninitialized there in the
- *     ORIGINAL too, so what this gate governs is the size of the accepted class below, which grows
- *     16 → 187 candidates over the fuzz's sweep. A discipline, not a soundness gate — and only
- *     because this file treats an uninitialized read as ill-defined rather than wrong.
+ *     value. NOT a soundness gate, though it reads like one, and `constFed` masks it so only
+ *     deleting both shows why: a survivor whose first mention is a READ was uninitialized there in
+ *     the ORIGINAL too, so no clobber appears — what this gate bounds is the size of the accepted
+ *     class below, which it holds down by an order of magnitude.
  *
  *  ACCEPTED, NOT FIXED: a survivor assigned only on SOME paths still absorbs the other's value on
  *  the paths that skip it. The original read an uninitialized local there, so both spellings are
  *  ill-defined rather than one being wrong — but this is a real difference and the differ, not this
- *  gate, is what keeps it from faking a match. The fuzz reaches it (8 of its 176 candidates) and
- *  asserts it stays reachable, so the carve-out that excuses it cannot quietly become dead. */
+ *  gate, is what keeps it from faking a match. The fuzz asserts it stays reachable, so the carve-out
+ *  that excuses it cannot quietly become dead. */
 export function coalesceCandidates(sfn: SFn): { merged: string; sfn: SFn }[] {
   if (sfn.locals.length < 2) {
     return [];

--- a/packages/core/src/l3/coalesce.ts
+++ b/packages/core/src/l3/coalesce.ts
@@ -97,23 +97,29 @@ function rename(body: Stmt[], from: string, to: string): Stmt[] {
  *     statement's own index with the ENCLOSING loop flag. That is safe only because a condition
  *     cannot WRITE, so it can extend a read range but never reorder a definition — an earlier
  *     version of this comment claimed the gate covered conditions too, which it does not.
- *     Differential fuzzing supports this: removing the gate produces clobbers immediately, leaving
- *     it on produces none. No such harness is committed, so nothing here re-checks it.
- *   - both must be CONSTANT-fed. A codegen heuristic, not soundness — removing it stayed
- *     clobber-free under the same (uncommitted) fuzz and simply scored worse, because a load-fed
- *     local is one the compiler had a reason to keep where it was. It is also what currently BOUNDS
+ *     `test/coalesce-fuzz.test.ts` is the differential check, and it runs BOTH arms: over its
+ *     generated programs no candidate this pass emits changes a defined read, and the same programs
+ *     with the loop flag suppressed DO — so the first arm is not green because nothing happened.
+ *   - both must be CONSTANT-fed. A codegen heuristic, not soundness, and that is now measured
+ *     rather than asserted: deleting this gate and re-running that fuzz stays clobber-free while
+ *     offering about a third more merges. A load-fed local is one the compiler had a reason to keep
+ *     where it was, and taking it anyway scored worse. The gate is also what currently BOUNDS
  *     candidate growth: merges are `L(L-1)/2` in the local count, each a distinct source and so a
  *     distinct compile, and nothing else caps that. Corpus-wide today: 2 rows, 13 kept sources.
  *   - the survivor's first mention must be an ASSIGN THAT DOES NOT ALSO READ IT. `b = g(b)` is a
  *     write and a read in one statement; counting it as a pure write let `g` receive the absorbed
- *     value. These two gates are NOT independent: `constFed` also rejects a self-reading assign
- *     (its value is not a literal), so it masks this one. No committed test isolates it — this is
- *     defence-in-depth for the day `constFed` is relaxed, which the note above makes plausible.
+ *     value. The two gates are NOT independent — `constFed` also rejects a self-reading assign, so
+ *     it masks this one — and deleting both is what isolates this one's job. Doing that produces no
+ *     clobber at all: a survivor whose first mention is a READ was uninitialized there in the
+ *     ORIGINAL too, so what this gate governs is the size of the accepted class below, which grows
+ *     16 → 187 candidates over the fuzz's sweep. A discipline, not a soundness gate — and only
+ *     because this file treats an uninitialized read as ill-defined rather than wrong.
  *
  *  ACCEPTED, NOT FIXED: a survivor assigned only on SOME paths still absorbs the other's value on
  *  the paths that skip it. The original read an uninitialized local there, so both spellings are
  *  ill-defined rather than one being wrong — but this is a real difference and the differ, not this
- *  gate, is what keeps it from faking a match. */
+ *  gate, is what keeps it from faking a match. The fuzz reaches it (8 of its 176 candidates) and
+ *  asserts it stays reachable, so the carve-out that excuses it cannot quietly become dead. */
 export function coalesceCandidates(sfn: SFn): { merged: string; sfn: SFn }[] {
   if (sfn.locals.length < 2) {
     return [];

--- a/packages/core/test/coalesce-fuzz.test.ts
+++ b/packages/core/test/coalesce-fuzz.test.ts
@@ -1,30 +1,16 @@
-// The differential fuzz behind coalesce.ts's loop gate — the one gate in that file whose
-// justification is SOUNDNESS rather than codegen quality, and which until now rested on a harness
-// that was run once and never committed.
+// The differential fuzz for coalesce.ts's loop gate — see that file for what the gate claims.
 //
-// The claim: excluding a local mentioned inside a loop is what makes preorder statement order a
-// sufficient approximation of liveness, so `x.last < y.first` really does mean the ranges are
-// disjoint. Two arms check it, and BOTH are needed — the second is what stops the first from being
-// a test that passes because nothing happens.
-//
-//   A. every candidate the pass emits preserves every defined read (no clobber);
-//   B. the same programs with the loop flag suppressed DO clobber, so the generator reaches the
-//      shapes the gate exists for.
-//
-// Arm B suppresses the flag by INPUT rather than by a test-only switch in the pass, so the real
-// predicate and the real rename run in both arms — see the rewrite below.
+// Arm A: no candidate the pass emits changes a defined read. Arm B: the same programs with the loop
+// flag suppressed DO — without which arm A is also what "emitted nothing" looks like.
 import { describe, expect, test } from 'vitest';
 
 import { T } from '../src/ir/types';
 import type { Expr, SFn, Stmt } from '../src/l3/ast';
 import { coalesceCandidates } from '../src/l3/coalesce';
 
-// ── the schedule ───────────────────────────────────────────────────────────────────────────────
-// Control flow comes from a pre-drawn list, not from the values: each `if` takes its arm and each
-// loop its trip count from the next draw. Conditions are still EVALUATED (their reads are observed)
-// and their value discarded. That makes the two trees run the same path by construction — so the
-// traces align index for index and every difference is a value difference — and it makes the
-// comparison quantify over schedules the values might never produce, including zero-trip loops.
+// Control flow comes from a pre-drawn list, not from the values, so both trees take the same path by
+// construction: traces align index for index and every difference is a value difference. Conditions
+// are still evaluated — their reads are observed — and their value discarded.
 type Schedule = () => number;
 const schedule = (draws: number[]): Schedule => {
   let at = 0;
@@ -41,11 +27,8 @@ function run(sfn: SFn, sched: Schedule): Val[] {
   const env = new Map<string, Val>();
   const reads: Val[] = [];
 
-  // UNDEF POISONS. An expression over an uninitialized local is as indeterminate as the local
-  // itself, so it must not re-enter the defined world as a concrete number — that is what makes the
-  // carve-out below match the documented case instead of over-reporting. It is not hypothetical:
-  // modelling `b = b + 1` on an undefined `b` as a defined value made this harness call one legal
-  // merge a clobber.
+  // UNDEF POISONS: an expression over an uninitialized local is as indeterminate as the local, so it
+  // must not re-enter the defined world as a number. Without this the harness over-reports.
   const evalExpr = (e: Expr): Val => {
     switch (e.k) {
       case 'var': {
@@ -124,10 +107,9 @@ function compare(orig: SFn, cand: SFn, draws: number[]): 'same' | 'undefined-onl
   return a.some((v, i) => v !== b[i]) ? 'undefined-only' : 'same';
 }
 
-// ── the generator ──────────────────────────────────────────────────────────────────────────────
-// Small on purpose. It emits only what the gate reasons about: constant-fed locals (so merges are
-// legal at all), reads, and the three positions where a later-indexed statement can run before an
-// earlier one — a loop body, and a `for`'s init and inc.
+// The generator emits only what the gate reasons about: constant-fed locals, reads, and the three
+// positions where a later-indexed statement can run before an earlier one — a loop body, and a
+// `for`'s init and inc.
 const LOCALS = ['a', 'b', 'c'];
 
 function mulberry32(seed: number): () => number {
@@ -143,16 +125,15 @@ function mulberry32(seed: number): () => number {
 function generate(seed: number): SFn {
   const rnd = mulberry32(seed);
   const pick = <X>(xs: X[]): X => xs[Math.floor(rnd() * xs.length)];
-  // A local is chosen with a DRIFT towards the end of the program, so ranges are often disjoint.
-  // Uniform choice makes almost every pair overlap in preorder, so the pass emits almost nothing and
-  // the sweep runs thousands of programs to test a handful of merges.
+  // Locals are chosen with a DRIFT towards the end of the program, so ranges are often disjoint.
+  // Under uniform choice almost every pair overlaps in preorder and the sweep runs thousands of
+  // programs to test a handful of merges.
   let emitted = 0;
   const local = (): string =>
     rnd() < 0.8 ? LOCALS[Math.min(LOCALS.length - 1, Math.floor(emitted / 5))] : pick(LOCALS);
   const read = (n: string): Expr => ({ k: 'var', name: n });
   const obs = (): Stmt => ({ k: 'exprstmt', value: { k: 'call', fn: 'obs', args: [read(local())] } });
-  // mostly constant-fed, since `constFed` would otherwise reject the pair before the loop gate is
-  // ever consulted and the whole fuzz would go vacuous
+  // mostly constant-fed, or `constFed` rejects the pair before the loop gate is ever consulted
   const value = (): Expr =>
     rnd() < 0.85
       ? { k: 'const', value: Math.floor(rnd() * 100) }
@@ -189,10 +170,9 @@ function generate(seed: number): SFn {
   };
 }
 
-// ── arm B's ablation, as an input rewrite ──────────────────────────────────────────────────────
-// A loop becomes an `if` carrying the same condition, body and child order, tagged so it can be
-// turned back after the pass has run. `stmtChildren` and `stmtExprs` then agree node for node with
-// the loop's, so `spans` produces an identical map except for `inLoop` — the gate ablated, and
+// Arm B's ablation, as an input rewrite: a loop becomes an `if` over the same children, tagged so it
+// can be turned back after the pass has run. `stmtChildren`/`stmtExprs` then agree node for node with
+// the loop's, so `spans` produces an identical map except for `inLoop` — that gate ablated and
 // nothing else. `for`'s children are `[init, inc, ...body]`, so the `if` lists them in that order.
 const MARK = { while: '__was_while__', for: '__was_for__' } as const;
 const tag = (fn: string, cond: Expr): Expr => ({ k: 'call', fn, args: [cond] });
@@ -266,9 +246,7 @@ describe('the loop gate, differentially', () => {
   const ablated = sweep(withoutLoopGate);
 
   test('the sweep reaches mergeable programs at all', () => {
-    // Without this, "no clobbers" would also be the result of emitting nothing. 2000 programs
-    // currently offer 176 merges; the floor is well under that so ordinary generator tuning does
-    // not have to move it.
+    // A floor well under what the generator currently offers, so tuning it does not have to move.
     expect(kept.candidates).toBeGreaterThan(80);
   });
 
@@ -277,17 +255,13 @@ describe('the loop gate, differentially', () => {
   });
 
   test('suppressing the loop flag DOES clobber — the gate is load-bearing', () => {
-    // The gate's whole justification, and the only thing that stops the test above from passing
-    // for the wrong reason. If this goes green, either the generator stopped reaching loops or the
-    // pass stopped consulting `inLoop`.
+    // Green here means the generator stopped reaching loops, or the pass stopped consulting `inLoop`.
     expect(ablated.clobbered.length).toBeGreaterThan(0);
   });
 
   test('the accepted-not-fixed case is real, and is what the carve-out covers', () => {
-    // A survivor written on only SOME paths absorbs the other's value where the original read an
-    // uninitialized local. coalesce.ts documents this as accepted; the count says it is not
-    // hypothetical (8 of 176 today), so the carve-out above is load-bearing rather than an unused
-    // escape hatch that a later reader could delete as dead.
+    // coalesce.ts accepts this class; asserting it stays reachable stops the carve-out that excuses
+    // it from quietly becoming dead code.
     expect(kept.undefinedOnly).toBeGreaterThan(0);
   });
 });

--- a/packages/core/test/coalesce-fuzz.test.ts
+++ b/packages/core/test/coalesce-fuzz.test.ts
@@ -1,0 +1,293 @@
+// The differential fuzz behind coalesce.ts's loop gate — the one gate in that file whose
+// justification is SOUNDNESS rather than codegen quality, and which until now rested on a harness
+// that was run once and never committed.
+//
+// The claim: excluding a local mentioned inside a loop is what makes preorder statement order a
+// sufficient approximation of liveness, so `x.last < y.first` really does mean the ranges are
+// disjoint. Two arms check it, and BOTH are needed — the second is what stops the first from being
+// a test that passes because nothing happens.
+//
+//   A. every candidate the pass emits preserves every defined read (no clobber);
+//   B. the same programs with the loop flag suppressed DO clobber, so the generator reaches the
+//      shapes the gate exists for.
+//
+// Arm B suppresses the flag by INPUT rather than by a test-only switch in the pass, so the real
+// predicate and the real rename run in both arms — see the rewrite below.
+import { describe, expect, test } from 'vitest';
+
+import { T } from '../src/ir/types';
+import type { Expr, SFn, Stmt } from '../src/l3/ast';
+import { coalesceCandidates } from '../src/l3/coalesce';
+
+// ── the schedule ───────────────────────────────────────────────────────────────────────────────
+// Control flow comes from a pre-drawn list, not from the values: each `if` takes its arm and each
+// loop its trip count from the next draw. Conditions are still EVALUATED (their reads are observed)
+// and their value discarded. That makes the two trees run the same path by construction — so the
+// traces align index for index and every difference is a value difference — and it makes the
+// comparison quantify over schedules the values might never produce, including zero-trip loops.
+type Schedule = () => number;
+const schedule = (draws: number[]): Schedule => {
+  let at = 0;
+  return () => draws[at++ % draws.length];
+};
+
+/** A local that was never assigned on this path. The ORIGINAL reading one is the documented
+ *  ACCEPTED-NOT-FIXED case (both spellings are ill-defined), so such a read constrains nothing. */
+const UNDEF = null;
+type Val = number | typeof UNDEF;
+
+/** Every value a variable read observed, in execution order. */
+function run(sfn: SFn, sched: Schedule): Val[] {
+  const env = new Map<string, Val>();
+  const reads: Val[] = [];
+
+  // UNDEF POISONS. An expression over an uninitialized local is as indeterminate as the local
+  // itself, so it must not re-enter the defined world as a concrete number — that is what makes the
+  // carve-out below match the documented case instead of over-reporting. It is not hypothetical:
+  // modelling `b = b + 1` on an undefined `b` as a defined value made this harness call one legal
+  // merge a clobber.
+  const evalExpr = (e: Expr): Val => {
+    switch (e.k) {
+      case 'var': {
+        const v = env.get(e.name) ?? UNDEF;
+        reads.push(v);
+        return v;
+      }
+      case 'const':
+        return e.value;
+      case 'bin': {
+        const l = evalExpr(e.l);
+        const r = evalExpr(e.r);
+        return l === UNDEF || r === UNDEF ? UNDEF : (l + r) | 0;
+      }
+      case 'call':
+        e.args.forEach(evalExpr);
+        return 0;
+      default:
+        throw new Error(`the generator does not emit ${e.k}`);
+    }
+  };
+
+  const exec = (list: Stmt[]): void => {
+    for (const s of list) {
+      switch (s.k) {
+        case 'assign':
+          env.set(s.name, evalExpr(s.value));
+          break;
+        case 'exprstmt':
+          evalExpr(s.value);
+          break;
+        case 'if':
+          evalExpr(s.cond);
+          exec(sched() % 2 === 0 ? s.then : s.else);
+          break;
+        case 'while': {
+          // test-at-top: the condition runs once more than the body
+          const n = sched() % 3;
+          evalExpr(s.cond);
+          for (let i = 0; i < n; i++) {
+            exec(s.body);
+            evalExpr(s.cond);
+          }
+          break;
+        }
+        case 'for': {
+          const n = sched() % 3;
+          exec([s.init]);
+          evalExpr(s.cond);
+          for (let i = 0; i < n; i++) {
+            exec(s.body);
+            exec([s.inc]);
+            evalExpr(s.cond);
+          }
+          break;
+        }
+        default:
+          throw new Error(`the generator does not emit ${s.k}`);
+      }
+    }
+  };
+
+  exec(sfn.body);
+  return reads;
+}
+
+/** How `cand` differs from `orig` on one schedule. `undefined-only` is coalesce.ts's documented
+ *  ACCEPTED-NOT-FIXED case; `clobber` is the one the loop gate exists to prevent. */
+function compare(orig: SFn, cand: SFn, draws: number[]): 'same' | 'undefined-only' | 'clobber' {
+  const a = run(orig, schedule(draws));
+  const b = run(cand, schedule(draws));
+  // a length difference is a clobber of its own: the rename dropped or duplicated a read
+  if (a.length !== b.length || a.some((v, i) => v !== UNDEF && v !== b[i])) {
+    return 'clobber';
+  }
+  return a.some((v, i) => v !== b[i]) ? 'undefined-only' : 'same';
+}
+
+// ── the generator ──────────────────────────────────────────────────────────────────────────────
+// Small on purpose. It emits only what the gate reasons about: constant-fed locals (so merges are
+// legal at all), reads, and the three positions where a later-indexed statement can run before an
+// earlier one — a loop body, and a `for`'s init and inc.
+const LOCALS = ['a', 'b', 'c'];
+
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let x = Math.imul(t ^ (t >>> 15), 1 | t);
+    x = (x + Math.imul(x ^ (x >>> 7), 61 | x)) ^ x;
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function generate(seed: number): SFn {
+  const rnd = mulberry32(seed);
+  const pick = <X>(xs: X[]): X => xs[Math.floor(rnd() * xs.length)];
+  // A local is chosen with a DRIFT towards the end of the program, so ranges are often disjoint.
+  // Uniform choice makes almost every pair overlap in preorder, so the pass emits almost nothing and
+  // the sweep runs thousands of programs to test a handful of merges.
+  let emitted = 0;
+  const local = (): string =>
+    rnd() < 0.8 ? LOCALS[Math.min(LOCALS.length - 1, Math.floor(emitted / 5))] : pick(LOCALS);
+  const read = (n: string): Expr => ({ k: 'var', name: n });
+  const obs = (): Stmt => ({ k: 'exprstmt', value: { k: 'call', fn: 'obs', args: [read(local())] } });
+  // mostly constant-fed, since `constFed` would otherwise reject the pair before the loop gate is
+  // ever consulted and the whole fuzz would go vacuous
+  const value = (): Expr =>
+    rnd() < 0.85
+      ? { k: 'const', value: Math.floor(rnd() * 100) }
+      : { k: 'bin', op: '+', l: read(local()), r: { k: 'const', value: 1 } };
+  const assign = (): Stmt => ({ k: 'assign', name: local(), value: value() });
+  const cond = (): Expr => (rnd() < 0.5 ? read(local()) : { k: 'const', value: 1 });
+
+  const block = (depth: number): Stmt[] => {
+    const out: Stmt[] = [];
+    for (let i = 0, n = 2 + Math.floor(rnd() * 4); i < n; i++) {
+      const r = rnd();
+      emitted++;
+      if (r < 0.4) {
+        out.push(assign());
+      } else if (r < 0.75 || depth === 0) {
+        out.push(obs());
+      } else if (r < 0.85) {
+        out.push({ k: 'if', cond: cond(), then: block(depth - 1), else: block(depth - 1) });
+      } else if (r < 0.93) {
+        out.push({ k: 'while', cond: cond(), body: block(depth - 1) });
+      } else {
+        out.push({ k: 'for', init: assign(), cond: cond(), inc: assign(), body: block(depth - 1) });
+      }
+    }
+    return out;
+  };
+
+  return {
+    name: 'f',
+    params: [],
+    locals: LOCALS.map((n) => ({ name: n, type: T.s(32) })),
+    retType: T.void(),
+    body: block(2),
+  };
+}
+
+// ── arm B's ablation, as an input rewrite ──────────────────────────────────────────────────────
+// A loop becomes an `if` carrying the same condition, body and child order, tagged so it can be
+// turned back after the pass has run. `stmtChildren` and `stmtExprs` then agree node for node with
+// the loop's, so `spans` produces an identical map except for `inLoop` — the gate ablated, and
+// nothing else. `for`'s children are `[init, inc, ...body]`, so the `if` lists them in that order.
+const MARK = { while: '__was_while__', for: '__was_for__' } as const;
+const tag = (fn: string, cond: Expr): Expr => ({ k: 'call', fn, args: [cond] });
+
+function loopsAsIfs(body: Stmt[]): Stmt[] {
+  return body.map((s): Stmt => {
+    switch (s.k) {
+      case 'while':
+        return { k: 'if', cond: tag(MARK.while, s.cond), then: loopsAsIfs(s.body), else: [] };
+      case 'for':
+        return { k: 'if', cond: tag(MARK.for, s.cond), then: loopsAsIfs([s.init, s.inc, ...s.body]), else: [] };
+      case 'if':
+        return { ...s, then: loopsAsIfs(s.then), else: loopsAsIfs(s.else) };
+      default:
+        return s;
+    }
+  });
+}
+
+function ifsAsLoops(body: Stmt[]): Stmt[] {
+  return body.map((s): Stmt => {
+    if (s.k !== 'if') {
+      return s;
+    }
+    const then = ifsAsLoops(s.then);
+    if (s.cond.k === 'call' && s.cond.fn === MARK.while) {
+      return { k: 'while', cond: s.cond.args[0], body: then };
+    }
+    if (s.cond.k === 'call' && s.cond.fn === MARK.for) {
+      return { k: 'for', init: then[0], cond: s.cond.args[0], inc: then[1], body: then.slice(2) };
+    }
+    return { ...s, then, else: ifsAsLoops(s.else) };
+  });
+}
+
+const withoutLoopGate = (sfn: SFn): { merged: string; sfn: SFn }[] =>
+  coalesceCandidates({ ...sfn, body: loopsAsIfs(sfn.body) }).map((c) => ({
+    ...c,
+    sfn: { ...c.sfn, body: ifsAsLoops(c.sfn.body) },
+  }));
+
+// ── the two arms ───────────────────────────────────────────────────────────────────────────────
+const PROGRAMS = 2000;
+const SCHEDULES = [
+  [0, 1, 2, 1, 0, 2, 2, 0, 1],
+  [2, 2, 2, 2, 2, 2],
+  [1, 0, 1, 0, 1, 0],
+];
+
+function sweep(candidatesOf: (sfn: SFn) => { merged: string; sfn: SFn }[]) {
+  let candidates = 0;
+  const clobbered: string[] = [];
+  let undefinedOnly = 0;
+  for (let seed = 1; seed <= PROGRAMS; seed++) {
+    const sfn = generate(seed);
+    for (const c of candidatesOf(sfn)) {
+      candidates++;
+      const worst = SCHEDULES.map((draws) => compare(sfn, c.sfn, draws));
+      if (worst.includes('clobber')) {
+        clobbered.push(`seed ${seed}, merge ${c.merged}`);
+      } else if (worst.includes('undefined-only')) {
+        undefinedOnly++;
+      }
+    }
+  }
+  return { candidates, clobbered, undefinedOnly };
+}
+
+describe('the loop gate, differentially', () => {
+  const kept = sweep(coalesceCandidates);
+  const ablated = sweep(withoutLoopGate);
+
+  test('the sweep reaches mergeable programs at all', () => {
+    // Without this, "no clobbers" would also be the result of emitting nothing. 2000 programs
+    // currently offer 176 merges; the floor is well under that so ordinary generator tuning does
+    // not have to move it.
+    expect(kept.candidates).toBeGreaterThan(80);
+  });
+
+  test('no candidate the pass emits changes a DEFINED read', () => {
+    expect(kept.clobbered).toEqual([]);
+  });
+
+  test('suppressing the loop flag DOES clobber — the gate is load-bearing', () => {
+    // The gate's whole justification, and the only thing that stops the test above from passing
+    // for the wrong reason. If this goes green, either the generator stopped reaching loops or the
+    // pass stopped consulting `inLoop`.
+    expect(ablated.clobbered.length).toBeGreaterThan(0);
+  });
+
+  test('the accepted-not-fixed case is real, and is what the carve-out covers', () => {
+    // A survivor written on only SOME paths absorbs the other's value where the original read an
+    // uninitialized local. coalesce.ts documents this as accepted; the count says it is not
+    // hypothetical (8 of 176 today), so the carve-out above is load-bearing rather than an unused
+    // escape hatch that a later reader could delete as dead.
+    expect(kept.undefinedOnly).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/test/coalesce.test.ts
+++ b/packages/core/test/coalesce.test.ts
@@ -52,7 +52,8 @@ describe('gates', () => {
 
   test('a mention inside a LOOP blocks it — the sound-critical gate', () => {
     // Without this, preorder order stops implying disjoint liveness: a back edge can run a later
-    // statement before an earlier one. A fuzz with the gate removed finds clobbers immediately.
+    // statement before an earlier one. One shape, pinned; `coalesce-fuzz.test.ts` is what quantifies
+    // over shapes, and it also checks that suppressing the gate really does clobber.
     const body: Stmt[] = [
       asg('a', 1),
       { k: 'while', cond: { k: 'const', value: 1 }, body: [use('a'), asg('b', 2), use('b')] },


### PR DESCRIPTION
`coalesce.ts` justifies its loop-body exclusion as SOUND-critical — it is what makes preorder
statement order a sufficient approximation of liveness — and then says:

> Differential fuzzing supports this: removing the gate produces clobbers immediately, leaving it on
> produces none. **No such harness is committed, so nothing here re-checks it.**

Two other gates in the same block leaned on the same absent harness. This commits it.

## The harness

`packages/core/test/coalesce-fuzz.test.ts` generates constant-fed programs over the shapes the gate
reasons about — a loop body, and a `for`'s init/inc, the positions where a later-indexed statement
can run before an earlier one — then interprets the original and every candidate the pass emits,
comparing what each variable read observed.

Control flow comes from a pre-drawn schedule rather than from the values, so both trees take the
same path by construction (traces align index for index, every difference is a value difference) and
the comparison quantifies over schedules the values might never produce, zero-trip loops included.

Two arms, because the first alone would be green if the pass emitted nothing:

| | candidates | changes a defined read |
|---|---|---|
| gates as shipped | 176 | 0 |
| loop flag suppressed | 376 | 55 |

Arm B suppresses the flag by **input**, not by a test-only switch in the pass: a loop rewritten as
an `if` over the same children has the same preorder indices and mentions the same names, so `spans`
produces an identical map except for `inLoop`. The real predicate and the real rename run in both
arms.

**Acceptance criterion**: deleting `x.inLoop || y.inLoop` from the source fails arm A with 55
clobbering programs. A guard that survives the thing it guards against is not a guard.

## What the ablations changed in the comment

- **constant-fed** — confirmed as claimed: deleting it stays clobber-free and offers about a third
  more merges. A codegen heuristic, not soundness.
- **first-mention-is-a-write** — the comment called this defence-in-depth that nothing isolated.
  Deleting it together with `constFed` (which masks it) isolates it, and it produces no clobber at
  all: a survivor whose first mention is a *read* was uninitialized there in the original too. What
  it governs is the size of the file's own ACCEPTED-NOT-FIXED class, 16 → 187 candidates. A
  discipline, not a soundness gate.
- **accepted-not-fixed** — now counted (8 of 176) and asserted to stay reachable, so the carve-out
  that excuses it cannot quietly become dead code.

One harness bug found and fixed on the way: modelling `b = b + 1` over an undefined `b` as a defined
value let an indeterminate read re-enter the defined world, and made the harness call one legal merge
a clobber. UNDEF poisons.

## Size

211 lines of harness, 32 of comment. The first cut carried 58 — a header that restated `coalesce.ts`'s
claim back at it, the war story above, and digits that nothing asserts. Those belong here and in the
round notes, not in the source. Branch-wide comment delta: +34.

## Gates

`test:offline` 854 (was 850) · typecheck clean · lint 0 errors (41 warnings, same as main) ·
`format:check` clean. The `packages/core/src` diff is comment-only — verified by filtering comment
lines out of `git diff` and getting nothing back — so no benchmark row can move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)