### PR TITLE
An unadopted name must not reach the emitted C

### DIFF
--- a/packages/core/src/contracts.ts
+++ b/packages/core/src/contracts.ts
@@ -40,20 +40,35 @@ export function assertTypesRecovered(fn: Fn): void {
   }
 }
 
-/** Post structuring: the AST must reference no unresolved value. The structurer emits the
- *  sentinel var `"?"` when it cannot resolve a value (a dropped def, or an opcode it has no
- *  lowering for) — which would print as uncompilable source. Fail at the structuring boundary
- *  instead of emitting garbage. */
+/** Post structuring: the AST must reference no unresolved name. The structurer emits the sentinel
+ *  var `"?"` when it cannot resolve a value (a dropped def, or an opcode it has no lowering for),
+ *  which would print as uncompilable source. Fail at the boundary instead of emitting garbage.
+ *
+ *  `undefined` is the same failure from the other side — not a spelling the structurer chooses
+ *  (`Expr` declares `name: string`) but a `varName.get(v)!` whose value was never adopted, printing
+ *  as the token `undefined`. Both are checked on every ROUTE a name takes into the AST, and those
+ *  are not all expressions: `var` / `addr` / `field` / `call` carry one, and so does an `assign`'s
+ *  DESTINATION — a bare string field the expression walk never reaches. */
 export function assertResolved(sfn: SFn): void {
   // Derived from the shared exprChildren/stmtExprs/stmtChildren traversal so no statement kind
   // can be missed. A gap `marker` is annotate-mode's DESIGNED spelling of an unresolved value
-  // ("resolved" by construction); only its args could still hide a stray `"?"` — and args are
+  // ("resolved" by construction); only its args could still hide a stray name — and args are
   // exactly its children.
-  const badExpr = (e: Expr): boolean => (e.k === 'var' && e.name === '?') || exprChildren(e).some(badExpr);
-  const badStmt = (s: Stmt): boolean => stmtExprs(s).some(badExpr) || stmtChildren(s).some(badStmt);
+  const badName = (n: string | undefined): boolean => n === '?' || n === undefined;
+  // Every Expr kind that CARRIES a name, not just `var` — each is read through the same
+  // `map.get(d)!` / `attrs.x as string` and prints straight into the source. `carriesName` is asked
+  // separately because an ABSENT name is the case being caught: keying off `nameOf` alone refuses nothing.
+  const carriesName = (e: Expr): boolean => e.k === 'var' || e.k === 'addr' || e.k === 'field' || e.k === 'call';
+  const nameOf = (e: Expr): string | undefined =>
+    e.k === 'call' ? e.fn : e.k === 'marker' ? undefined : (e as { name?: string }).name;
+  const badExpr = (e: Expr): boolean => (carriesName(e) && badName(nameOf(e))) || exprChildren(e).some(badExpr);
+  // An `assign`'s DESTINATION is a bare string field, so the expression walk never reaches it.
+  const badStmt = (s: Stmt): boolean =>
+    (s.k === 'assign' && badName(s.name)) || stmtExprs(s).some(badExpr) || stmtChildren(s).some(badStmt);
   if (sfn.body.some(badStmt)) {
     throw new ContractError(
-      `structuring left an unresolved value ('?') in '${sfn.name}' — a dropped def or unlowered opcode`,
+      `structuring left an unresolved name ('?' or one never adopted) in '${sfn.name}' — ` +
+        `a dropped def, an unlowered opcode, or a name the structurer assumed the naming pipeline gave it`,
     );
   }
 }

