### PR TITLE
Validate --proto instead of ignoring what it cannot read

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -101,22 +101,6 @@ compiler's codegen, so the named spelling and its raw-address sibling are both e
 `--score-against`'s byte-diff picks the winner — a tie goes to the name. Unmapped addresses
 (MMIO registers, unnamed cells) keep the honest cast spelling.
 
-### What the ELF cannot tell you
-
-A DWARF signature exists only for a function the compiler **compiled**. A callee still written in
-assembly has none, so the frontend counts live argument registers instead — and when the compiler
-happened to leave values in the next ones, it over-counts. Nothing in the register file can say
-otherwise, so `--proto` is how you state the arity you know:
-
-```
-echo '{"thunk_HeapFree": {"params": 1}}' > proto.json
-asmlift fn.s --config decomp.yaml --score-against build/x.o --proto proto.json
-```
-
-On one klonoa function that single arity is worth **53 objdiff points**. A malformed table is
-refused rather than ignored: `params: "1"` would otherwise fall back to the guessed arity, which is
-the same 53 points with nothing said about it.
-
 ### Producing the ELF
 
 asmlift only cares which sections end up in the one file `elf:` names, so mix and match:
@@ -140,6 +124,25 @@ A worked example with all three channels is the Klonoa decomp's
 [`asmlift-elf` target](https://github.com/Dream-Atelier/kl-eod-decomp/blob/main/Makefile):
 agbcc `-g` for shapes and signatures, plus a macro-only sidecar graft; the project's default
 `make` sha-verifies the same link.
+
+### When there is no signature: `--proto`
+
+A callee still written in assembly was never compiled from C, so no `-g` build produces a signature
+for it. The frontend then counts the contiguous argument registers holding a value at the call — an
+intervening call disproves some of those and they are dropped, but a value the compiler merely left
+behind in the next register reads as an argument, and nothing in the register file distinguishes the
+two. The call comes out with arguments the callee never took.
+
+`--proto` is how you state the arity you know:
+
+```
+echo '{"AsmCallee": {"params": 1}}' > proto.json
+asmlift fn.s --target agbcc --proto proto.json
+```
+
+Measured on one real function, a single callee's arity is worth 53 objdiff points. A malformed
+entry is refused (exit `64`) rather than ignored — `params: "1"` would otherwise read as an omitted
+`params` and fall back to the same guess, costing those points with nothing said about it.
 
 ## Using it as a library
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,16 +37,16 @@ usage: asmlift <file.s|file.asm|file.o|-> [--target <agbcc|ido7.1|gcc2.7.2kmc|gc
                 [--asm-data <dump.txt>] [--proto <proto.json>]
 ```
 
-| Flag              | Meaning                                                                                                                                                                                                                                  |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--target`        | Which ISA+compiler pair produced the input. Optional inside a `decomp.yaml` project (resolution: flag > `tools.asmlift.target` > `platform`, traced on stderr; an ambiguous platform like `n64` asks you to choose rather than guessing) |
-| `--name`          | The function to decompile when the input holds several (default: auto-detected)                                                                                                                                                          |
-| `--backend`       | Output language: `c` (default) or `pascal`                                                                                                                                                                                               |
-| `--strict`        | Fail on any gap instead of annotating. Default: gaps become in-source `ASMLIFT_ERROR` markers plus stderr diagnostics                                                                                                                    |
-| `--config`        | Explicit `decomp.yaml` path (default: nearest ancestor of the input file)                                                                                                                                                                |
-| `--score-against` | Compile the output (and every ranked candidate) and objdiff-score it against this object. Implies strict; the per-candidate score table goes to stderr                                                                                   |
-| `--asm-data`      | For text input: an `objdump -s -r -t` dump of the object the asm came from, supplying the data sections text lacks (jump tables, anonymous constants). Object-file input extracts this itself and does not take the flag                 |
-| `--proto`         | Function prototypes as JSON (`{"sym": {"params": N \| ["u8", ...], "returnsVoid": true}, ...}`): a callee's params drives its call-argument recovery; the decompiled function's own entry supplies its void-ness                         |
+| Flag              | Meaning                                                                                                                                                                                                                                                                                                    |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--target`        | Which ISA+compiler pair produced the input. Optional inside a `decomp.yaml` project (resolution: flag > `tools.asmlift.target` > `platform`, traced on stderr; an ambiguous platform like `n64` asks you to choose rather than guessing)                                                                   |
+| `--name`          | The function to decompile when the input holds several (default: auto-detected)                                                                                                                                                                                                                            |
+| `--backend`       | Output language: `c` (default) or `pascal`                                                                                                                                                                                                                                                                 |
+| `--strict`        | Fail on any gap instead of annotating. Default: gaps become in-source `ASMLIFT_ERROR` markers plus stderr diagnostics                                                                                                                                                                                      |
+| `--config`        | Explicit `decomp.yaml` path (default: nearest ancestor of the input file)                                                                                                                                                                                                                                  |
+| `--score-against` | Compile the output (and every ranked candidate) and objdiff-score it against this object. Implies strict; the per-candidate score table goes to stderr                                                                                                                                                     |
+| `--asm-data`      | For text input: an `objdump -s -r -t` dump of the object the asm came from, supplying the data sections text lacks (jump tables, anonymous constants). Object-file input extracts this itself and does not take the flag                                                                                   |
+| `--proto`         | Function prototypes as JSON (`{"sym": {"params": N \| ["u8", ...], "returnsVoid": true}, ...}`): a callee's params drives its call-argument recovery; the decompiled function's own entry supplies its void-ness. Every entry is validated — a malformed one is refused (exit `64`), never quietly ignored |
 
 Exit codes: `0` clean (or byte-exact match when scoring) · `1` gaps, declined, or nonmatch —
 the stderr tag says which (`[declined]` = principled refusal, `[internal error]` = bug) ·
@@ -100,6 +100,22 @@ Every map fact is a ranked lever, never an override: naming a global can change 
 compiler's codegen, so the named spelling and its raw-address sibling are both enumerated, and
 `--score-against`'s byte-diff picks the winner — a tie goes to the name. Unmapped addresses
 (MMIO registers, unnamed cells) keep the honest cast spelling.
+
+### What the ELF cannot tell you
+
+A DWARF signature exists only for a function the compiler **compiled**. A callee still written in
+assembly has none, so the frontend counts live argument registers instead — and when the compiler
+happened to leave values in the next ones, it over-counts. Nothing in the register file can say
+otherwise, so `--proto` is how you state the arity you know:
+
+```
+echo '{"thunk_HeapFree": {"params": 1}}' > proto.json
+asmlift fn.s --config decomp.yaml --score-against build/x.o --proto proto.json
+```
+
+On one klonoa function that single arity is worth **53 objdiff points**. A malformed table is
+refused rather than ignored: `params: "1"` would otherwise fall back to the guessed arity, which is
+the same 53 points with nothing said about it.
 
 ### Producing the ELF
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -251,8 +251,8 @@ export async function runCli(
         stderr: `asmlift: cannot read --proto file: ${e instanceof Error ? e.message : e}\n`,
       };
     }
-    // Every entry, not just the envelope: `protoArity` falls back to the arg-register heuristic on
-    // a malformed `params`, so a table accepted here decompiles at a GUESSED arity and says nothing.
+    // Every entry, not just the envelope — an unreadable `params` decompiles at a guessed arity
+    // rather than failing (see validatePrototypes).
     const problems = validatePrototypes(parsed);
     if (problems.length) {
       return usage(`--proto ${protoFlag}:\n${problems.map((p) => `  ${p}`).join('\n')}`);

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -21,7 +21,7 @@ import { FrontendUnsupportedError } from '@asmlift/core/frontend/errors';
 import { VerifyError } from '@asmlift/core/ir/verify';
 import type { LanguageBackend } from '@asmlift/core/l3/ast';
 import { type OnGap, decompile } from '@asmlift/core/pipeline';
-import type { Prototypes } from '@asmlift/core/proto';
+import { type Prototypes, validatePrototypes } from '@asmlift/core/proto';
 import { RaiseUnsupportedError } from '@asmlift/core/raise/errors';
 import { StructureError } from '@asmlift/core/structure/structure';
 import { type SymbolMap, asIfUndecompiled } from '@asmlift/core/symbols';
@@ -241,12 +241,9 @@ export async function runCli(
   let prototypes: Prototypes | undefined;
   const protoFlag = flags.get('proto') as string | undefined;
   if (protoFlag !== undefined) {
+    let parsed: unknown;
     try {
-      const parsed: unknown = JSON.parse(readFileSync(resolve(protoFlag), 'utf8'));
-      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-        return usage('--proto must be a JSON object: {"sym": {"params": N | ["u8", ...], "returnsVoid": true}, ...}');
-      }
-      prototypes = parsed as Prototypes;
+      parsed = JSON.parse(readFileSync(resolve(protoFlag), 'utf8'));
     } catch (e) {
       return {
         code: 66,
@@ -254,6 +251,13 @@ export async function runCli(
         stderr: `asmlift: cannot read --proto file: ${e instanceof Error ? e.message : e}\n`,
       };
     }
+    // Every entry, not just the envelope: `protoArity` falls back to the arg-register heuristic on
+    // a malformed `params`, so a table accepted here decompiles at a GUESSED arity and says nothing.
+    const problems = validatePrototypes(parsed);
+    if (problems.length) {
+      return usage(`--proto ${protoFlag}:\n${problems.map((p) => `  ${p}`).join('\n')}`);
+    }
+    prototypes = parsed as Prototypes;
   }
 
   // tools.asmlift.elf → the project's symbol map (names + declaration shapes). Explicit

--- a/packages/cli/test/offline/cli.test.ts
+++ b/packages/cli/test/offline/cli.test.ts
@@ -1,6 +1,7 @@
 // CLI surface tests — offline (no toolchain: decompile-only via runCli, no compile/score).
 // The corpus fixtures live in @asmlift/core's test dir; read cross-package by path.
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vitest';
 
@@ -76,4 +77,53 @@ test('gaps exit 1 with markers; strict declines are tagged, not internal', async
   expect(strict.code).toBe(1);
   expect(strict.stderr).toContain('[declined]');
   expect(strict.stderr).not.toContain('[internal error]');
+});
+
+// --proto validation. `protoArity` falls back to the arg-register heuristic on a malformed
+// `params`, which is right for an OMITTED one and silent for a mistyped one — so a table that is
+// accepted here decompiles at a guessed arity with nothing said about it. Measured on klonoa's
+// LoadBGTilemapData, the difference between a correct table and a mistyped one is 53 objdiff
+// points and no output whatsoever.
+const protoFile = (table: unknown) => {
+  const dir = mkdtempSync(join(tmpdir(), 'asmlift-proto-'));
+  const p = join(dir, 'p.json');
+  writeFileSync(p, typeof table === 'string' ? table : JSON.stringify(table));
+  return p;
+};
+
+test('--proto: a well-formed table is accepted in both param spellings', async () => {
+  for (const params of [1, ['u8']]) {
+    const r = await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', protoFile({ callee: { params } }));
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+  }
+});
+
+test('--proto: a mistyped params is REFUSED, not silently ignored', async () => {
+  const r = await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', protoFile({ callee: { params: '1' } }));
+  expect(r.code).toBe(64);
+  expect(r.stderr).toContain('callee: "params" must be a non-negative integer');
+  expect(r.stdout).toBe('');
+});
+
+test('--proto: a misspelled key is REFUSED — it would otherwise do nothing at all', async () => {
+  const r = await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', protoFile({ callee: { paramz: 1 } }));
+  expect(r.code).toBe(64);
+  expect(r.stderr).toContain('unknown key "paramz"');
+});
+
+test('--proto: every bad entry is named, and the file path is in the message', async () => {
+  const p = protoFile({ a: { params: -1 }, b: { returnsVoid: 'yes' } });
+  const r = await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', p);
+  expect(r.stderr).toContain(p);
+  expect(r.stderr).toContain('a: "params"');
+  expect(r.stderr).toContain('b: "returnsVoid"');
+});
+
+test('--proto: unreadable file and non-object JSON stay distinguishable (66 vs 64)', async () => {
+  const missing = await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', join(tmpdir(), 'nope-asmlift.json'));
+  expect(missing.code).toBe(66);
+  const scalar = await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', protoFile('42'));
+  expect(scalar.code).toBe(64);
+  expect(scalar.stderr).toContain('must be an object mapping a symbol name to its prototype');
 });

--- a/packages/cli/test/offline/cli.test.ts
+++ b/packages/cli/test/offline/cli.test.ts
@@ -79,11 +79,9 @@ test('gaps exit 1 with markers; strict declines are tagged, not internal', async
   expect(strict.stderr).not.toContain('[internal error]');
 });
 
-// --proto validation. `protoArity` falls back to the arg-register heuristic on a malformed
-// `params`, which is right for an OMITTED one and silent for a mistyped one — so a table that is
-// accepted here decompiles at a guessed arity with nothing said about it. Measured on klonoa's
-// LoadBGTilemapData, the difference between a correct table and a mistyped one is 53 objdiff
-// points and no output whatsoever.
+// --proto validation, at the CLI surface: which exit code each malformed table earns, and that an
+// unreadable file stays distinguishable from an unusable one. Why the refusals exist at all is
+// validatePrototypes' own contract (core/proto.ts) and is pinned there.
 const protoFile = (table: unknown) => {
   const dir = mkdtempSync(join(tmpdir(), 'asmlift-proto-'));
   const p = join(dir, 'p.json');

--- a/packages/core/src/proto.ts
+++ b/packages/core/src/proto.ts
@@ -27,6 +27,45 @@ export interface FnProto {
 /** symbol → prototype. The function under decompilation and its callees share one table. */
 export type Prototypes = Record<string, FnProto>;
 
+/** Problems with an UNTRUSTED prototype table — empty when it is well formed.
+ *
+ *  A `Prototypes` written by hand — the CLI's `--proto` JSON — is the one case where `protoArity`'s
+ *  fallback is the wrong behaviour. Falling back to the arg-register
+ *  heuristic is right when `params` is OMITTED; on `params: "2"` it silently decompiles at a
+ *  guessed arity, and the user who wrote the table has no way to tell. Same for a misspelled
+ *  `returnVoid`, which would simply do nothing. Reporting lets the caller refuse instead.
+ *
+ *  Messages name the symbol so a table with several entries points at the broken one. */
+export function validatePrototypes(value: unknown): string[] {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return ['must be an object mapping a symbol name to its prototype'];
+  }
+  const problems: string[] = [];
+  for (const [sym, proto] of Object.entries(value)) {
+    if (typeof proto !== 'object' || proto === null || Array.isArray(proto)) {
+      problems.push(`${sym}: must be an object, e.g. {"params": 2}`);
+      continue;
+    }
+    for (const key of Object.keys(proto)) {
+      if (key !== 'params' && key !== 'returnsVoid') {
+        problems.push(`${sym}: unknown key "${key}" (expected "params" or "returnsVoid")`);
+      }
+    }
+    const { params, returnsVoid } = proto as { params?: unknown; returnsVoid?: unknown };
+    if (params !== undefined) {
+      const countOk = typeof params === 'number' && Number.isInteger(params) && params >= 0;
+      const listOk = Array.isArray(params) && params.every((t) => typeof t === 'string');
+      if (!countOk && !listOk) {
+        problems.push(`${sym}: "params" must be a non-negative integer or a list of type strings`);
+      }
+    }
+    if (returnsVoid !== undefined && typeof returnsVoid !== 'boolean') {
+      problems.push(`${sym}: "returnsVoid" must be a boolean`);
+    }
+  }
+  return problems;
+}
+
 /** The call-site arity a proto declares, normalizing the count form (`2`) and the typed-list
  *  form (`["u8", "s32"]`) to one number. `undefined` when `params` is omitted — the caller then
  *  falls back to its arg-register heuristic. Reading a typed list as its length is what lets a

--- a/packages/core/src/proto.ts
+++ b/packages/core/src/proto.ts
@@ -27,15 +27,28 @@ export interface FnProto {
 /** symbol → prototype. The function under decompilation and its callees share one table. */
 export type Prototypes = Record<string, FnProto>;
 
-/** Problems with an UNTRUSTED prototype table — empty when it is well formed.
+/** The call-site arity a proto declares, normalizing the count form (`2`) and the typed-list
+ *  form (`["u8", "s32"]`) to one number. `undefined` when `params` is omitted — the caller then
+ *  falls back to its arg-register heuristic. Reading a typed list as its length is what lets a
+ *  header-derived proto (`params: ["u8"]`) recover its argument instead of silently dropping it. */
+export function protoArity(p: FnProto | undefined): number | undefined {
+  if (typeof p?.params === 'number') {
+    return p.params;
+  }
+  if (Array.isArray(p?.params)) {
+    return p.params.length;
+  }
+  // Omitted OR malformed (e.g. a bare `"u8"` string reaching the untyped CLI `--proto` JSON):
+  // fall back to the frontend's arg-register heuristic rather than misread a string's `.length`.
+  return undefined;
+}
+
+/** Problems with a HAND-WRITTEN prototype table — empty when it is well formed.
  *
- *  A `Prototypes` written by hand — the CLI's `--proto` JSON — is the one case where `protoArity`'s
- *  fallback is the wrong behaviour. Falling back to the arg-register
- *  heuristic is right when `params` is OMITTED; on `params: "2"` it silently decompiles at a
- *  guessed arity, and the user who wrote the table has no way to tell. Same for a misspelled
- *  `returnVoid`, which would simply do nothing. Reporting lets the caller refuse instead.
- *
- *  Messages name the symbol so a table with several entries points at the broken one. */
+ *  `protoArity` above falls back to the arg-register heuristic on a `params` it cannot read, which
+ *  is right when `params` is omitted and silent when it is mistyped: `params: "2"` then decompiles
+ *  at a guessed arity, and a misspelled `returnsVoid` does nothing at all. Neither is visible in
+ *  the output, so a table that came from outside is checked before it reaches either. */
 export function validatePrototypes(value: unknown): string[] {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     return ['must be an object mapping a symbol name to its prototype'];
@@ -64,22 +77,6 @@ export function validatePrototypes(value: unknown): string[] {
     }
   }
   return problems;
-}
-
-/** The call-site arity a proto declares, normalizing the count form (`2`) and the typed-list
- *  form (`["u8", "s32"]`) to one number. `undefined` when `params` is omitted — the caller then
- *  falls back to its arg-register heuristic. Reading a typed list as its length is what lets a
- *  header-derived proto (`params: ["u8"]`) recover its argument instead of silently dropping it. */
-export function protoArity(p: FnProto | undefined): number | undefined {
-  if (typeof p?.params === 'number') {
-    return p.params;
-  }
-  if (Array.isArray(p?.params)) {
-    return p.params.length;
-  }
-  // Omitted OR malformed (e.g. a bare `"u8"` string reaching the untyped CLI `--proto` JSON):
-  // fall back to the frontend's arg-register heuristic rather than misread a string's `.length`.
-  return undefined;
 }
 
 /** The C type spelling for one declared parameter/return, or null when the facts do not

--- a/packages/core/test/proto-validate.test.ts
+++ b/packages/core/test/proto-validate.test.ts
@@ -1,7 +1,6 @@
-// validatePrototypes — the guard on a HAND-WRITTEN prototype table (`--proto` JSON, the
-// `decomp.yaml` key). `protoArity` falls back to the arg-register heuristic on a malformed
-// `params`, which is right for an omitted one and silent for a mistyped one, so the table has to
-// be refused before it gets there.
+// validatePrototypes — the guard on a hand-written prototype table (the CLI's `--proto` JSON).
+// What each refusal is FOR: `protoArity` reads a malformed `params` as an omitted one and falls
+// back to the arg-register heuristic, so anything accepted here decompiles at a guessed arity.
 import { describe, expect, test } from 'vitest';
 
 import { protoArity, validatePrototypes } from '../src/proto';
@@ -22,7 +21,7 @@ describe('accepts every form the type allows', () => {
 
 describe('refuses what would otherwise decompile at a guessed arity', () => {
   test('a stringly-typed count — the case protoArity silently drops', () => {
-    expect(protoArity({ params: '2' } as never)).toBeUndefined(); // silent today
+    expect(protoArity({ params: '2' } as never)).toBeUndefined();
     expect(validatePrototypes({ f: { params: '2' } })).toEqual([
       'f: "params" must be a non-negative integer or a list of type strings',
     ]);

--- a/packages/core/test/proto-validate.test.ts
+++ b/packages/core/test/proto-validate.test.ts
@@ -1,0 +1,62 @@
+// validatePrototypes — the guard on a HAND-WRITTEN prototype table (`--proto` JSON, the
+// `decomp.yaml` key). `protoArity` falls back to the arg-register heuristic on a malformed
+// `params`, which is right for an omitted one and silent for a mistyped one, so the table has to
+// be refused before it gets there.
+import { describe, expect, test } from 'vitest';
+
+import { protoArity, validatePrototypes } from '../src/proto';
+
+describe('accepts every form the type allows', () => {
+  test.each([
+    ['a bare arity', { f: { params: 2 } }],
+    ['a typed list', { f: { params: ['u8', 's32'] } }],
+    ['zero parameters', { f: { params: 0 } }],
+    ['returnsVoid alone', { f: { returnsVoid: true } }],
+    ['both', { f: { params: ['u8'], returnsVoid: false } }],
+    ['an empty proto — the frontend then guesses, which is a choice not a mistake', { f: {} }],
+    ['an empty table', {}],
+  ])('%s', (_label, table) => {
+    expect(validatePrototypes(table)).toEqual([]);
+  });
+});
+
+describe('refuses what would otherwise decompile at a guessed arity', () => {
+  test('a stringly-typed count — the case protoArity silently drops', () => {
+    expect(protoArity({ params: '2' } as never)).toBeUndefined(); // silent today
+    expect(validatePrototypes({ f: { params: '2' } })).toEqual([
+      'f: "params" must be a non-negative integer or a list of type strings',
+    ]);
+  });
+
+  test('a misspelled key, which would simply do nothing', () => {
+    expect(validatePrototypes({ f: { returnVoid: true } })).toEqual([
+      'f: unknown key "returnVoid" (expected "params" or "returnsVoid")',
+    ]);
+  });
+
+  test.each([
+    ['a negative arity', { f: { params: -1 } }],
+    ['a fractional arity', { f: { params: 1.5 } }],
+    ['a list holding a non-string', { f: { params: ['u8', 4] } }],
+    ['a non-boolean returnsVoid', { f: { returnsVoid: 'yes' } }],
+    ['a proto that is not an object', { f: 2 }],
+    ['a proto that is an array', { f: [] }],
+  ])('%s', (_label, table) => {
+    expect(validatePrototypes(table).length).toBeGreaterThan(0);
+  });
+
+  test.each([
+    ['null', null],
+    ['an array', [{ f: { params: 1 } }]],
+    ['a scalar', 'f=2'],
+  ])('the table itself being %s', (_label, table) => {
+    expect(validatePrototypes(table)).toEqual(['must be an object mapping a symbol name to its prototype']);
+  });
+
+  test('every broken entry is named, not just the first', () => {
+    const problems = validatePrototypes({ a: { params: '1' }, b: { returnsVoid: 1 }, c: { params: 3 } });
+    expect(problems).toHaveLength(2);
+    expect(problems[0]).toContain('a:');
+    expect(problems[1]).toContain('b:');
+  });
+});


### PR DESCRIPTION
Replaces #59, which added a `decomp.yaml` key. That was the wrong shape — re-verifying the issue showed the config key bought nothing.

## What I re-verified

**The 53-point win needs no asmlift change.** `--proto` already delivers it on merged `main`:

```
{"thunk_HeapFree":{"params":1}}    ->  584
(no proto)                          ->  637
```

**And asmlift genuinely cannot infer the arity here.** Three routes, all measured, all closed:

- *The ELF* — no DIE for `thunk_HeapFree` at all. Its name appears **exactly once in the whole file**, in `.symtab`. The project declares it in `src/system.c`, not a header, so the types-sidecar never sees it either.
- *The register file* — I implemented a must-analysis (`defined on every path`, the discipline `trimClobberedCallArgs` already uses) and it changed nothing: the leftover `r1`/`r2`/`r3` really are defined on every path, from a do-while body, with no intervening call. Reverted; no inhabitant.
- *The callee's own code* — `thunk_HeapFree` is a Thumb→ARM interworking veneer (`bx pc / nop / <branch>`). It touches no argument register. Its arity comes from `Free`, which is ARM code one hop further on.

So `--proto` is the right channel, and a config key would have been a second spelling of it.

## What is actually broken

`--proto` checked only that the JSON parsed to an object. Below that it accepted anything — and `protoArity` deliberately falls back to the arg-register heuristic on a malformed `params`, which is correct when `params` is *omitted* and silent when it's *mistyped*:

```
{"thunk_HeapFree":{"params":"1"}}  ->  637   silently
{"thunk_HeapFree":{"paramz":1}}    ->  637   silently
```

53 points between a table that works and one that looks like it does, with nothing said. That's the loud-vs-silent rule, and it needs no new surface to fix.

`validatePrototypes` lives in core beside `protoArity` — one module owns both what the shape is and what a malformed one costs. It names every bad entry rather than the first, and carries the file path.

## Gates

`npx vitest run` 1319 · `pnpm bench run` + `bench regression` **0 lost / 0 missing / 0 gained / 0 flips**, and all 778 rows byte-identical in outcome, score and source · typecheck clean · `eslint apps packages` 0 errors.

(The regression gate on #58/#59 was run without a preceding `bench run`, so it compared stale results. Re-run properly here, and #58 re-verified after the fact — also 0 rows changed.)
