### PR TITLE
An immediate is a number, not a spelling

### DIFF
--- a/packages/core/src/frontend/thumb.ts
+++ b/packages/core/src/frontend/thumb.ts
@@ -150,9 +150,16 @@ function classifyXfer(ins: Instr): XferKind | null {
   }
   // A write to PC is a control transfer. `mov pc, lr` restores the link register → return; any other
   // computed/loaded PC write (`mov pc, rN` rN≠lr, `ldr pc, …`, `add/sub pc, …`) is an indirect jump.
+  //
+  // BY REGISTER, NOT BY ALIAS. `pc` and `r15` are one register, and `readData` already says so; here
+  // the alias decides CONTROL FLOW, so missing it does not degrade — the write is not a transfer at
+  // all, the terminator never forms, and execution runs on into the next block. `mov r15, lr` mid
+  // function deleted the early return outright AND minted a phantom parameter for the `lr` read that
+  // was left behind, with no diagnostic. `lr`/`r14` is the same question one operand over, and it is
+  // the safe half: missing it reads as an indirect jump, which declines loud.
   const dest = ins.ops[0]?.replace(/[[\]]/g, '');
-  if (dest === 'pc') {
-    if ((mn === 'mov' || mn === 'movs') && ins.ops[1] === 'lr') {
+  if (dest === 'pc' || dest === 'r15') {
+    if ((mn === 'mov' || mn === 'movs') && (ins.ops[1] === 'lr' || ins.ops[1] === 'r14')) {
       return 'return';
     }
     return 'indirect';
@@ -179,15 +186,9 @@ function classifyXfer(ins: Instr): XferKind | null {
   return null;
 }
 
-// A raw immediate's VALUE, as far as this parse goes. The radix test is case-insensitive because
-// gas accepts `0X`, and getting that wrong is not a near miss: `parseInt` stops at the first
-// character it cannot consume, so `#0X1` read as radix 10 is 0 where the assembler encodes 1.
-//
-// Still LOOSE by design — a binary literal (`#0b1`) and an octal one (`#010`, 8 to gas and 10 to
-// `parseInt`) are both misread, silently. That is why `immEq` below exists instead of callers
-// comparing against this: a caller that can refuse should. The ones that cannot — the arithmetic
-// fall-throughs below, the frame walk — carry the hole, and no corpus spells either form (of 105411
-// `#` operands across the vendored checkouts, every one this misreads is absent).
+// A raw immediate's value. Case-insensitive on the radix because gas accepts `0X` and `parseInt`
+// with the wrong one reads `#0X1` as 0 — see `immEq` below for why this stays loose about binary,
+// octal and expressions, and which callers therefore have to refuse rather than ask this.
 const imm = (s: string) => parseInt(s.replace(/^#/, ''), /0[xX]/.test(s) ? 16 : 10);
 
 // AN IMMEDIATE IS A NUMBER, NOT A SPELLING, and which spelling appears is the producer's choice
@@ -200,7 +201,8 @@ const imm = (s: string) => parseInt(s.replace(/^#/, ''), /0[xX]/.test(s) ? 16 : 
 //
 // The operand must be a plain integer LITERAL, and that shape check is the whole point of this
 // helper rather than an incidental guard. `imm()` is `parseInt`, which stops at the first character
-// it cannot consume, so it reads `#2*2` as 2 — and `#2*2` is not malformed, it is an expression gas
+// it cannot consume — `#0b1` and `#0.5` read as 0, `#010` as 10 where gas means 8 — and it reads
+// `#2*2` as 2, which is not malformed but an expression gas
 // accepts and assembles to `lsls r0, r1, #4`. Matching it as a shift by two would recover a switch
 // whose stride is wrong by a factor of four: the emitted C is entirely ordinary and dispatches to
 // the wrong BLOCK, with no marker. `#2+1`, `#2-1` and `#2<<1` are the same trap. An adversarial

--- a/packages/core/src/frontend/thumb.ts
+++ b/packages/core/src/frontend/thumb.ts
@@ -179,7 +179,54 @@ function classifyXfer(ins: Instr): XferKind | null {
   return null;
 }
 
-const imm = (s: string) => parseInt(s.replace(/^#/, ''), s.includes('0x') ? 16 : 10);
+// A raw immediate's VALUE, as far as this parse goes. The radix test is case-insensitive because
+// gas accepts `0X`, and getting that wrong is not a near miss: `parseInt` stops at the first
+// character it cannot consume, so `#0X1` read as radix 10 is 0 where the assembler encodes 1.
+//
+// Still LOOSE by design — a binary literal (`#0b1`) and an octal one (`#010`, 8 to gas and 10 to
+// `parseInt`) are both misread, silently. That is why `immEq` below exists instead of callers
+// comparing against this: a caller that can refuse should. The ones that cannot — the arithmetic
+// fall-throughs below, the frame walk — carry the hole, and no corpus spells either form (of 105411
+// `#` operands across the vendored checkouts, every one this misreads is absent).
+const imm = (s: string) => parseInt(s.replace(/^#/, ''), /0[xX]/.test(s) ? 16 : 10);
+
+// AN IMMEDIATE IS A NUMBER, NOT A SPELLING, and which spelling appears is the producer's choice
+// rather than the machine's. Counting the gated shapes (`add`/`rsb rD, rS, #0`) over the vendored
+// checkouts, every producer writes `#0` — sa3's split 11158, sa3's build 9837, klonoa's build 1072,
+// and `#0x0` not once between them — EXCEPT klonoa's own disassembly, which writes `#0x0` 3533
+// times against 36. So an idiom keyed on the token is off for one whole project in silence, which
+// is what this predicate exists to stop. `#2`, `#0x2` and `#0x02` are likewise one shift, and the
+// jump-table shift recogniser used to compare the operand text and so rejected the third.
+//
+// The operand must be a plain integer LITERAL, and that shape check is the whole point of this
+// helper rather than an incidental guard. `imm()` is `parseInt`, which stops at the first character
+// it cannot consume, so it reads `#2*2` as 2 — and `#2*2` is not malformed, it is an expression gas
+// accepts and assembles to `lsls r0, r1, #4`. Matching it as a shift by two would recover a switch
+// whose stride is wrong by a factor of four: the emitted C is entirely ordinary and dispatches to
+// the wrong BLOCK, with no marker. `#2+1`, `#2-1` and `#2<<1` are the same trap. An adversarial
+// probe found this after the first cut of this helper shipped with exactly that hole, and the test
+// that claimed to pin the property sampled only `#3`/`#0x3`/`#0x1`/`r2` and so passed anyway.
+//
+// Anything that is not a bare decimal or hex literal therefore fails this test — which is a
+// DECLINE only where the caller declines, and the three callers differ. The jump-table recogniser
+// returns null; the `add` and `rsb` copy/negate arms fall through to their own lowering, and for
+// `add`/`sub` that lowering is `constVal(imm(…))`, which is loose. So a non-match is a refusal at
+// two of the three sites and a possibly-wrong constant at the third; `#0b1` renders `+ 0` there.
+// The hole is `imm`'s rather than this predicate's, and a characterization test pins it.
+//
+// The refused class that DOES occur is the signed literal: 722 negative immediates across the
+// corpus (`#-0x4` ×287, `#-0x004`, …), all of them inert here because neither 0 nor 2 is negative —
+// but `imm` reads them correctly and this does not, so the two disagree on a populated class and a
+// future `want` has to know that.
+//
+// One divergence is knowingly left in, and it is inert at both values this is used with.
+// A leading zero means octal to gas and decimal to `Number`, so `#010` is 8 there and 10 here —
+// but for `want === 2` both readings fail and the dispatch declines either way, and for
+// `want === 0` every octal spelling of zero (`#0`, `#00`, `#000`) is zero under both. A `want`
+// other than those two has to revisit this, because for e.g. `want === 8` the readings disagree.
+const IMM_LITERAL = /^#\s*(?:0[xX][0-9a-fA-F]+|[0-9]+)$/;
+const immEq = (op: string | undefined, want: number): boolean =>
+  op !== undefined && IMM_LITERAL.test(op) && Number(op.slice(1).trim()) === want;
 
 // Expand fused register-range tokens (`r4-r7` → r4,r5,r6,r7) in a register list. Ranges are
 // numeric-endpoint only (`rN-rM`); a range whose endpoint is an ALIAS (`r4-pc`/`-lr`/`-sp`) is
@@ -1019,30 +1066,6 @@ interface JumpTable {
 // since `lsl rD, rS, #imm` is low-register-only, so the add here is always the low-register form.
 const isDataOp = (mn: string, base: 'lsl' | 'add'): boolean => mn === base || mn === `${base}s`;
 
-// A shift amount is a NUMBER, not a spelling. `#2`, `#0x2` and `#0x02` are the same shift; the
-// recogniser used to compare the operand text and so rejected the third.
-//
-// The operand must be a plain integer LITERAL, and that shape check is the whole point of this
-// helper rather than an incidental guard. `imm()` is `parseInt`, which stops at the first character
-// it cannot consume, so it reads `#2*2` as 2 — and `#2*2` is not malformed, it is an expression gas
-// accepts and assembles to `lsls r0, r1, #4`. Matching it as a shift by two would recover a switch
-// whose stride is wrong by a factor of four: the emitted C is entirely ordinary and dispatches to
-// the wrong BLOCK, with no marker. `#2+1`, `#2-1` and `#2<<1` are the same trap. An adversarial
-// probe found this after the first cut of this helper shipped with exactly that hole, and the test
-// that claimed to pin the property sampled only `#3`/`#0x3`/`#0x1`/`r2` and so passed anyway.
-//
-// Anything that is not a bare decimal or hex literal therefore DECLINES, which is the safe
-// direction: a real dispatch spells its shift as a literal. Known false declines, all loud and none
-// observed in any corpus: a binary literal (`#0b10`) and a signed one (`#+2`).
-//
-// One divergence is knowingly left in, and it is inert AT THE ONLY VALUE THIS IS USED WITH.
-// A leading zero means octal to gas and decimal to `Number`, so `#010` is 8 there and 10 here —
-// but both readings are compared against 2, both fail, and the dispatch declines either way; `#02`
-// is 2 under both. **If this helper is ever reused for a `want` other than 2, that has to be
-// revisited**, because for e.g. `want === 8` the two readings disagree about `#010`.
-const IMM_LITERAL = /^#\s*(?:0[xX][0-9a-fA-F]+|[0-9]+)$/;
-const immEq = (op: string | undefined, want: number): boolean =>
-  op !== undefined && IMM_LITERAL.test(op) && Number(op.slice(1).trim()) === want;
 function recoverJumpTable(
   bounds: AsmBlock,
   disp: AsmBlock,
@@ -2113,11 +2136,17 @@ export function lift(
             break;
           }
           // `add rD, rS, #0` is agbcc's low-register copy idiom (Thumb `mov rD, rS` between
-          // low regs isn't always available). Model it as a pure copy — same SSA value — not
-          // an `x + 0` add. This keeps output clean and, crucially, makes a value copied to a
-          // callee-saved register before a call read as still-live *after* the call, which is
-          // how call-argument liveness tells a passed argument from a preserved one.
-          if (c === '#0') {
+          // low regs isn't always available). Model it as a pure copy — the SAME SSA VALUE — not
+          // an `x + 0` add. Value identity is what it buys: the pattern engine matches on it
+          // (`{same:'X'}`), and the structurer's pre-update loop test compares a back-edge argument
+          // against an exit argument by identity, so an `x + 0` between them reads as a different
+          // value and declines a loop that is perfectly ordinary.
+          //
+          // NOT call-argument liveness, which this comment claimed for several releases: both arms
+          // end in `writeData(reg(a), …)`, and the arity machinery (`fallbackArgc`,
+          // `trimClobberedCallArgs`) is keyed on the register, never on the value — measured, zero
+          // arity changes across 3337 corpus functions even with this idiom ablated entirely.
+          if (immEq(c, 0)) {
             writeData(reg(a), bi, readData(reg(b), bi));
             break;
           }
@@ -2190,7 +2219,7 @@ export function lift(
           // Reverse subtract. `rsb rD, rS, #0` is the negate idiom (0 - rS) → -x. Any other form
           // (`rsb rD, rS, #N`, N≠0 — not a Thumb-1 encoding, but be safe) is NOT modelled: degrade
           // to a loud `opaque` rather than silently leaving rD unwritten (a silent miscompile).
-          if (c === '#0') {
+          if (immEq(c, 0)) {
             const res = mkValue(T.unk(32));
             irb.ops.push(mkOp('neg', { operands: [readData(reg(b), bi)], results: [res] }));
             writeData(reg(a), bi, res);

--- a/packages/core/test/thumb-frontend.test.ts
+++ b/packages/core/test/thumb-frontend.test.ts
@@ -57,6 +57,34 @@ describe('an immediate idiom is keyed on the VALUE, not the spelling', () => {
   });
 });
 
+// THE SAME QUESTION FOR A REGISTER ALIAS, and here it decides CONTROL FLOW rather than a value, so
+// missing it does not degrade: the write is not recognised as a transfer, no terminator forms, and
+// execution runs on into the next block. `readData` already treats `pc` and `r15` as one register;
+// `classifyXfer` did not.
+describe('a PC write is a control transfer under either spelling', () => {
+  const body = (dest: string, src: string) =>
+    `\tpush\t{r4, lr}\n\tcmp\tr0, #0\n\tbeq\t.L1\n\tmov\t${dest}, ${src}\n.L1:\n\tadd\tr0, r0, #1\n\tpop\t{r4}\n\tpop\t{r1}\n\tbx\tr1\n`;
+  const RETURNS =
+    's32 f(s32 a0) {\n    if (a0 != 0) {\n        return a0;\n    } else {\n        return a0 + 1;\n    }\n}\n';
+
+  test.each([
+    ['pc', 'lr'],
+    ['r15', 'lr'],
+    ['pc', 'r14'],
+    ['r15', 'r14'],
+  ])('`mov %s, %s` is the return', (dest, src) => {
+    expect(dc('f', body(dest, src)).source).toBe(RETURNS);
+  });
+
+  // …and a PC write that is NOT the link register is an indirect jump, which declines. Spelled
+  // `r15` it used to be no transfer at all: the early return vanished and the leftover read minted
+  // a phantom parameter, both silently.
+  test.each(['pc', 'r15'])('`mov %s, rN` is an indirect jump, loudly', (dest) => {
+    expect(() => dc('f', body(dest, 'lr'))).not.toThrow(); // control
+    expect(() => dc('f', body(dest, 'r3'))).toThrow(/indirect\/computed jump/);
+  });
+});
+
 describe('Thumb frontend robustness (CONTRACT-AS-INVARIANT)', () => {
   test('a conditional branch split from its cmp by a label declines loud', () => {
     // The label between `cmp` and `bge` splits the block, so the branch has no reaching compare in

--- a/packages/core/test/thumb-frontend.test.ts
+++ b/packages/core/test/thumb-frontend.test.ts
@@ -8,6 +8,55 @@ import { ARMV4T_AGBCC } from '../src/target';
 
 const dc = (sym: string, body: string) => decompile(sym, `${sym}:\n${body}`, ARMV4T_AGBCC);
 
+// THE SPELLING OF AN IMMEDIATE IS NOT ITS VALUE. Two producers feed this frontend and write the
+// same zero differently — agbcc's own `.s` emits `#0`, a pret-style disassembly emits `#0x0` — so an
+// idiom gated on the TOKEN is silently off for a whole project. Counting the two gated shapes over
+// the vendored agbcc checkouts: sa3 writes `#0` 9510 times and `#0x0` never; klonoa writes `#0` 36
+// times and `#0x0` 3533.
+//
+// The predicate is `immEq`, a LITERAL-shape test rather than a `parseInt`, and the refusal tests
+// are why: `parseInt` stops at the first character it cannot consume, so `#0b1` reads as zero — and
+// at the `rsb` site that turned a loud decline into a confident negate. The `add` site cannot make
+// the same promise, because a non-match there falls through to `imm()` rather than refusing; the
+// last test pins what that costs instead of pretending it does not exist.
+describe('an immediate idiom is keyed on the VALUE, not the spelling', () => {
+  const spellings = ['#0', '#0x0', '#0X0', '#00'];
+
+  // Not cosmetic: the copy makes both sides the SAME SSA VALUE, which is what the pattern engine
+  // (`{same:'X'}`) and the structurer's pre-update loop test compare on.
+  test.each(spellings)('`add rD, rS, %s` is a register copy', (n) => {
+    expect(dc('f', `\tpush\t{r4, lr}\n\tadd\tr0, r1, ${n}\n\tpop\t{r4}\n\tpop\t{r1}\n\tbx\tr1\n`).source).toBe(
+      's32 f(s32 a0) {\n    return a0;\n}\n',
+    );
+  });
+
+  // This one degrades LOUD when unrecognised — an `rsb` the arm does not claim becomes an `opaque`,
+  // so the wrong spelling costs the whole function rather than one `+ 0`.
+  test.each(spellings)('`rsb rD, rS, %s` is a negate', (n) => {
+    expect(dc('f', `\tpush\t{r4, lr}\n\trsb\tr0, r1, ${n}\n\tpop\t{r4}\n\tpop\t{r1}\n\tbx\tr1\n`).source).toBe(
+      's32 f(s32 a0) {\n    return -a0;\n}\n',
+    );
+  });
+
+  // REFUSALS at the `rsb` site, where a non-match declines. `parseInt` reads every one of these as
+  // zero; the shape test is the only thing between them and a confident negate.
+  test.each(['#0X10', '#0b1', '#0.5', '#0e5', '#0*4'])('`rsb rD, rS, %s` is not a negate', (n) => {
+    const rsb = (imm: string) => `\tpush\t{r4, lr}\n\trsb\tr0, r1, ${imm}\n\tpop\t{r4}\n\tpop\t{r1}\n\tbx\tr1\n`;
+    expect(() => dc('f', rsb('#0'))).not.toThrow(); // control
+    expect(() => dc('f', rsb(n))).toThrow(/unmodelled instruction 'rsb'/);
+  });
+
+  // CHARACTERIZATION, not an assertion of correctness. A non-match at the `add` site falls through
+  // to `constVal(imm(…))`, and `imm` does not read binary — gas assembles `#0b1` as `+ 1`. Nothing
+  // in any corpus spells it (105411 `#` operands, zero of this class), so the honest move is to pin
+  // the gap where a reader will find it rather than leave the header claiming it cannot happen.
+  test('KNOWN GAP: a binary immediate reaches the `add` lowering and is misread', () => {
+    const add = (imm: string) => `\tpush\t{r4, lr}\n\tadd\tr0, r1, ${imm}\n\tpop\t{r4}\n\tpop\t{r1}\n\tbx\tr1\n`;
+    expect(dc('f', add('#0X1')).source).toBe('s32 f(s32 a0) {\n    return a0 + 1;\n}\n'); // the radix fix
+    expect(dc('f', add('#0b1')).source).toBe('s32 f(s32 a0) {\n    return a0 + 0;\n}\n'); // gas: + 1
+  });
+});
+
 describe('Thumb frontend robustness (CONTRACT-AS-INVARIANT)', () => {
   test('a conditional branch split from its cmp by a label declines loud', () => {
     // The label between `cmp` and `bge` splits the block, so the branch has no reaching compare in


### PR DESCRIPTION
Two producers feed the Thumb frontend and write the same value differently. Counting the gated shapes (`add`/`rsb rD, rS, #0`) over the vendored checkouts, **every producer writes `#0`** — sa3's split 11158, sa3's build 9837, klonoa's build 1072, and `#0x0` not once between them — **except klonoa's own disassembly, which writes `#0x0` 3533 times against 36.**

Two idioms were gated on the literal token `c === '#0'`, so both were off for that whole project in silence. The one that matters is agbcc's low-register copy, which Thumb-1 needs because `mov rD, rS` between low registers is not always available.

| | |
|---|---|
| `0b7cbc9` | key an immediate idiom on its VALUE, not on how it is spelled |
| `abbe834` | a PC write is a control transfer under either spelling of the register |

## What the copy actually buys

**SSA value identity** — the pattern engine matches on it (`{same:'X'}`), and the structurer's pre-update loop test compares a back-edge argument against an exit argument by identity, so an `x + 0` between them reads as a different value and declines an ordinary loop. Ablating the idiom flips 5 corpus functions between lift and decline, so it is load-bearing for lifting, not only readability.

It is **not** call-argument liveness, which the arm's comment claimed for several releases and which this PR's first draft repeated. Both arms end in `writeData(reg(a), …)` and the arity machinery is keyed on the register, never the value — measured, zero arity changes across 3337 functions even with the idiom fully ablated. The comment now records the disproof.

## Both adversarial rounds found something, and round 1 found a critical in the fix itself

The first cut added a *second* helper built on `imm()` = `parseInt`. `s.includes('0x')` is lowercase-only, so `#0X1`, `#0b1`, `#0.5` all read as **zero** — and at the `rsb` site that turned a loud decline into `return -a0;` for an instruction computing `16 - a0`. The exact loud→silent trade the arm's own comment exists to prevent, in a commit about spelling discipline.

`immEq`/`IMM_LITERAL` — a shape predicate, not a `parseInt` — already existed 860 lines down in the same file, carrying a comment that records an adversarial probe finding the identical hole once before. Both sites use it now; it moves up beside `imm`, and its standing *"revisit if reused for a `want` other than 2"* note is discharged for zero. `imm`'s radix test is also made case-insensitive, so `#0X1` no longer reads as 0 in the frame walk or `constVal` either.

Round 2 then found that the moved comment's safety paragraph (*"anything that is not a bare literal therefore DECLINES… all loud"*) was true only at the caller it used to sit above; the `add` arm falls through to `imm()` instead. Qualified, with the residue pinned as a characterization test rather than asserted away.

## The second commit

`classifyXfer` tested `dest === 'pc'`, so `mov r15, lr` was not a transfer at all — no terminator forms, execution runs into the next block, and the leftover `lr` read mints a phantom parameter:

```
mov pc,  lr   ->  if (a0 != 0) { return a0; } else { return a0 + 1; }
mov r15, lr   ->  s32 f(s32 a0, s32 a1) { return a0 + 1; }
```

`readData` already treats the two as one register; this was the one site where the alias decides *control flow* and the one site that did not ask. It lands here because the first commit fixes a zero-inhabitant `rsb` site on the argument that structurally identical gates must not be left spelling-keyed — and that argument cannot apply to the cheap case but not to the one with a demonstrated silent miscompile.

## Measurement

The benchmark **cannot see this**: its agbcc rows are built from agbcc's own `.s`, so 0 of 755 rows change and the totals stay asmlift 368 / m2c 348. The evidence is the sweep over the 3337 functions in the vendored checkouts, where 217 carry `add rD, rS, #0x0` but only 14 lift on `main` at all:

```
0 declined -> lifts, 0 lifts -> declined, 1 decline-text change
12 functions' C changed: 9 shorter, 2 longer, 1 longer-but-better
```

953 offline + 279 matching tests. Every guard is ablation-tested: loosening `immEq` fails the five refusal tests plus the jump-table strictness test; reverting either idiom site fails three each; dropping either register alias fails three and two.

## Named, not fixed

- **The two real regressions.** `EntityPositionFromLevelTable` grows 216 chars because more base identity merges two element groups in `raise/struct-arrays.ts`, whose `clean` test is group-wide — one block-arg use now contaminates a group that recovered cleanly alone. The follow-up is to split the group on its dirty element rather than discard it. `sub_0804BC44` renders `4294959104` where it read `-8192`; same bits into a `u16` store, but the C type flips signed to unsigned and that would matter under `>>`, `/` or a relational compare.
- A binary immediate (`#0b1`) still reaches the `add` lowering and renders `+ 0` where gas assembles `+ 1`. Zero of the corpus's 105411 `#` operands spell it; a `KNOWN GAP` test pins it.
- Uppercase register aliases (`mov pc, LR`) decline loud, so they are a false decline rather than a hole.
- Unrelated, found while measuring: `results.json` is not byte-stable across runs — 5 rows embed a random temp directory in a `droppedCandidates` error string, so `bench merge` always dirties the tree. No artifact refresh is included here, since no row moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)