--- a/packages/core/src/structure/hazards.ts
+++ b/packages/core/src/structure/hazards.ts
@@ -89,7 +89,7 @@ export interface SinkCandidate {
 export const PREUPDATE_SINK_GATES: readonly Gate<SinkCandidate>[] = [
   {
     id: 'arg-is-loop-variable',
-    why: 'an expression moved into the body is recomputed, and an effectful one runs a different number of times',
+    why: 'a value computed in the body still holds the PREVIOUS iteration at the top of it, where the copy lands',
     sound: true,
     guardedBy: 'hazards.test.ts: ablating arg-is-loop-variable admits a computed exit arg',
     rejects: (c) => !c.argIsLoopVariable,

--- a/packages/core/src/structure/structure.ts
+++ b/packages/core/src/structure/structure.ts
@@ -2534,9 +2534,12 @@ export function structure(fn: Fn, opts: StructureOptions = {}): SFn {
   };
   const loopSub = (li: LoopInfo): Map<Value, string> => subFor(li.header.params, li.backArgOfParam);
 
-  // The sunk exit copies, as body statements. Each arg is a header param — the sink's first
-  // refusal condition — so this is a plain `dest = <loop variable>` reading the value the name
-  // still holds at the top of the body, and needs no substitution. Slot order keeps it deterministic.
+  // The sunk exit copies, as body statements. `arg-is-loop-variable` makes each arg a header param,
+  // so this is a plain `dest = <loop variable>` reading the value the name still holds at the top of
+  // the body, and needs no substitution. Slot order keeps it deterministic.
+  //
+  // Both names are read as invariants, not checked: every block param carries one, and a header
+  // param is a block param. `assertResolved` is what catches a widening that breaks that.
   const preUpdateCopies = (exit: Block, exitArgs: readonly Value[], sunk: Set<number>): Stmt[] =>
     [...sunk]
       .sort((x, y) => x - y)

--- a/packages/core/test/loop-preupdate-sink.test.ts
+++ b/packages/core/test/loop-preupdate-sink.test.ts
@@ -112,12 +112,19 @@ test('do-while: the trailing copy opens the body and leaves nothing behind after
   );
 });
 
-// REFUSAL — the exit arg COMPUTES from the loop variable instead of being it. Sinking that would
-// evaluate `%3 + %0` every iteration rather than once, and an effectful arg would run a different
-// number of times, so the decline stands.
+// REFUSAL — the exit arg COMPUTES from the loop variable instead of being it. The copy would land
+// at the TOP of the body, where a body-computed value still holds the PREVIOUS iteration, and the
+// copy builder has only a name path to spell it with. The `do-while` and fused-guard variants stop
+// at DIFFERENT refusals, which is what each test pins.
 const TRAILING_PTR_EXPR = TRAILING_PTR.replace(
   '  cond_br %5, ^bb1(%4), ^bb2(%3, %4)',
   '  %9: s32* = add %3, %0\n  cond_br %5, ^bb1(%4), ^bb2(%9, %4)',
+);
+
+// The same one-fact edit at the `do-while`: ^bb2's exit edge carries `%7 + 1` instead of `%7`.
+const TRAILING_DOWHILE_EXPR = TRAILING_DOWHILE.replace(
+  '  cond_br %12, ^bb2(%8, %13, %11), ^bb3(%7)',
+  '  %15: s32 = add %7, %10\n  cond_br %12, ^bb2(%8, %13, %11), ^bb3(%15)',
 );
 
 // REFUSAL — the guard tests something the loop does not. `isGuardShapedPred` only asks whether the
@@ -159,9 +166,18 @@ const ZERO_TRIP_VALUE_LOST = `fn fusedrop {
 `;
 
 test('an exit arg that COMPUTES from the loop variable is not sinkable — still declines', () => {
-  expect(TRAILING_PTR_EXPR).not.toBe(TRAILING_PTR); // the one-fact edit landed
-  expect(() => emit(TRAILING_PTR)).not.toThrow(); // control: the base shape IS accepted
-  expect(() => emit(TRAILING_PTR_EXPR)).toThrow(StructureError);
+  expect(TRAILING_DOWHILE_EXPR).not.toBe(TRAILING_DOWHILE); // the one-fact edit landed
+  expect(() => emit(TRAILING_DOWHILE)).not.toThrow(); // control: the base shape IS accepted
+  // The message, not just a throw. Neither fixture reaches the sink's own gate as its refusal —
+  // this one stops at the pre-update hazard, the fused-guard one at the zero-trip rule — so only
+  // pinning WHICH refusal keeps a widened gate from passing on someone else's.
+  expect(() => emit(TRAILING_DOWHILE_EXPR)).toThrow(/do-while condition or a post-loop value/);
+});
+
+test('the same edit under a fused guard declines too, on the zero-trip rule', () => {
+  expect(TRAILING_PTR_EXPR).not.toBe(TRAILING_PTR);
+  expect(() => emit(TRAILING_PTR)).not.toThrow();
+  expect(() => emit(TRAILING_PTR_EXPR)).toThrow(/zero-trip run/);
 });
 
 test('a guard not provably the loop test is not sinkable — declines instead of vanishing', () => {

--- a/packages/core/test/resolved-contract.test.ts
+++ b/packages/core/test/resolved-contract.test.ts
@@ -1,0 +1,55 @@
+// UNIT tests for the structuring boundary contract (contracts.ts assertResolved): no name the
+// emitted AST carries may be unresolved.
+//
+// Hand-built AST, the same way effects-contract.ts pins its rule — the point is the coverage
+// itself, independent of whether today's structurer can produce the shape. A name reaches the AST
+// by TWO routes and the contract has to see both: as a `var` EXPRESSION, and as an `assign`
+// DESTINATION, which is a bare string field that no expression walk visits.
+//
+// Two spellings per route. `"?"` is the structurer's designed sentinel for a value it could not
+// resolve. `undefined` is a broken invariant instead: `Expr` declares `name: string`, so the only
+// way to reach one is a `varName.get(v)!` whose value was never adopted — and it prints as the
+// token `undefined`, uncompilable in exactly the way `"?"` is.
+import { expect, test } from 'vitest';
+
+import { cBackend } from '../src/backend/c';
+import { ContractError, assertResolved } from '../src/contracts';
+import { T } from '../src/ir/types';
+import type { SFn, Stmt } from '../src/l3/ast';
+
+const sfnWith = (body: Stmt[]): SFn => ({ name: 'f', params: [], locals: [], retType: T.void(), body });
+const copy = (dest: string | undefined, from: string | undefined): SFn =>
+  sfnWith([{ k: 'assign', name: dest as string, value: { k: 'var', name: from as string } }]);
+
+test('a resolved copy passes — the control both refusals are measured against', () => {
+  expect(() => assertResolved(copy('v0', 'v1'))).not.toThrow();
+});
+
+test('an unresolved name is refused in the VALUE, both spellings', () => {
+  expect(() => assertResolved(copy('v0', '?'))).toThrow(ContractError);
+  expect(() => assertResolved(copy('v0', undefined))).toThrow(ContractError);
+});
+
+// The destination is not an Expr, so `stmtExprs` never yields it: a walk over expressions alone
+// passes this and the backend prints `undefined = v1;`.
+test('an unresolved name is refused in the DESTINATION too', () => {
+  expect(() => assertResolved(copy('?', 'v1'))).toThrow(ContractError);
+  expect(() => assertResolved(copy(undefined, 'v1'))).toThrow(ContractError);
+});
+
+// What the contract is for: every refusal above is a line the backend would otherwise emit.
+test('each refused shape is one the backend would have emitted', () => {
+  expect(cBackend.emit(copy('v0', undefined))).toContain('v0 = undefined;');
+  expect(cBackend.emit(copy(undefined, 'v1'))).toContain('undefined = v1;');
+});
+
+// Nesting: the contract walks into statement children, so a copy buried in a loop body is refused
+// on the same terms as one at the top level.
+test('a nested statement is walked, not just the top level', () => {
+  const inLoop: Stmt = {
+    k: 'dowhile',
+    cond: { k: 'var', name: 'v0' },
+    body: [{ k: 'assign', name: undefined as unknown as string, value: { k: 'var', name: 'v1' } }],
+  };
+  expect(() => assertResolved(sfnWith([inLoop]))).toThrow(ContractError);
+});


### PR DESCRIPTION
## What

`assertResolved` is the boundary contract for *"structuring left a value it could not resolve"*. It tested **one spelling on one node kind**: a `var` whose name is the `'?'` sentinel.

Every other name in the AST is read through a `varName.get(v)!` / `attrs.x as string` assertion — an invariant claim about the naming pipeline, not a check. When one of those is wrong the node carries `undefined`, prints as the token `undefined`, and passes every boundary contract, `assertDerefsTyped` and `assertEffectsPreserved` included.

## How it was found

The trailing-value sink. `preUpdateCopies` spells each sunk copy as `varName.get(exitArgs[j])!`, and `arg-is-loop-variable` is the only thing between it and an unnamed arg. That gate's stated `why` was about *recomputation cost and effect counts* — which is not what it guards — so widening it on the strength of its own comment puts invalid C in the output.

Reproducible on the committed corpus. With the gate ablated, `synthetic:preupdate_exit:agbcc`:

| | strict | annotate |
|---|---|---|
| before | emits `a2 = undefined;` | emits it with **`diagnostics: []`** — the harness grades a clean-looking function instead of a decline |
| after | `ContractError` | `stubResult` decline |

The annotate half is the part that matters: a silent `undefined` that *reports itself as fine*.

## Changes

- **`assertResolved` rejects an absent name as well as `'?'`, on every route a name takes into the AST** — `var` / `addr` / `field` / `call`, and an `assign`'s **destination**, which is a bare string field the expression walk never reaches. Four of the nine name producers write that destination, so checking expressions alone would have covered the one site this was found at and nothing else.
- **The gate's `why` states what it guards**: a value computed in the body still holds the previous iteration at the top of it, where the copy lands. That failure mode is *silent* and the contract cannot see it — the gate stays the guard, the contract is only a backstop.
- **The refusal fixtures pin their decline message.** Neither reaches the sink's own gate: the `do-while` one stops at the pre-update hazard, the fused-guard one at the zero-trip rule. Asserting only `toThrow(StructureError)` let either pass on someone else's refusal.
- New `resolved-contract.test.ts`, modelled on `effects-contract.test.ts` (hand-built AST, unit-tests one contract).

## Gates

- `npx vitest run` — **1249 passed**, `pnpm typecheck` and lint clean
- `pnpm bench regression` — **0 lost, 0 missing, 0 gained, 0 other flips (760 rows)**
- Differential sweep over all 760 rows × {strict, annotate} = 1520 `decompile()` calls, main vs branch: **0 differing outputs**; same through `enumerateCandidates`. The change is inert in normal operation, which is what a fix to an unreachable path should be.

## Not done

- **No scoreboard movement, and no benchmark row to chase.** No real row declines on this link — the four that do are synthetic rows authored in #50/#51. The ten agbcc functions that exercise the path live in the dogfood corpus, outside the 40-row-per-project benchmark.
- **The trailing-value sink still refuses a computed exit arg.** Rendering one needs a placement (the copy would have to land where the value is available, not at the top of the body), which is a capability, not a bug fix. Left for a round that has a row behind it.
- `structure.ts:2532` puts a possibly-`undefined` into a `Map<Value, string>` whose read at `:1904` is a truthy test, so a missing loop-param name silently downgrades rather than surfacing. Pre-existing, out of scope, noted for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)