### PR TITLE
tools.asmlift.prototypes, and refuse a malformed table

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,12 +56,13 @@ the stderr tag says which (`[declined]` = principled refusal, `[internal error]`
 
 All asmlift settings live in a spec-compliant `tools.asmlift` block:
 
-| Field      | Meaning                                                                                                                                                                                                                                                                    |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `target`   | asmlift target key — needed when the `platform` maps to several compilers (`n64` → `ido7.1`, `gcc2.7.2kmc` or `gcc2.7.2`)                                                                                                                                                  |
-| `compiler` | Candidate-compile command template: source file in, relocatable object out. Runs via `sh` with the decomp.yaml's directory as cwd                                                                                                                                          |
-| `objdump`  | Host objdump binary for `.o` input (overrides the PATH/env-resolved default: `mips-linux-gnu-objdump` / `powerpc-eabi-objdump`)                                                                                                                                            |
-| `elf`      | The project's built ELF, relative to this `decomp.yaml` — the address→symbol source. Absent ⇒ no symbol map. An unreadable ELF is a loud input error (exit `66`), never a silent map-less run. What it feeds and how to produce one: [The symbol map](#the-symbol-map-elf) |
+| Field        | Meaning                                                                                                                                                                                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `target`     | asmlift target key — needed when the `platform` maps to several compilers (`n64` → `ido7.1`, `gcc2.7.2kmc` or `gcc2.7.2`)                                                                                                                                                  |
+| `compiler`   | Candidate-compile command template: source file in, relocatable object out. Runs via `sh` with the decomp.yaml's directory as cwd                                                                                                                                          |
+| `objdump`    | Host objdump binary for `.o` input (overrides the PATH/env-resolved default: `mips-linux-gnu-objdump` / `powerpc-eabi-objdump`)                                                                                                                                            |
+| `elf`        | The project's built ELF, relative to this `decomp.yaml` — the address→symbol source. Absent ⇒ no symbol map. An unreadable ELF is a loud input error (exit `66`), never a silent map-less run. What it feeds and how to produce one: [The symbol map](#the-symbol-map-elf) |
+| `prototypes` | Callee prototypes the ELF cannot state — see [Prototypes](#prototypes-what-the-elf-cannot-state)                                                                                                                                                                           |
 
 Template placeholders: `{{inputPath}}` (candidate source path),
 `{{outputPath}}` (where the object must land), `{{symbol}}` (the function name). An unknown
@@ -83,6 +84,39 @@ Scoring rules, in the project's spirit of never guessing:
   template that injects the project's own headers rejects the probe (C89 duplicate typedef)
   and asmlift then drops both its typedefs and its synthesized declarations for every
   candidate; a template that accepts it keeps both. The verdict is cached per run.
+
+## Prototypes: what the ELF cannot state
+
+A DWARF signature exists only for a function the compiler **compiled**. A callee still written in
+assembly has none, so the frontend falls back to counting live argument registers and guesses the
+arity — which inflates the call and keeps otherwise-dead values alive to the exit block. On one
+measured klonoa function a single wrong callee arity is worth **63 objdiff points**.
+
+State it in the config and every run gets it, including a repro script someone else pastes:
+
+```yaml
+tools:
+  asmlift:
+    prototypes:
+      thunk_HeapFree: { params: 1 }
+      DrawSprite: { params: [u8, s32, 'void *'], returnsVoid: true }
+```
+
+`params` is either a bare arity (`1`) or the typed list a header extraction produces — asmlift reads
+its **length** for the call-site arity today, and keeping the types lets a later pass pin each
+argument's width. `returnsVoid` belongs to the function under decompilation, so a trailing `bx lr`
+does not surface a meaningless return value.
+
+Three sources, each overriding the one below it:
+
+1. `--proto <file.json>` — the same table, per invocation
+2. `tools.asmlift.prototypes`
+3. the `elf`'s own DWARF signatures
+
+Both hand-written channels are **validated and refused loudly** (exit `65` for the config, `64` for
+`--proto`), naming every bad entry. This matters more than it looks: a malformed `params` makes
+asmlift fall back to the register heuristic, so an accepted-but-wrong table would decompile at a
+guessed arity with nothing to say so. A misspelled `returnVoid` is refused for the same reason.
 
 ## The symbol map: `elf`
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -7,6 +7,7 @@
 // enhancement, never required. One deliberate choice: on an ambiguous platform
 // (n64 ⇒ ido7.1, gcc2.7.2kmc or gcc2.7.2) asmlift DECLINES naming the candidates instead of falling back
 // to a generic default — per the cardinal rule, a guessed compiler mis-scores candidates.
+import type { Prototypes } from '@asmlift/core/proto';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import YAML from 'yaml';
@@ -25,6 +26,12 @@ export interface AsmliftToolConfig {
    *  names from `.symtab`, declaration shapes from the linked-in DWARF types-sidecar when
    *  present. Absent ⇒ no symbol map (today's behavior). */
   elf?: string;
+  /** callee prototypes the ELF cannot state. A DWARF signature exists only for a function the
+   *  compiler COMPILED, so a callee still written in assembly has none and the frontend falls back
+   *  to counting argument registers — worth 63 objdiff points on one measured klonoa function.
+   *  `--proto` says the same thing, but only on the command line, where no published repro script
+   *  carries it. Merged UNDER `--proto`, and over the ELF's own signatures. */
+  prototypes?: Prototypes;
 }
 
 export interface DecompVersion {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -21,7 +21,7 @@ import { FrontendUnsupportedError } from '@asmlift/core/frontend/errors';
 import { VerifyError } from '@asmlift/core/ir/verify';
 import type { LanguageBackend } from '@asmlift/core/l3/ast';
 import { type OnGap, decompile } from '@asmlift/core/pipeline';
-import type { Prototypes } from '@asmlift/core/proto';
+import { type Prototypes, validatePrototypes } from '@asmlift/core/proto';
 import { RaiseUnsupportedError } from '@asmlift/core/raise/errors';
 import { StructureError } from '@asmlift/core/structure/structure';
 import { type SymbolMap, asIfUndecompiled } from '@asmlift/core/symbols';
@@ -75,6 +75,7 @@ Gaps are annotated in-source as ASMLIFT_ERROR markers, diagnostics on stderr.
   --asm-data       for text input: objdump -s -r -t dump of the source object
                    (jump tables, anonymous constants)
   --proto          callee prototypes JSON, e.g. {"sym":{"params":2|["u8","s32"]}}
+                   (merged OVER tools.asmlift.prototypes in decomp.yaml)
 
 Exit codes: 0 clean/match · 1 gaps/declined/nonmatch · 64 usage · 66 unreadable input.
 Full reference (flags, decomp.yaml integration): the @asmlift/cli README.`;
@@ -139,6 +140,7 @@ export async function runCli(
   // tools.asmlift payload (compile command, objdump override).
   let toolCfg: AsmliftToolConfig | undefined;
   let configDir: string | undefined;
+  let configPath: string | undefined;
   let targetKey: string;
   let targetTrace = '';
   try {
@@ -146,6 +148,7 @@ export async function runCli(
     const loaded = loadDecompConfig(flags.get('config') as string | undefined, startDir);
     toolCfg = loaded?.config.tools?.asmlift;
     configDir = loaded ? dirname(loaded.path) : undefined;
+    configPath = loaded?.path;
     const res = resolveTarget(flags.get('target') as string | undefined, loaded);
     if ('error' in res) {
       return usage(res.error);
@@ -238,15 +241,27 @@ export async function runCli(
     // one combined objdump text carries all three tables (symbols, relocs, contents)
     asmData = parseAsmData(dump, dump, dump, true);
   }
+  // Two channels for the same table, and `--proto` wins per entry: the flag is what the user has
+  // in front of them, the config is what the project ships. Both are hand-written, so both are
+  // validated — `protoArity` falls back to the arg-register heuristic on a malformed `params`, and
+  // a table accepted silently would decompile at a guessed arity with nothing to say so.
   let prototypes: Prototypes | undefined;
+  if (toolCfg?.prototypes !== undefined) {
+    const problems = validatePrototypes(toolCfg.prototypes);
+    if (problems.length) {
+      return {
+        code: 65,
+        stdout: '',
+        stderr: `asmlift: tools.asmlift.prototypes in ${configPath}:\n${problems.map((p) => `  ${p}\n`).join('')}`,
+      };
+    }
+    prototypes = { ...toolCfg.prototypes };
+  }
   const protoFlag = flags.get('proto') as string | undefined;
   if (protoFlag !== undefined) {
+    let parsed: unknown;
     try {
-      const parsed: unknown = JSON.parse(readFileSync(resolve(protoFlag), 'utf8'));
-      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-        return usage('--proto must be a JSON object: {"sym": {"params": N | ["u8", ...], "returnsVoid": true}, ...}');
-      }
-      prototypes = parsed as Prototypes;
+      parsed = JSON.parse(readFileSync(resolve(protoFlag), 'utf8'));
     } catch (e) {
       return {
         code: 66,
@@ -254,6 +269,11 @@ export async function runCli(
         stderr: `asmlift: cannot read --proto file: ${e instanceof Error ? e.message : e}\n`,
       };
     }
+    const problems = validatePrototypes(parsed);
+    if (problems.length) {
+      return usage(`--proto: ${problems.join('; ')}`);
+    }
+    prototypes = { ...prototypes, ...(parsed as Prototypes) };
   }
 
   // tools.asmlift.elf → the project's symbol map (names + declaration shapes). Explicit

--- a/packages/cli/test/offline/config.test.ts
+++ b/packages/cli/test/offline/config.test.ts
@@ -120,3 +120,62 @@ test('CLI: --score-against with a missing object is exit 66; bad compile templat
   expect(badTemplate.code).toBe(64);
   expect(badTemplate.stderr).toContain('{{inputPath}} and {{outputPath}}');
 });
+
+// tools.asmlift.prototypes — the channel for an arity the project's ELF cannot state. A DWARF
+// signature exists only for a function the compiler COMPILED, so a callee still in assembly has
+// none and the frontend counts argument registers instead.
+const CALLER_ASM =
+  '\t.globl\tf\n\t.thumb_func\nf:\n\tpush\t{lr}\n\tmov\tr0, #1\n\tmov\tr1, #2\n\tmov\tr2, #3\n' +
+  '\tbl\tcallee\n\tpop\t{r1}\n\tbx\tr1\n';
+
+const withConfig = (yaml: string) => {
+  const root = tmp();
+  writeFileSync(join(root, 'decomp.yaml'), yaml);
+  const file = join(root, 'f.s');
+  writeFileSync(file, CALLER_ASM);
+  return { root, file };
+};
+
+test('CLI: tools.asmlift.prototypes gives a callee its declared arity', async () => {
+  const bare = withConfig('platform: gba\n');
+  // without it the frontend guesses from the argument registers that are live
+  expect((await runCli([bare.file])).stdout).toContain('callee(1, 2, 3)');
+
+  const { file } = withConfig('platform: gba\ntools:\n  asmlift:\n    prototypes:\n      callee: { params: 1 }\n');
+  const r = await runCli([file]);
+  expect(r.code).toBe(0);
+  expect(r.stdout).toContain('callee(1)');
+});
+
+test('CLI: --proto wins per entry over the config, and the two merge', async () => {
+  const { root, file } = withConfig(
+    'platform: gba\ntools:\n  asmlift:\n    prototypes:\n      callee: { params: 3 }\n      other: { params: 1 }\n',
+  );
+  const proto = join(root, 'p.json');
+  writeFileSync(proto, JSON.stringify({ callee: { params: 1 } }));
+  const r = await runCli([file, '--proto', proto]);
+  expect(r.stdout).toContain('callee(1)'); // the flag's entry, not the config's 3
+});
+
+test('CLI: a malformed prototype table is REFUSED, naming the file and every bad entry', async () => {
+  // `protoArity` falls back to the arg-register heuristic on a bad `params`, so accepting this
+  // would decompile at a guessed arity with nothing said about it.
+  const { file } = withConfig(
+    'platform: gba\ntools:\n  asmlift:\n    prototypes:\n      callee: { params: "1" }\n      other: { returnVoid: true }\n',
+  );
+  const r = await runCli([file]);
+  expect(r.code).toBe(65);
+  expect(r.stderr).toContain('decomp.yaml');
+  expect(r.stderr).toContain('callee: "params" must be a non-negative integer');
+  expect(r.stderr).toContain('other: unknown key "returnVoid"');
+  expect(r.stdout).toBe('');
+});
+
+test('CLI: a malformed --proto file is a usage error, not a silent guess', async () => {
+  const { root, file } = withConfig('platform: gba\n');
+  const proto = join(root, 'p.json');
+  writeFileSync(proto, JSON.stringify({ callee: { params: '1' } }));
+  const r = await runCli([file, '--proto', proto]);
+  expect(r.code).toBe(64);
+  expect(r.stderr).toContain('"params" must be a non-negative integer');
+});

--- a/packages/core/src/proto.ts
+++ b/packages/core/src/proto.ts
@@ -27,6 +27,45 @@ export interface FnProto {
 /** symbol → prototype. The function under decompilation and its callees share one table. */
 export type Prototypes = Record<string, FnProto>;
 
+/** Problems with an UNTRUSTED prototype table — empty when it is well formed.
+ *
+ *  A `Prototypes` reaching asmlift by hand (a `--proto` JSON file, a `decomp.yaml` key) is the one
+ *  case where `protoArity`'s fallback is the wrong behaviour. Falling back to the arg-register
+ *  heuristic is right when `params` is OMITTED; on `params: "2"` it silently decompiles at a
+ *  guessed arity, and the user who wrote the table has no way to tell. Same for a misspelled
+ *  `returnVoid`, which would simply do nothing. Reporting lets the caller refuse instead.
+ *
+ *  Messages name the symbol so a table with several entries points at the broken one. */
+export function validatePrototypes(value: unknown): string[] {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return ['must be an object mapping a symbol name to its prototype'];
+  }
+  const problems: string[] = [];
+  for (const [sym, proto] of Object.entries(value)) {
+    if (typeof proto !== 'object' || proto === null || Array.isArray(proto)) {
+      problems.push(`${sym}: must be an object, e.g. {"params": 2}`);
+      continue;
+    }
+    for (const key of Object.keys(proto)) {
+      if (key !== 'params' && key !== 'returnsVoid') {
+        problems.push(`${sym}: unknown key "${key}" (expected "params" or "returnsVoid")`);
+      }
+    }
+    const { params, returnsVoid } = proto as { params?: unknown; returnsVoid?: unknown };
+    if (params !== undefined) {
+      const countOk = typeof params === 'number' && Number.isInteger(params) && params >= 0;
+      const listOk = Array.isArray(params) && params.every((t) => typeof t === 'string');
+      if (!countOk && !listOk) {
+        problems.push(`${sym}: "params" must be a non-negative integer or a list of type strings`);
+      }
+    }
+    if (returnsVoid !== undefined && typeof returnsVoid !== 'boolean') {
+      problems.push(`${sym}: "returnsVoid" must be a boolean`);
+    }
+  }
+  return problems;
+}
+
 /** The call-site arity a proto declares, normalizing the count form (`2`) and the typed-list
  *  form (`["u8", "s32"]`) to one number. `undefined` when `params` is omitted — the caller then
  *  falls back to its arg-register heuristic. Reading a typed list as its length is what lets a

--- a/packages/core/test/proto-validate.test.ts
+++ b/packages/core/test/proto-validate.test.ts
@@ -1,0 +1,62 @@
+// validatePrototypes — the guard on a HAND-WRITTEN prototype table (`--proto` JSON, the
+// `decomp.yaml` key). `protoArity` falls back to the arg-register heuristic on a malformed
+// `params`, which is right for an omitted one and silent for a mistyped one, so the table has to
+// be refused before it gets there.
+import { describe, expect, test } from 'vitest';
+
+import { protoArity, validatePrototypes } from '../src/proto';
+
+describe('accepts every form the type allows', () => {
+  test.each([
+    ['a bare arity', { f: { params: 2 } }],
+    ['a typed list', { f: { params: ['u8', 's32'] } }],
+    ['zero parameters', { f: { params: 0 } }],
+    ['returnsVoid alone', { f: { returnsVoid: true } }],
+    ['both', { f: { params: ['u8'], returnsVoid: false } }],
+    ['an empty proto — the frontend then guesses, which is a choice not a mistake', { f: {} }],
+    ['an empty table', {}],
+  ])('%s', (_label, table) => {
+    expect(validatePrototypes(table)).toEqual([]);
+  });
+});
+
+describe('refuses what would otherwise decompile at a guessed arity', () => {
+  test('a stringly-typed count — the case protoArity silently drops', () => {
+    expect(protoArity({ params: '2' } as never)).toBeUndefined(); // silent today
+    expect(validatePrototypes({ f: { params: '2' } })).toEqual([
+      'f: "params" must be a non-negative integer or a list of type strings',
+    ]);
+  });
+
+  test('a misspelled key, which would simply do nothing', () => {
+    expect(validatePrototypes({ f: { returnVoid: true } })).toEqual([
+      'f: unknown key "returnVoid" (expected "params" or "returnsVoid")',
+    ]);
+  });
+
+  test.each([
+    ['a negative arity', { f: { params: -1 } }],
+    ['a fractional arity', { f: { params: 1.5 } }],
+    ['a list holding a non-string', { f: { params: ['u8', 4] } }],
+    ['a non-boolean returnsVoid', { f: { returnsVoid: 'yes' } }],
+    ['a proto that is not an object', { f: 2 }],
+    ['a proto that is an array', { f: [] }],
+  ])('%s', (_label, table) => {
+    expect(validatePrototypes(table).length).toBeGreaterThan(0);
+  });
+
+  test.each([
+    ['null', null],
+    ['an array', [{ f: { params: 1 } }]],
+    ['a scalar', 'f=2'],
+  ])('the table itself being %s', (_label, table) => {
+    expect(validatePrototypes(table)).toEqual(['must be an object mapping a symbol name to its prototype']);
+  });
+
+  test('every broken entry is named, not just the first', () => {
+    const problems = validatePrototypes({ a: { params: '1' }, b: { returnsVoid: 1 }, c: { params: 3 } });
+    expect(problems).toHaveLength(2);
+    expect(problems[0]).toContain('a:');
+    expect(problems[1]).toContain('b:');
+  });
+});


### PR DESCRIPTION
A DWARF signature exists only for a function the compiler **compiled**. A callee still written in assembly has none, so the frontend falls back to counting live argument registers and guesses — which inflates the call and keeps otherwise-dead values alive to the exit block.

On klonoa's `LoadBGTilemapData`, one wrong callee arity (`thunk_HeapFree`) is worth **53 objdiff points — 637 → 584**, measured through the config alone.

Until now the only channel was `--proto` on the command line, which **no published repro script carries**. The project that knows the arity had no way to state it.

```yaml
tools:
  asmlift:
    prototypes:
      thunk_HeapFree: { params: 1 }
      DrawSprite: { params: [u8, s32, "void *"], returnsVoid: true }
```

Precedence, each overriding the one below: `--proto` → `tools.asmlift.prototypes` → the ELF's DWARF. The two hand-written channels merge per entry.

## The part that isn't just a config key

Both hand-written channels are now **validated and refused loudly**.

`protoArity` deliberately falls back to the arg-register heuristic on a malformed `params` — correct when `params` is *omitted*, silent when it's *mistyped*. So this:

```yaml
prototypes:
  callee: { params: "1" }   # string, not number
```

would have decompiled at a guessed arity with nothing said about it, and a misspelled `returnVoid` would have done nothing at all. Exactly the failure mode this project treats as worse than an error.

`validatePrototypes` lives in core so both channels share one definition, and names every bad entry rather than the first. Config refuses with exit `65`, `--proto` with `64` — and `--proto` previously accepted **any** JSON object whatsoever.

## Deliberately not done

klonoa's own `decomp.yaml` is **not** changed here. Adding the entry there would move the `kleod:*` benchmark rows, which is a separate decision from shipping the mechanism.

Gates: `npx vitest run` 1317, `pnpm bench regression` 0 lost / 0 gained / 0 flips, typecheck clean, `eslint apps packages` 0 errors. Found during the `LoadBGTilemapData` gap attribution (Finding 3).
