### PR TITLE
Address-placement guards, and gates as data

### DIFF
--- a/packages/core/src/l3/argbase.ts
+++ b/packages/core/src/l3/argbase.ts
@@ -42,7 +42,12 @@ import type { Expr, SFn, Stmt } from './ast';
 import { mapExprChildren, stmtExprs } from './ast';
 import { nameAllocator } from './hoist';
 
-/** A base this pass may evaluate early: pure, and not something a store can change under us. */
+/** A base this pass may evaluate early: pure, and not something a store can change under us.
+ *
+ *  NO shadowing filter, unlike scopebase.ts's `isLeaf`, and the asymmetry is deliberate: that pass
+ *  re-spells the base as `&g`, which under a shadowing local names a different object, while this
+ *  one keeps the base expression verbatim and places the assignment immediately before the same
+ *  statement. Adding the filter here only loses hoists (test/addr-placement.test.ts). */
 function eligibleBase(base: Expr, globals: ReadonlySet<string>): boolean {
   return base.k === 'addr' || base.k === 'const' || (base.k === 'var' && globals.has(base.name));
 }

--- a/packages/core/src/l3/basecse.ts
+++ b/packages/core/src/l3/basecse.ts
@@ -21,6 +21,7 @@
 import { type IrType, T, scalarTypeForAccess } from '../ir/types';
 import type { Expr, SFn, Stmt } from './ast';
 import { mapExprChildren, stmtChildren, stmtExprs } from './ast';
+import { type Gate, firstRejection } from './gates';
 import { nameAllocator } from './hoist';
 
 // A HOISTABLE base is a bare `addr` (a global address) or a bare `const` (a numeric pointer
@@ -43,12 +44,11 @@ interface Collected {
   meta: Map<string, { base: HoistableBase; width: number; signed: boolean }>;
   /** keys with ANY use inside a loop — disqualified (see the loop note in `hoistReusedGlobalBases`). */
   inLoop: Set<string>;
-  /** per key, how many times each CONSTANT offset was accessed. A constant offset touched 2+ times
-   *  is a SCALAR access at one fixed location (a `*(T*)C |= x` MMIO read-modify-write, or repeated
-   *  `*p`), which the compiler re-materializes rather than register-holds — hoisting it MISMATCHES
-   *  (it broke the ProcessHBlankWait match). A key with ANY repeated constant offset is therefore
-   *  disqualified, even if it ALSO has distinct-offset uses (a mixed scalar+array base). A genuine
-   *  reused array base touches each constant offset once, or uses a variable index (not tallied). */
+  /** per key, how many times each CONSTANT offset was accessed — the input to the
+   *  `repeated-const-offset` gate, which losing the ProcessHBlankWait match is what bought. A
+   *  genuine reused array base touches each constant offset once, or indexes by a variable (not
+   *  tallied); a repeat means a scalar re-access, and ONE is enough to disqualify the base even
+   *  when it also has distinct-offset uses. */
   constOffCount: Map<string, Map<number, number>>;
 }
 
@@ -139,27 +139,57 @@ function rewriteStmt(s: Stmt, localFor: Map<string, string>): Stmt {
   }
 }
 
