### PR TITLE
chore(release): @asmlift/core and @asmlift/cli 0.5.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asmlift/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "type": "module",
   "description": "The asmlift command line: decompile one function to C/Pascal from the terminal",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asmlift/core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "type": "module",
   "description": "Match decompile an assembly function to C or Pascal",


### PR DESCRIPTION
Bumps both public packages to `0.5.0`. No source changes — only the two `version` fields; `pnpm install` left the lockfile untouched.

## Gates (docs/releasing.md), all run locally on a clean tree

| # | gate | result |
| - | ---- | ------ |
| 1 | `pnpm run typecheck` | exit 0 |
| 2 | `pnpm run lint` | exit 0 |
| 3 | `pnpm run format:check` | exit 0 |
| 4 | `pnpm run test:offline` | covered by gate 5 |
| 5 | `pnpm test` — full suite incl. matching | exit 0, **279 tests / 31 files** |
| 6 | `pnpm bench run && bench merge && bench regression` | **0 lost, 0 missing, 0 gained, 0 other flips** (743 rows) |

Gate 5 is the one hosted CI cannot run, so it was run locally as the doc requires. Gate 6 was a real `bench run` (240 real rows, 26.0s) followed by `merge`, not a self-comparison of the committed results — and its exit status was read directly, not through a pipe. Benchmark score is unchanged at **asmlift 363 vs m2c 342**; the only diff `merge` produced was nondeterministic noise (timestamp, commit hash, temp-dir names inside agbcc error strings), so it was reverted rather than committed.

## Tarball verification

Both packed and inspected:

- `asmlift-core-0.5.0.tgz` (348K) — `files: ["src"]`, no dependencies, ships `src/ LICENSE README.md`.
- `asmlift-cli-0.5.0.tgz` (144K) — `files: ["dist","src"]`, `bin.asmlift → ./dist/asmlift.mjs`, and `workspace:^` correctly resolved to `"@asmlift/core": "^0.5.0"`.

The `dist/` in the working tree was a stale Aug-10 build (`prepublishOnly` rebuilds it at publish time), so it was rebuilt and smoke-tested: the shipped bundle decompiles a Thumb function end-to-end, exit 0.

## After merge

Publish is a human step — npm publish-2FA needs a fresh single-use OTP per package, core first:

```
pnpm --filter @asmlift/core publish --access public --otp=<code>
pnpm --filter @asmlift/cli  publish --access public --otp=<code>
```

then `git tag -a v0.5.0 <release-commit>` and push the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)