### PR TITLE
Merge DWARF prototypes in the traced tower

### DIFF
--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -13,7 +13,7 @@ import { verify } from './ir/verify';
 import type { LanguageBackend } from './l3/ast';
 import { DEFAULT_IDIOM_PATTERNS, RewritePattern, applyPattern, dce, patternApplies } from './pattern/engine';
 import { type OnGap, raiseRecovered, structureChecked, stubResult } from './pipeline';
-import type { Prototypes } from './proto';
+import { type Prototypes, prototypesFromSymbols } from './proto';
 import { type SymbolMap, symbolsByName } from './symbols';
 import { type TargetDescription, structureOptionsFor } from './target';
 
@@ -135,7 +135,10 @@ function traceTower(
   opts: TraceOptions,
 ): { source: string; report: TraceReport } {
   const backend = opts.backend ?? cBackend;
-  const prototypes = opts.prototypes ?? {};
+  // Merged exactly as pipeline.ts does: the project's own DWARF signatures fill in what the caller
+  // did not state. A trace that lifted from a different table would explain a run that never
+  // happened.
+  const prototypes = prototypesFromSymbols(opts.symbols, opts.prototypes ?? {});
   const returnsVoid = prototypes[name]?.returnsVoid ?? false;
   const trace: StageTrace[] = [];
   const patternEvents: PatternEvent[] = [];

--- a/packages/core/test/trace.test.ts
+++ b/packages/core/test/trace.test.ts
@@ -68,6 +68,23 @@ test('trace: the symbols knob has decompile() parity — named lift dump, named 
   expect(bare.source).not.toContain('gCounter');
 });
 
+test('trace: a CALLEE signature in the symbol map reaches the lift, as it does in decompile()', () => {
+  // The map's contribution is not just NAMES. `prototypesFromSymbols` turns a code symbol's DWARF
+  // signature into a prototype, and the frontend reads that for the callee's ARITY — otherwise it
+  // falls back to counting argument registers and guesses. Both towers must merge the same table,
+  // or a trace explains a lift the real run never performed.
+  const asm =
+    'f:\n\tpush\t{lr}\n\tmov\tr0, #1\n\tmov\tr1, #2\n\tmov\tr2, #3\n' + '\tbl\tcallee\n\tpop\t{r1}\n\tbx\tr1\n';
+  const int = { size: 4, signed: true };
+  const symbols = new Map([
+    [0x08000100, [{ name: 'callee', kind: 'code' as const, signature: { returns: null, params: [int] } }]],
+  ]);
+  const traced = decompileTraced('f', asm, ARMV4T_AGBCC, { symbols });
+  expect(traced.source).toBe(decompile('f', asm, ARMV4T_AGBCC, { symbols }).source);
+  // the signature says ONE parameter, so the call takes one — not the three the arg registers hold
+  expect(traced.source).toContain('callee(1)');
+});
+
 test('trace: annotate mode degrades a hard failure to the stub, never a throw', () => {
   const { source, report } = decompileTraced('mystery', 'not assembly at all\n', ARMV4T_AGBCC, { onGap: 'annotate' });
   expect(report.trace).toEqual([]);


### PR DESCRIPTION
`traceTower` took `opts.prototypes` raw, where `pipeline.ts:115` and `rank.ts:191` both merge the symbol map's own DWARF signatures under it.

The frontend reads a callee's prototype for its **arity**. Without the merge it falls back to counting argument registers, so a trace explained a lift the real run never performed:

```
trace:      return callee(1, 2, 3);
decompile:  return callee(1);
```

`returnsVoid` was read off the same unmerged table (`trace.ts:139` vs `pipeline.ts:134`), so the structurer could disagree about the return shape as well.

## Scope

**No benchmark row moves** — scoring goes through `pipeline`/`rank`, which were always correct. What was wrong is the *explanation* surface: the CLI's `--trace` output and the webapp's Pipeline view, i.e. exactly the thing you consult when a decompile looks wrong.

The existing symbols-parity test passed because its fixture is a `data` symbol with no signature, so `prototypesFromSymbols` contributed nothing. The new test uses a **code** symbol carrying one, and fails without the fix.

Found during the `LoadBGTilemapData` gap attribution; unrelated to that function, so it ships alone.

Gates: `npx vitest run` 1295, `pnpm test:matching` 283, `pnpm bench regression` 0 lost / 0 gained / 0 flips, typecheck clean, `eslint apps packages` 0 errors.