+/** One base under consideration, keyed as `(base, width, signedness)`. */
+export interface BaseKey {
+  key: string;
+  uses: number;
+  inLoop: boolean;
+  /** some CONSTANT offset through this base is touched 2+ times */
+  repeatedConstOffset: boolean;
+}
+
+/** The admission rules. NONE is sound, and that is a property of the pass rather than an oversight:
+ *  a wrong hoist emits the same address held in a different place, so it costs bytes and a match,
+ *  never meaning. The zero-lost benchmark gate is what referees them.
+ *
+ *  The `loop` rule is the subtle one. A loop-body base is loop-invariant, so the compiler keeps it
+ *  in a register across the loop too — but hoisting to the FUNCTION TOP forces a callee-saved
+ *  register, which can add the prologue push/pop the original avoided. `l3/scopebase.ts` is the
+ *  scope-aware hoist that serves those instead. */
+export const BASECSE_GATES: readonly Gate<BaseKey>[] = [
+  {
+    id: 'single-use',
+    why: 'one access re-materializes as cheaply as a named local',
+    sound: false,
+    rejects: (c) => c.uses < 2,
+  },
+  {
+    id: 'loop',
+    why: 'a function-top hoist of a loop base forces a callee-saved register the original avoided',
+    sound: false,
+    rejects: (c) => c.inLoop,
+  },
+  {
+    id: 'repeated-const-offset',
+    why: 'a fixed offset touched twice is a scalar RMW, which the compiler re-materializes',
+    sound: false,
+    rejects: (c) => c.repeatedConstOffset,
+  },
+];
+
 export function hoistReusedGlobalBases(sfn: SFn): SFn {
   const c: Collected = { count: new Map(), order: [], meta: new Map(), inLoop: new Set(), constOffCount: new Map() };
   collect(sfn.body, c, false);
-  // A repeated CONSTANT offset means a scalar re-access at a fixed location (MMIO RMW / repeated
-  // `*p`) the compiler re-materializes — disqualify the whole base, even mixed with array uses.
-  const hasRepeatedConstOffset = (k: string): boolean => {
-    for (const n of c.constOffCount.get(k)?.values() ?? []) {
-      if (n >= 2) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  // Reuse 2+ and NOT used inside a loop. A loop-body base is loop-invariant, so the compiler ALSO
-  // keeps it in a register across the loop — but hoisting it to the function top forces a
-  // callee-saved register that can add prologue push/pop the original avoided, worsening the match
-  // (register-pressure matching, not a correctness issue). Straight-line / branch reuse is the safe
-  // win; a loop-body base is left inline for a future scope-aware hoist.
   const { count, order, meta } = c;
-  const hoisted = order.filter((k) => (count.get(k) ?? 0) >= 2 && !c.inLoop.has(k) && !hasRepeatedConstOffset(k));
+  const hoisted = order.filter(
+    (k) =>
+      firstRejection(BASECSE_GATES, {
+        key: k,
+        uses: count.get(k) ?? 0,
+        inLoop: c.inLoop.has(k),
+        repeatedConstOffset: [...(c.constOffCount.get(k)?.values() ?? [])].some((n) => n >= 2),
+      }) === null,
+  );
   if (hoisted.length === 0) {
     return sfn;
   }

--- a/packages/core/src/l3/basecse.ts
+++ b/packages/core/src/l3/basecse.ts
@@ -26,7 +26,10 @@ import { nameAllocator } from './hoist';
 // A HOISTABLE base is a bare `addr` (a global address) or a bare `const` (a numeric pointer
 // address). Both are relocation-invariant leaves whose value the compiler keeps in one register
 // when it indexes them at 2+ sites. Anything else (a local var, a struct-element `p[a0]`, arbitrary
-// arithmetic) is NOT — agbcc may re-derive it.
+// arithmetic) is NOT — agbcc may re-derive it. Admitting the bare `var` that scopebase.ts and
+// argbase.ts take is the obvious consolidation and it is wrong twice over: this pass has no `lead`
+// handling, so a rank-aware `g[0][i]` comes out as `p[0][i]` through a scalar pointer, and it
+// undoes raise/gvn.ts's hoist on exactly the rows a symbol map serves (test/addr-placement.test.ts).
 type HoistableBase = Extract<Expr, { k: 'addr' } | { k: 'const' }>;
 const isHoistableBase = (e: Expr): e is HoistableBase => e.k === 'addr' || e.k === 'const';
 const baseId = (b: HoistableBase): string => (b.k === 'addr' ? `a:${b.name}` : `c:${b.value}`);

--- a/packages/core/src/l3/coalesce.ts
+++ b/packages/core/src/l3/coalesce.ts
@@ -1,6 +1,7 @@
 import { typeToString } from '../ir/types';
 import type { Expr, SFn, Stmt } from './ast';
 import { exprChildren, mapExprChildren, stmtChildren, stmtExprs } from './ast';
+import { type Gate, firstRejection } from './gates';
 
 function namesIn(e: Expr, out: Set<string>): void {
   // `addr` names a GLOBAL, never a local — collected anyway. A name reaching BOTH forms would
@@ -17,7 +18,7 @@ function mentions(e: Expr, n: string): boolean {
   namesIn(e, seen);
   return seen.has(n);
 }
-interface Span {
+export interface Span {
   first: number;
   last: number;
   inLoop: boolean;
@@ -78,6 +79,71 @@ function rename(body: Stmt[], from: string, to: string): Stmt[] {
   };
   return body.map(inStmt);
 }
+/** One candidate merge under consideration: absorb `a` into `b`. */
+export interface MergePair {
+  a: string;
+  b: string;
+  /** `a`'s span */
+  x: Span;
+  /** `b`'s span — the SURVIVOR's, which is why the asymmetric gates read `y` */
+  y: Span;
+  sameType: boolean;
+  eitherIsParam: boolean;
+}
+
+/** The admission rules, in evaluation order. Two arguments the `why` fields have no room for:
+ *
+ *  WHAT `loop` BUYS is the right to read preorder statement order as liveness. Preorder is a
+ *  topological order of the CFG except where a later-indexed statement can run before an earlier
+ *  one, and every position that does that — a `for`'s `init`/`inc`, any loop body — is inside a
+ *  loop. A loop's own CONDITION is not covered: it is visited at the loop statement's own index with
+ *  the ENCLOSING flag, which is safe only because a condition cannot WRITE.
+ *
+ *  ABLATE `first-is-write` ALONE AND NOTHING HAPPENS — `const-fed` masks it, so a survivor first
+ *  mentioned by a read was uninitialized there in the original too. Drop both to see what it does,
+ *  which is to bound the accepted class below by an order of magnitude. `const-fed` likewise bounds
+ *  candidate growth: merges go as `L(L-1)/2` in the local count, each a distinct compile. */
+export const COALESCE_GATES: readonly Gate<MergePair>[] = [
+  {
+    id: 'param',
+    why: 'a param is the function’s own signature, not a recovered local',
+    sound: false,
+    rejects: (c) => c.eitherIsParam,
+  },
+  {
+    id: 'type',
+    why: 'the survivor keeps its own declared type, so the two must agree',
+    sound: false,
+    rejects: (c) => !c.sameType,
+  },
+  {
+    id: 'loop',
+    why: 'a back edge can run a later statement first, so preorder stops implying disjoint liveness',
+    sound: true,
+    guardedBy: 'coalesce-fuzz.test.ts: dropping it clobbers a defined read',
+    rejects: (c) => c.x.inLoop || c.y.inLoop,
+  },
+  {
+    id: 'const-fed',
+    why: 'a load-fed local is one the compiler had a reason to keep where it was',
+    sound: false,
+    rejects: (c) => !c.x.constFed || !c.y.constFed,
+  },
+  {
+    id: 'overlap',
+    why: 'the ranges must not overlap — the survivor would absorb a value still live',
+    sound: true,
+    guardedBy: 'coalesce.test.ts: OVERLAPPING ranges never merge',
+    rejects: (c) => c.x.last >= c.y.first,
+  },
+  {
+    id: 'first-is-write',
+    why: 'a survivor first MENTIONED by a read would see the absorbed value there',
+    sound: false,
+    rejects: (c) => !c.y.firstIsWrite,
+  },
+];
+
 /** Every legal single merge, each as its own tree — NOT one committed choice.
  *
  *  Which pair a register allocator coalesced is not derivable from the L3 tree, and first-fit gets
@@ -88,62 +154,62 @@ function rename(body: Stmt[], from: string, to: string): Stmt[] {
  *  `/regcopy`'s "the tail choice is allocator-ambiguous, so both are ranked" — so every candidate is
  *  emitted and the differ referees.
  *
- *  GATES:
- *   - a local mentioned inside a loop BODY is excluded. SOUND-critical: it is what makes preorder
- *     statement order a sufficient approximation of liveness. Preorder is a topological order of the
- *     CFG except where a later-indexed statement can run before an earlier one, and the positions
- *     that do that — a `for`'s `init`/`inc`, and everything in any loop body — are inside a loop, so
- *     the gate covers them. A loop's own CONDITION is NOT covered: it is visited at the loop
- *     statement's own index with the ENCLOSING loop flag. That is safe only because a condition
- *     cannot WRITE, so it can extend a read range but never reorder a definition — an earlier
- *     version of this comment claimed the gate covered conditions too, which it does not.
- *     `test/coalesce-fuzz.test.ts` is the differential check; delete this gate and it fails.
- *   - both must be CONSTANT-fed. A codegen heuristic, not soundness: deleting it stays clobber-free
- *     under that fuzz and simply scored worse, because a load-fed local is one the compiler had a
- *     reason to keep where it was. It is also what currently BOUNDS candidate growth: merges are
- *     `L(L-1)/2` in the local count, each a distinct source and so a distinct compile, and nothing
- *     else caps that. Corpus-wide today: 2 rows, 13 kept sources.
- *   - the survivor's first mention must be an ASSIGN THAT DOES NOT ALSO READ IT. `b = g(b)` is a
- *     write and a read in one statement; counting it as a pure write let `g` receive the absorbed
- *     value. NOT a soundness gate, though it reads like one, and `constFed` masks it so only
- *     deleting both shows why: a survivor whose first mention is a READ was uninitialized there in
- *     the ORIGINAL too, so no clobber appears — what this gate bounds is the size of the accepted
- *     class below, which it holds down by an order of magnitude.
- *
  *  ACCEPTED, NOT FIXED: a survivor assigned only on SOME paths still absorbs the other's value on
  *  the paths that skip it. The original read an uninitialized local there, so both spellings are
- *  ill-defined rather than one being wrong — but this is a real difference and the differ, not this
+ *  ill-defined rather than one being wrong — but this is a real difference and the differ, not any
  *  gate, is what keeps it from faking a match. The fuzz asserts it stays reachable, so the carve-out
  *  that excuses it cannot quietly become dead. */
 export function coalesceCandidates(sfn: SFn): { merged: string; sfn: SFn }[] {
+  return coalesceUnder(COALESCE_GATES, sfn).candidates;
+}
+
+/** `coalesceCandidates` with the gate table supplied, plus which gate refused each pair.
+ *
+ *  The parameter exists so a test can run the pass with one gate DROPPED — the ablation as a value,
+ *  rather than as a flag compiled into the shipped path or an input rewritten to dodge a predicate.
+ *  `refusals` is what makes a gate's reachability checkable: a rule nothing ever reaches is a rule
+ *  no test can be failing on purpose. */
+export function coalesceUnder(
+  gates: readonly Gate<MergePair>[],
+  sfn: SFn,
+): { candidates: { merged: string; sfn: SFn }[]; refusals: Map<string, number> } {
+  const refusals = new Map<string, number>();
   if (sfn.locals.length < 2) {
-    return [];
+    return { candidates: [], refusals };
   }
   const params = new Set(sfn.params.map((p) => p.name));
   const typeOf = new Map(sfn.locals.map((l) => [l.name, typeToString(l.type)]));
   const sp = spans(sfn.body);
-  const out: { merged: string; sfn: SFn }[] = [];
+  const candidates: { merged: string; sfn: SFn }[] = [];
   for (const a of sfn.locals.map((l) => l.name)) {
     for (const b of sfn.locals.map((l) => l.name)) {
       const x = sp.get(a);
       const y = sp.get(b);
-      if (a === b || !x || !y || params.has(a) || params.has(b)) {
+      // Not a gate: this is what makes the pair a pair at all. A name with no span is one the body
+      // never mentions, so there is no range to reason about.
+      if (a === b || !x || !y) {
         continue;
       }
-      if (typeOf.get(a) !== typeOf.get(b) || x.inLoop || y.inLoop || !x.constFed || !y.constFed) {
-        continue;
-      }
-      if (x.last >= y.first || !y.firstIsWrite) {
+      const refused = firstRejection(gates, {
+        a,
+        b,
+        x,
+        y,
+        sameType: typeOf.get(a) === typeOf.get(b),
+        eitherIsParam: params.has(a) || params.has(b),
+      });
+      if (refused !== null) {
+        refusals.set(refused, (refusals.get(refused) ?? 0) + 1);
         continue;
       }
       // Labelled by the PAIR, not by an index into enumeration order: an index silently re-points
       // at a different merge if `sfn.locals` ordering ever changes, leaving a recorded provenance
       // that is wrong but plausible.
-      out.push({
+      candidates.push({
         merged: `${a}-${b}`,
         sfn: { ...sfn, body: rename(sfn.body, a, b), locals: sfn.locals.filter((l) => l.name !== a) },
       });
     }
   }
-  return out;
+  return { candidates, refusals };
 }

--- a/packages/core/src/l3/gates.ts
+++ b/packages/core/src/l3/gates.ts
@@ -1,0 +1,67 @@
+// A pass's admission rules as DATA, so "does every sound gate have a test that fails without it?"
+// is a query instead of an audit.
+//
+// Because the table is a value, a test can drop one entry and re-run the pass: the real predicate,
+// on real input, with no test-only branch in the shipped path. That makes `sound` cost something to
+// declare — see `gateTableDefects` and the contract test that pairs with it.
+//
+// `why` is a LABEL, one line. The argument for why the rule is correct belongs in the file header,
+// which has room; duplicating it here is how a table stops paying for itself.
+export interface Gate<Ctx> {
+  /** stable, kebab-case; appears in test names and in the contract report */
+  readonly id: string;
+  /** one line: the reason the rule exists */
+  readonly why: string;
+  /** Remove it and some candidate is WRONG, not merely worse. Everything else is a codegen
+   *  heuristic the differ still referees. This flag is what makes `guardedBy` mandatory. */
+  readonly sound: boolean;
+  /** the test that fails when this gate is removed — required for a sound gate */
+  readonly guardedBy?: string;
+  /** true ⇒ REJECT this candidate */
+  readonly rejects: (c: Ctx) => boolean;
+}
+
+/** The id of the first gate that rejects `c`, or null when every gate admits it. FIRST, not all:
+ *  one decisive rule is what makes a refusal attributable, and it keeps the cost the same as the
+ *  `||` chain this replaces — evaluation still short-circuits. */
+export function firstRejection<Ctx>(gates: readonly Gate<Ctx>[], c: Ctx): string | null {
+  for (const g of gates) {
+    if (g.rejects(c)) {
+      return g.id;
+    }
+  }
+  return null;
+}
+
+/** A gate table with one entry removed — the ablation, as a value. Throws on an unknown id: a
+ *  typo'd ablation that silently tests nothing is the failure this file exists to prevent. */
+export function without<Ctx>(gates: readonly Gate<Ctx>[], id: string): readonly Gate<Ctx>[] {
+  if (!gates.some((g) => g.id === id)) {
+    throw new Error(`no gate '${id}' to ablate (have: ${gates.map((g) => g.id).join(', ')})`);
+  }
+  return gates.filter((g) => g.id !== id);
+}
+
+/** Structural defects in a gate table — the part checkable without running the pass. Returns
+ *  findings rather than throwing, so core stays free of a test-framework import. */
+export function gateTableDefects<Ctx>(gates: readonly Gate<Ctx>[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const g of gates) {
+    if (seen.has(g.id)) {
+      out.push(`duplicate gate id '${g.id}'`);
+    }
+    seen.add(g.id);
+    if (!/^[a-z][a-z0-9-]*$/.test(g.id)) {
+      out.push(`gate id '${g.id}' is not kebab-case`);
+    }
+    if (g.why.trim().length < 12) {
+      out.push(`gate '${g.id}' has no usable \`why\``);
+    }
+    // the one rule that costs something to declare
+    if (g.sound && !g.guardedBy?.trim()) {
+      out.push(`gate '${g.id}' is marked sound but names no guard`);
+    }
+  }
+  return out;
+}

--- a/packages/core/src/l3/scopebase.ts
+++ b/packages/core/src/l3/scopebase.ts
@@ -146,7 +146,8 @@ function collect(
     // CONDITION the same way. They do NOT agree about a `for`'s `init`: basecse counts it in-loop
     // (its `stmtChildren('for')` is `[init, inc, …body]`, recursed with `nested`), this pass counts
     // it at the enclosing cadence, which is the truthful reading — it runs once. Recorded because
-    // the divergence is real and an extraction has to pick one.
+    // the divergence is real and an extraction has to pick one; both readings are pinned in
+    // test/addr-placement.test.ts so the pick is deliberate rather than whichever survives.
     stmtExprs(s).forEach((e) => visit(e, isLoop));
     if (s.k === 'for') {
       // `init`/`inc` are typed as the full Stmt union, so a COMPOUND one is type-legal. `stmtExprs`

--- a/packages/core/src/raise/gvn.ts
+++ b/packages/core/src/raise/gvn.ts
@@ -39,6 +39,9 @@
 // analysis.ts, whose materialize-into-a-local rule covers `const`, `call` and the memory reads, NOT
 // address ops), so the address is re-spelled at each access exactly as the original source did.
 // Hoisting therefore does not create the long live range that hoisting a LOADED value would.
+// That is a promise ANOTHER module keeps, so `test/addr-placement.test.ts` holds it to it: let
+// analysis.ts materialize an address op and the entry hoist becomes a function-top local — the one
+// this pass exists to delete, reintroduced one level up.
 //
 // SCOPE, deliberately narrow: `code: true` symbols (a promoted function pointer, spelled `(u32)Name`
 // rather than `&Name`) are numbered separately from data ones, because the attr is part of what the
@@ -47,11 +50,18 @@
 // THE WIN IS CONTINGENT ON THE SYMBOL MAP, which is worth knowing before relying on it. With a map
 // supplying an array's rank the accesses render as `gSym[0][i]`, a `var` base that
 // `l3/basecse.ts`'s `isHoistableBase` cannot see, so nothing re-creates the local this pass
-// deleted. WITHOUT a map (verified by running the row map-less) the same accesses spell as
-// `addr`, basecse sees the reuse, and it hoists a function-top `p0 = (u16 *)&gBgTilemapBufs` —
-// the same local, one level up. Three modules now answer "is this
-// address a local?" with independent policies (here: never; basecse: when reused 2+ times;
-// l3/scopebase.ts: at the innermost scope), and reconciling them is recorded debt.
+// deleted. WITHOUT one the same accesses spell as `addr`, basecse sees the reuse, and it hoists a
+// function-top `p0 = (u16 *)&gBgTilemapBufs` — the same local, one level up. Both arms are pinned
+// in `test/addr-placement.test.ts`; before that they rested on a run nobody could repeat.
+//
+// FOUR modules now answer "is this address a local?" with independent policies — here: never;
+// basecse: at the function top, when reused 2+ times; l3/scopebase.ts: at the innermost scope
+// holding the uses; l3/argbase.ts: immediately before a call whose arguments share it. Reconciling
+// them is recorded debt, and the same test pins the two places they actively disagree, because a
+// consolidation has to PICK rather than discover them: a `for`'s init (basecse reads it at loop
+// cadence and refuses, scopebase at the enclosing one and hoists) and a global name shadowed by a
+// local (scopebase must refuse — it re-spells the base as `&g` — while argbase may fire, because it
+// keeps the base expression verbatim).
 import { Block, Fn, Op, Value, mkOp, replaceAllUsesWith } from '../ir/core';
 
 /** Ops whose result depends on `attrs` alone — no operands, no memory, no control flow. */

--- a/packages/core/test/addr-placement.test.ts
+++ b/packages/core/test/addr-placement.test.ts
@@ -1,0 +1,182 @@
+// The cross-module contract between the four passes that answer "is this address a local?" —
+// raise/gvn.ts (never), l3/basecse.ts (function top), l3/scopebase.ts (innermost scope),
+// l3/argbase.ts (before the call). Each is unit-tested on its own; what has no home is what they
+// promise EACH OTHER, which is where a consolidation would break something silently.
+import { describe, expect, test } from 'vitest';
+
+import { cBackend } from '../src/backend/c';
+import { parse } from '../src/ir/parse';
+import { simplifyTrivialPhis } from '../src/ir/simplify';
+import { T } from '../src/ir/types';
+import { materializeArgBases } from '../src/l3/argbase';
+import type { Expr, SFn, Stmt } from '../src/l3/ast';
+import { hoistReusedGlobalBases } from '../src/l3/basecse';
+import { hoistScopedBases } from '../src/l3/scopebase';
+import { structureChecked } from '../src/pipeline';
+import { numberPureValues } from '../src/raise/gvn';
+import type { SymbolInfo } from '../src/symbols';
+
+// Two arms both naming `gTable`, merged, then read at two statements with a call between them —
+// the shape gvn.ts's header is written about, and the one that satisfies analysis.ts's
+// multi-use-live-across-a-call test if that test ever admitted an address op.
+const TWO_ARMS_ACROSS_A_CALL = `fn f {
+^bb0(%0: s32):
+  %1: s32 = const {value=0}
+  %2: u32 = icmp_ne %0, %1
+  cond_br %2, ^bb1(), ^bb2()
+^bb1():
+  %3: u16* = gaddr {sym="gTable"}
+  br ^bb3(%3)
+^bb2():
+  %4: u16* = gaddr {sym="gTable"}
+  br ^bb3(%4)
+^bb3(%5: u16*):
+  %6: s32 = load %5 {off=0, signed=false, width=2}
+  %7: s32 = call %6 {target="sink"}
+  %8: s32 = load %5 {off=8, signed=false, width=2}
+  ret %8
+}
+`;
+
+const numbered = (symbols?: Map<string, SymbolInfo>): SFn => {
+  const fn = parse(TWO_ARMS_ACROSS_A_CALL);
+  expect(numberPureValues(fn)).toBe(2);
+  simplifyTrivialPhis(fn);
+  return structureChecked(fn, symbols ? { symbols } : {});
+};
+
+/** gTable as the project's own headers declare it: `u16 gTable[4][0x400]`. */
+const RANK_2 = new Map<string, SymbolInfo>([
+  ['gTable', { name: 'gTable', kind: 'data', shape: 'array', elemSize: 2, dims: [4, 1024], declared: true }],
+]);
+
+describe('gvn hoists to the ENTRY block, which is only free if nothing gives it a home', () => {
+  test('a numbered address reused across a call is re-spelled at each use, not named', () => {
+    // gvn puts one `gaddr` in the entry block — the MAXIMAL live range, the opposite of what the
+    // other three passes do — and its whole safety argument is that the structurer inlines a pure
+    // non-`const` value at each use. Widen analysis.ts's materialize rule to address ops and this
+    // reverts to `v0 = (u16 *)&gTable;` at the function top: the very local gvn exists to delete,
+    // reintroduced one level up. Nothing else in the suite notices that edit.
+    const out = numbered(RANK_2);
+    expect(out.locals).toEqual([]);
+    expect(cBackend.emit(out)).toContain('gTable[0][0]');
+  });
+});
+
+describe('the win is contingent on the symbol map — gvn.ts says so, this is the measurement', () => {
+  test('WITH a rank-aware map the accesses spell bare, and no pass re-creates the local', () => {
+    expect(cBackend.emit(numbered(RANK_2))).not.toMatch(/u16 \* \w+;/);
+  });
+
+  test('WITHOUT one they spell `(u16 *)&gTable` and basecse hoists the local straight back', () => {
+    // Not a defect to fix: it is the same address in the same place, one pass later, and it is why
+    // gvn.ts calls its own win contingent. Pinned so the contingency cannot quietly stop being true.
+    const src = cBackend.emit(numbered());
+    expect(src).toMatch(/u16 \* (\w+);\n\s+\1 = \(u16 \*\)&gTable;/);
+  });
+});
+
+const ix = (i: Expr, base: Expr = { k: 'addr', name: 'g' }): Expr => ({
+  k: 'index',
+  base,
+  idx: i,
+  width: 1,
+  signed: false,
+});
+
+describe('basecse and scopebase disagree about a `for` init, and the disagreement is observable', () => {
+  // scopebase.ts records this in a comment; a consolidation has to pick one reading, so it is pinned
+  // rather than described. A `for`'s init runs ONCE: scopebase counts it at the enclosing cadence
+  // (the truthful reading), basecse counts it in-loop via `stmtChildren('for')` and refuses.
+  const forStmt: Stmt = {
+    k: 'for',
+    init: {
+      k: 'assign',
+      name: 'i',
+      value: { k: 'bin', op: '+', l: ix({ k: 'const', value: 1 }), r: ix({ k: 'var', name: 'a0' }) },
+    },
+    cond: { k: 'const', value: 1 },
+    inc: { k: 'assign', name: 'i', value: { k: 'const', value: 0 } },
+    body: [{ k: 'exprstmt', value: { k: 'call', fn: 'sink', args: [] } }],
+  };
+  const fn: SFn = {
+    name: 'f',
+    params: [{ name: 'a0', type: T.s(32) }],
+    locals: [{ name: 'i', type: T.s(32) }],
+    globals: [{ name: 'g', type: T.ptr(T.u(8)) }],
+    retType: T.void(),
+    body: [{ k: 'if', cond: { k: 'const', value: 1 }, then: [forStmt], else: [] }],
+  };
+
+  test('basecse refuses it — its `for` children are recursed with the loop flag set', () => {
+    expect(cBackend.emit(hoistReusedGlobalBases(fn))).toContain('((u8 *)&g)[1]');
+  });
+
+  test('scopebase hoists it, immediately before the loop', () => {
+    const out = hoistScopedBases(fn);
+    expect(out).not.toBeNull();
+    expect(cBackend.emit(out!)).toMatch(/(\w+) = \(u8 \*\)&g;\n\s+for \(i = \1\[1\]/);
+  });
+});
+
+describe('a global name shadowed by a local: scopebase refuses, argbase does not — and must not', () => {
+  // The asymmetry is load-bearing, not drift. scopebase re-spells the base as `&g`, which under a
+  // shadowing local binds the LOCAL's address — a different object — so it filters shadowed names
+  // out. argbase keeps the base expression verbatim (`(u8 *)g`) and places the assignment
+  // immediately before the same statement, so it denotes what the original access denoted.
+  // Giving argbase scopebase's filter, or scopebase argbase's laxity, breaks one of them.
+  const shadowed: SFn = {
+    name: 'f',
+    params: [],
+    locals: [{ name: 'g', type: T.ptr(T.u(8)) }],
+    globals: [
+      { name: 'g', type: T.ptr(T.u(8)) },
+      { name: 'h', type: T.ptr(T.u(8)) },
+    ],
+    retType: T.void(),
+    body: [
+      {
+        k: 'exprstmt',
+        value: {
+          k: 'call',
+          fn: 'sink',
+          args: [
+            ix({ k: 'const', value: 1 }, { k: 'var', name: 'g' }),
+            ix({ k: 'const', value: 2 }, { k: 'var', name: 'h' }),
+          ],
+        },
+      },
+    ],
+  };
+
+  test('argbase names it, by VALUE — `(u8 *)g`, never `&g`', () => {
+    const out = materializeArgBases(shadowed);
+    expect(out).not.toBeNull();
+    const src = cBackend.emit(out!);
+    expect(src).toContain('= (u8 *)g;');
+    expect(src).not.toContain('&g');
+  });
+
+  // Inside an `if` arm, so a scope exists to hoist INTO: at the function's top level scopebase
+  // declines whatever the name is, and the filter would not be what decided.
+  const inAnArm = (name: string): SFn => ({
+    ...shadowed,
+    body: [
+      {
+        k: 'if',
+        cond: { k: 'const', value: 1 },
+        then: [
+          { k: 'exprstmt', value: { k: 'call', fn: 'sink', args: [ix({ k: 'const', value: 1 }, { k: 'var', name })] } },
+          { k: 'exprstmt', value: { k: 'call', fn: 'sink', args: [ix({ k: 'const', value: 2 }, { k: 'var', name })] } },
+        ],
+        else: [],
+      },
+    ],
+  });
+
+  test('scopebase declines the shadowed name rather than take its address', () => {
+    expect(hoistScopedBases(inAnArm('g'))).toBeNull();
+    // the same shape on the UNSHADOWED `h` does fire — so it is the filter that decided
+    expect(cBackend.emit(hoistScopedBases(inAnArm('h'))!)).toContain('= (u8 *)&h;');
+  });
+});

--- a/packages/core/test/coalesce-fuzz.test.ts
+++ b/packages/core/test/coalesce-fuzz.test.ts
@@ -1,12 +1,15 @@
-// The differential fuzz for coalesce.ts's loop gate — see that file for what the gate claims.
+// The differential fuzz behind COALESCE_GATES — see coalesce.ts for what the gates claim.
 //
-// Arm A: no candidate the pass emits changes a defined read. Arm B: the same programs with the loop
-// flag suppressed DO — without which arm A is also what "emitted nothing" looks like.
+// Arm A: no candidate the pass emits changes a defined read. Arm B drops each gate the table calls
+// SOUND and requires that it DOES — without which arm A is also what "emitted nothing" looks like.
+// Arm B is written over the table, not over a named gate, so a rule added later is held to the same
+// bar without anyone remembering to.
 import { describe, expect, test } from 'vitest';
 
 import { T } from '../src/ir/types';
 import type { Expr, SFn, Stmt } from '../src/l3/ast';
-import { coalesceCandidates } from '../src/l3/coalesce';
+import { COALESCE_GATES, type MergePair, coalesceCandidates, coalesceUnder } from '../src/l3/coalesce';
+import { type Gate, gateTableDefects, without } from '../src/l3/gates';
 
 // Control flow comes from a pre-drawn list, not from the values, so both trees take the same path by
 // construction: traces align index for index and every difference is a value difference. Conditions
@@ -170,50 +173,6 @@ function generate(seed: number): SFn {
   };
 }
 
-// Arm B's ablation, as an input rewrite: a loop becomes an `if` over the same children, tagged so it
-// can be turned back after the pass has run. `stmtChildren`/`stmtExprs` then agree node for node with
-// the loop's, so `spans` produces an identical map except for `inLoop` — that gate ablated and
-// nothing else. `for`'s children are `[init, inc, ...body]`, so the `if` lists them in that order.
-const MARK = { while: '__was_while__', for: '__was_for__' } as const;
-const tag = (fn: string, cond: Expr): Expr => ({ k: 'call', fn, args: [cond] });
-
-function loopsAsIfs(body: Stmt[]): Stmt[] {
-  return body.map((s): Stmt => {
-    switch (s.k) {
-      case 'while':
-        return { k: 'if', cond: tag(MARK.while, s.cond), then: loopsAsIfs(s.body), else: [] };
-      case 'for':
-        return { k: 'if', cond: tag(MARK.for, s.cond), then: loopsAsIfs([s.init, s.inc, ...s.body]), else: [] };
-      case 'if':
-        return { ...s, then: loopsAsIfs(s.then), else: loopsAsIfs(s.else) };
-      default:
-        return s;
-    }
-  });
-}
-
-function ifsAsLoops(body: Stmt[]): Stmt[] {
-  return body.map((s): Stmt => {
-    if (s.k !== 'if') {
-      return s;
-    }
-    const then = ifsAsLoops(s.then);
-    if (s.cond.k === 'call' && s.cond.fn === MARK.while) {
-      return { k: 'while', cond: s.cond.args[0], body: then };
-    }
-    if (s.cond.k === 'call' && s.cond.fn === MARK.for) {
-      return { k: 'for', init: then[0], cond: s.cond.args[0], inc: then[1], body: then.slice(2) };
-    }
-    return { ...s, then, else: ifsAsLoops(s.else) };
-  });
-}
-
-const withoutLoopGate = (sfn: SFn): { merged: string; sfn: SFn }[] =>
-  coalesceCandidates({ ...sfn, body: loopsAsIfs(sfn.body) }).map((c) => ({
-    ...c,
-    sfn: { ...c.sfn, body: ifsAsLoops(c.sfn.body) },
-  }));
-
 // ── the two arms ───────────────────────────────────────────────────────────────────────────────
 const PROGRAMS = 2000;
 const SCHEDULES = [
@@ -241,9 +200,10 @@ function sweep(candidatesOf: (sfn: SFn) => { merged: string; sfn: SFn }[]) {
   return { candidates, clobbered, undefinedOnly };
 }
 
-describe('the loop gate, differentially', () => {
+const under = (gates: readonly Gate<MergePair>[]) => (sfn: SFn) => coalesceUnder(gates, sfn).candidates;
+
+describe('the gates, differentially', () => {
   const kept = sweep(coalesceCandidates);
-  const ablated = sweep(withoutLoopGate);
 
   test('the sweep reaches mergeable programs at all', () => {
     // A floor well under what the generator currently offers, so tuning it does not have to move.
@@ -254,14 +214,44 @@ describe('the loop gate, differentially', () => {
     expect(kept.clobbered).toEqual([]);
   });
 
-  test('suppressing the loop flag DOES clobber — the gate is load-bearing', () => {
-    // Green here means the generator stopped reaching loops, or the pass stopped consulting `inLoop`.
-    expect(ablated.clobbered.length).toBeGreaterThan(0);
-  });
-
   test('the accepted-not-fixed case is real, and is what the carve-out covers', () => {
     // coalesce.ts accepts this class; asserting it stays reachable stops the carve-out that excuses
     // it from quietly becoming dead code.
     expect(kept.undefinedOnly).toBeGreaterThan(0);
+  });
+});
+
+// THE GATE CONTRACT. Every rule the table calls SOUND has to earn the word, and the acceptance
+// criterion is the one four audit rounds applied by hand: drop the gate and something must break.
+// Written against the TABLE rather than against a named gate, so a rule added later is held to it
+// without anyone remembering to — which is the whole reason the gates became data.
+describe('COALESCE_GATES', () => {
+  test('the table is well-formed, and nothing calls itself sound without naming a guard', () => {
+    expect(gateTableDefects(COALESCE_GATES)).toEqual([]);
+  });
+
+  test.each(COALESCE_GATES.filter((g) => g.sound).map((g) => [g.id] as const))(
+    'the SOUND gate `%s` is load-bearing — dropping it clobbers a defined read',
+    (id) => {
+      // The ablation is a VALUE: the real predicate runs on the real input, with no test-only branch
+      // in the shipped path and no input rewritten to dodge it. `without` throws on an unknown id,
+      // so a typo here fails loudly instead of silently testing the unablated pass.
+      expect(sweep(under(without(COALESCE_GATES, id))).clobbered.length).toBeGreaterThan(0);
+    },
+  );
+
+  test('every gate actually refuses something — a rule nothing reaches guards nothing', () => {
+    // Reachability, not correctness: a gate the corpus never exercises is one no test could be
+    // failing on purpose, which is how a dead rule outlives the reason it was written.
+    const reached = new Set<string>();
+    for (let seed = 1; seed <= 400; seed++) {
+      for (const id of coalesceUnder(COALESCE_GATES, generate(seed)).refusals.keys()) {
+        reached.add(id);
+      }
+    }
+    // `param` and `type` need shapes the generator does not emit (it declares three same-typed
+    // locals and no params); coalesce.test.ts pins both directly.
+    const byUnitTest = new Set(['param', 'type']);
+    expect(COALESCE_GATES.filter((g) => !reached.has(g.id) && !byUnitTest.has(g.id)).map((g) => g.id)).toEqual([]);
   });
 });

--- a/packages/core/test/gate-contract.test.ts
+++ b/packages/core/test/gate-contract.test.ts
@@ -1,0 +1,43 @@
+// The contract every gate table is held to, in one place — so adopting `gates.ts` costs a pass one
+// line here rather than a test file of its own.
+//
+// What is NOT here: the differential check that a SOUND gate is load-bearing. That one needs the
+// pass's own oracle (coalesce's lives in coalesce-fuzz.test.ts, driven off its table), so this file
+// checks the part that is the same everywhere — the table is well-formed, nothing calls itself sound
+// without naming a guard, and the guard it names is a test that still exists.
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+import { BASECSE_GATES } from '../src/l3/basecse';
+import { COALESCE_GATES } from '../src/l3/coalesce';
+import { type Gate, gateTableDefects } from '../src/l3/gates';
+
+// Every declared table. A pass that adopts gates.ts and forgets this line gets no contract, which is
+// the one hole the pattern cannot close for itself — so keep it short and obvious.
+const TABLES: Record<string, readonly Gate<never>[]> = {
+  COALESCE_GATES: COALESCE_GATES as readonly Gate<never>[],
+  BASECSE_GATES: BASECSE_GATES as readonly Gate<never>[],
+};
+
+/** Every `test(...)`/`describe(...)` title in the core suite, as one blob to search. */
+const titles = readdirSync(__dirname)
+  .filter((f) => f.endsWith('.test.ts'))
+  .map((f) => readFileSync(join(__dirname, f), 'utf8'))
+  .join('\n');
+
+describe.each(Object.entries(TABLES))('%s', (_name, gates) => {
+  test('is well-formed, and nothing calls itself sound without naming a guard', () => {
+    expect(gateTableDefects(gates)).toEqual([]);
+  });
+
+  test('every named guard is a test that still exists', () => {
+    // `guardedBy` is prose until something reads it. Matching it against the suite's own titles is
+    // what stops it from decaying into a comment that names a test deleted two refactors ago.
+    const missing = gates
+      .filter((g) => g.guardedBy)
+      .map((g) => ({ id: g.id, guard: g.guardedBy!.split(':').pop()!.trim() }))
+      .filter((g) => !titles.includes(g.guard));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two things: **F5** (the self-declared debt at `raise/gvn.ts`) and then, after the comment count went up *again*, a structural change aimed at why it keeps happening.

---

# Part 1 — F5: what the four address-placement passes promise each other

Four passes decide **"is this address a local?"**, each unit-tested on its own:

| pass | policy |
|---|---|
| `raise/gvn.ts` | never — one `gaddr` in the entry block, re-spelled at each use |
| `l3/basecse.ts` | function top, when reused 2+ times |
| `l3/scopebase.ts` | innermost scope holding the uses |
| `l3/argbase.ts` | immediately before a call whose arguments share it |

The debt note said **three**. `argbase.ts` is a fourth, and `scopebase.ts` already cited it as a peer twice.

## The unguarded edge

`gvn` hoists to the **entry block** — the maximal live range, the opposite of the other three — and is safe only because `structure/analysis.ts` keys its materialize-into-a-local rule on `opcode === 'const'`. A promise another module keeps, in one string comparison, checked by nothing:

```c
 s32 f(s32 a0) {
-    sink(gTable[0][0]);
-    return gTable[0][4];
+    u16 * v0;
+    v0 = (u16 *)&gTable;
+    sink(*v0);
+    return v0[4];
 }
```

The function-top local `gvn` exists to delete, one level up — and **all 854 offline tests passed** with that edit in place.

## Acceptance criterion

| ablation | |
|---|---|
| baseline | 7 passed |
| `analysis.ts` materializes an address op | **2 failed** |
| `basecse` admits a bare `var` base | **2 failed** |
| `scopebase` reads a `for`-init at loop cadence | **1 failed** |
| `scopebase` drops its shadow filter | **1 failed** |
| `argbase` gains `scopebase`'s shadow filter | **1 failed** |

The shadow-filter test was **green under its own ablation** on the first draft — it declined because the uses sat at the function's top level, not because of shadowing. Rewritten to hoist inside an `if` arm, with the unshadowed name as a control.

## The debt, restated rather than deleted

A consolidation has to **pick** between two live disagreements, so both readings are pinned:

- **a `for`'s init** — `basecse` reads it at loop cadence and refuses; `scopebase` at the enclosing one (it runs once) and hoists.
- **a shadowed global** — `scopebase` *must* refuse (it re-spells the base as `&g`); `argbase` may fire (it keeps the base verbatim). Load-bearing asymmetry, not drift.

---

# Part 2 — gates as data

Three rounds of comment work each ended the same way: a manual audit answering *"does this gate have a test that fails without it?"*, with the answer written down as more prose. The comments grow because the knowledge has nowhere else to live — core is 31% comments, which is not a documentation problem but invariants the code cannot express.

I also tested and **discarded** the obvious alternative. All 81 module references in core resolve to real files. What rots is never the name: `gvn`'s "three modules" had three correct filenames. Nothing greppable separates a true claim from a false one.

## `l3/gates.ts`

A gate is `{id, why, sound, guardedBy, rejects}`. Because the table is a **value**:

- a test drops one entry and re-runs the pass — real predicate, real input, no test-only branch in the shipped path
- **`sound: true` costs something**: the contract runs the ablation, so calling a heuristic sound now fails instead of reading as rigour
- `guardedBy` is matched against the suite's own test titles, so it cannot decay into a comment naming a deleted test
- refusals are attributable, which makes gate reachability checkable

Converted `coalesce.ts` (6 gates, 2 sound) and `basecse.ts` (3 gates, **none** sound — a wrong hoist costs bytes, never meaning).

Meta-ablations, all caught:

| | |
|---|---|
| a heuristic falsely declared `sound` | **1 failed** |
| a sound gate with `guardedBy` removed | **1 failed** |
| the loop gate neutered in place | **2 failed** |

The title check **caught a live one on its first run**: `coalesce`'s `loop` gate named a test title renamed 20 minutes earlier in this same change.

**Deleted:** ~45 lines of F6's ablation-by-input machinery (rewriting loops as tagged `if`s to suppress one flag). It existed only because the gate was not a value. Arm B is now written over the table, so every sound gate added later is ablated automatically.

## Comment accounting

It went up again: **+55 net.** But **44 of those are the two new infrastructure files, paid once**, and the marginal cost of converting the second pass was **+2 comment lines and one registry line**. Prior rounds added 30–60 each with no slope; this one is ~2 per pass and retires the audit that generated the prose.

---

## Gates

- `pnpm test:offline` — **868 passed** (was 854)
- `pnpm test:matching` — **279 passed**
- `pnpm typecheck` — clean · `pnpm lint` — 0 errors, 41 warnings (baseline) · `pnpm format:check` — clean
- `pnpm bench run` + `merge` + `regression` — **0 lost, 0 missing, 0 gained, 0 other flips (743 rows)**. asmlift 363 vs m2c 342, unchanged. The only diff in `results.json` was the run timestamp, the commit hash, and randomized temp-dir names inside error strings, so it was reverted rather than committed.

Part 1 is comment-only in `packages/core/src`. Part 2 changes real code; the zero-flip gate above is what settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)