### PR TITLE
Meta-optimisation 1: make the round's measuring instruments the repo's, not each agent's

### DIFF
--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -25,6 +25,12 @@ you looked at this function's diff is a failure, even if the row flips to MATCH.
    with `pnpm bench target <row-id> --out <dir>` so you can iterate without the full harness.
 4. State the baseline in your first user-facing message. Never report progress without a
    before/after pair of real command output.
+5. **Write the ranked repro down verbatim, flags included** — every later measurement (each
+   reviewer's, each remediation's, the PR body's) re-runs *that* command, not one recomposed from
+   memory. The flags are part of the number: a callee still written in assembly has no DWARF
+   signature, so `LoadBGTilemapData` without `--proto '{"thunk_HeapFree":{"params":1}}'` scores
+   578 where the round's baseline is 547 — a plausible number that is comparable to nothing.
+   Quote the candidate and dropped counts beside every ranked score.
 
 ## Phase 1 — Diagnose the gap honestly
 
@@ -82,6 +88,19 @@ Before declaring the branch done: `pnpm bench run` (all tiers) and `pnpm bench r
 lost match blocks the branch.** If a match is lost, either tighten the gate on your lever or drop
 the lever — do not rationalize a trade unless the user explicitly approves it. Report the totals
 (asmlift vs m2c) before and after.
+
+Two things this gate does not catch by itself:
+
+- **The regenerated artifact is the LAST commit on the branch.** `results.json` stamps the commit
+  it was generated at, and every number you publish reads from it — so a commit that touches core,
+  cli, the harness or the dataset after it silently republishes numbers a rule version that no
+  longer exists produced. Regenerate after Phase 5's remediation, and run
+  `scripts/check-artifact-provenance.sh` before opening the PR.
+- **A corpus sweep's configuration is part of its claim.** Sweeping a project's functions with the
+  new rule ON vs OFF proves nothing about the configuration you did not run: with a symbol map
+  every absolute pool constant lifts to a `gaddr`, so a symbol-map sweep is blind to a rule that
+  only fires on raw addresses — which is exactly how a branch's own 464-function validation missed
+  a match it was losing. Run both, and say which sweep each count came from.
 
 ## Phase 5 — Adversarial round
 
@@ -163,3 +182,8 @@ this phase is the only pass they get.
    the next step would be. Do not force an ad-hoc hack to close the last few bytes.
 5. **Numbers come from commands.** Never state a diff number, a match, or a regression you did not
    just observe in tool output that you show or quote.
+6. **Never explain a discrepancy — re-run it.** A number that disagrees with this round's own
+   chain is a broken measurement until the Phase 0 command reproduces it. Running *a* command is
+   not enough to make a number real: a round once published 557 and 578 for a function whose
+   baseline was 547 and rationalised the gap as unpinned build objects, when the cause was a
+   dropped flag — the false number and the false story merged together.

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -25,12 +25,13 @@ you looked at this function's diff is a failure, even if the row flips to MATCH.
    with `pnpm bench target <row-id> --out <dir>` so you can iterate without the full harness.
 4. State the baseline in your first user-facing message. Never report progress without a
    before/after pair of real command output.
-5. **Write the ranked repro down verbatim, flags included** — every later measurement (each
-   reviewer's, each remediation's, the PR body's) re-runs *that* command, not one recomposed from
-   memory. The flags are part of the number: a callee still written in assembly has no DWARF
-   signature, so `LoadBGTilemapData` without `--proto '{"thunk_HeapFree":{"params":1}}'` scores
-   578 where the round's baseline is 547 — a plausible number that is comparable to nothing.
-   Quote the candidate and dropped counts beside every ranked score.
+5. **Write every repro command down verbatim, flags included** — the `--only` line above, and any
+   ranked enumeration you run outside the harness. Every later measurement (each reviewer's, each
+   remediation's, the PR body's) re-runs *that* command, not one recomposed from memory. The flags
+   are part of the number: a callee still written in assembly has no DWARF signature, so
+   `LoadBGTilemapData` without `--proto '{"thunk_HeapFree":{"params":1}}'` scores 578 where the
+   round's baseline is 547 — a plausible number that is comparable to nothing. Quote the candidate
+   and dropped counts beside every ranked score.
 
 ## Phase 1 — Diagnose the gap honestly
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,19 @@ jobs:
       # no Docker, no compilers — everything heavy is lazily invoked, never at import.
       - run: pnpm exec vitest run apps/benchmark/test
 
+  # Is the committed benchmark artifact older than the code it measures? Git-only and sub-second,
+  # so it needs neither pnpm nor a toolchain — but it does need real history, hence its own
+  # checkout at full depth. PR-only: main squash-merges, so main's own stamp is never reachable
+  # and the check reports UNKNOWN there by design.
+  artifact-provenance:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: scripts/check-artifact-provenance.sh ${{ github.event.pull_request.base.sha }}
+
   # The webapp — playground + benchmark, one Vite build: its own tsconfig (vite/DOM types) —
   # `tsc --noEmit && vite build` plus its unit tests are the gate. (This build type-checks the
   # benchmark sources too; it's how the report's schema/consumers can't silently drift apart.)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
   # so it needs neither pnpm nor a toolchain — but it does need real history, hence its own
   # checkout at full depth. PR-only: main squash-merges, so main's own stamp is never reachable
   # and the check reports UNKNOWN there by design.
+  # BOTH spellings of the base go in: `base.sha` freezes at the event and goes stale as soon as
+  # main gains a round, while the merge ref checked out here is rebuilt against main's current
+  # tip — excluding only the frozen sha reports main's own commits as this branch's.
   artifact-provenance:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -45,7 +48,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: scripts/check-artifact-provenance.sh ${{ github.event.pull_request.base.sha }}
+      - env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: scripts/check-artifact-provenance.sh "origin/$BASE_REF" "$BASE_SHA"
 
   # The webapp — playground + benchmark, one Vite build: its own tsconfig (vite/DOM types) —
   # `tsc --noEmit && vite build` plus its unit tests are the gate. (This build type-checks the

--- a/apps/benchmark/src/run/orchestrate.ts
+++ b/apps/benchmark/src/run/orchestrate.ts
@@ -24,33 +24,49 @@ export interface OrchestrateOptions {
   toolchain?: string; // synthetic: single-toolchain filter
 }
 
+export interface ShardOutcome {
+  code: number;
+  skips: number; // rows this shard could not measure (toolchain unavailable)
+}
+
 /** One shard child (a tsx subprocess), stdout streamed with a shard prefix. Resolves on exit. */
-function runShard(tier: Tier, shard: string, extra: string[]): Promise<number> {
+function runShard(tier: Tier, shard: string, extra: string[]): Promise<ShardOutcome> {
   const child = spawn('tsx', [CLI, 'run', '--serial', '--tier', tier, '--shard', shard, ...extra], {
     cwd: join(import.meta.dirname, '..', '..', '..', '..'),
     stdio: ['ignore', 'pipe', 'inherit'],
   });
   const tag = `[${tier} ${shard}]`;
   let buf = '';
+  let skips = 0;
+  const line = (l: string): void => {
+    // the child's own end-of-shard tally (runner.ts) — the parent needs it to total a tier, and
+    // stdout is the only channel it has: the part files carry results, and a skipped row is
+    // precisely a row that produced none
+    const m = /^SKIPPED (\d+)\//.exec(l);
+    if (m) {
+      skips += Number(m[1]);
+    }
+    console.log(`${tag} ${l}`);
+  };
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', (chunk: string) => {
     buf += chunk;
     let nl: number;
     while ((nl = buf.indexOf('\n')) >= 0) {
-      const line = buf.slice(0, nl);
+      const l = buf.slice(0, nl);
       buf = buf.slice(nl + 1);
-      if (line.trim()) {
-        console.log(`${tag} ${line}`);
+      if (l.trim()) {
+        line(l);
       }
     }
   });
-  return new Promise<number>((res) => {
+  return new Promise<ShardOutcome>((res) => {
     child.on('close', (code, signal) => {
       if (buf.trim()) {
-        console.log(`${tag} ${buf}`);
+        line(buf);
       }
       // a signal-killed child (OOM, segfault) reports code=null — that is a failure, not a 0
-      res(code ?? (signal ? 1 : 0));
+      res({ code: code ?? (signal ? 1 : 0), skips });
     });
   });
 }
@@ -94,15 +110,19 @@ export async function orchestrate(opts: OrchestrateOptions): Promise<void> {
     }
     const t0 = Date.now();
     console.log(`\n▶ ${tier}: fanning across ${opts.jobs} shards…`);
-    const codes = await Promise.all(
+    const outcomes = await Promise.all(
       Array.from({ length: opts.jobs }, (_, i) => runShard(tier, `${i}/${opts.jobs}`, extra)),
     );
-    const failed = codes.filter((c) => c !== 0).length;
+    const failed = outcomes.filter((o) => o.code !== 0).length;
     failedShards += failed;
+    const skips = outcomes.reduce((sum, o) => sum + o.skips, 0);
     const n = stitch(tier, opts.jobs);
     const secs = ((Date.now() - t0) / 1000).toFixed(1);
+    // A skip total belongs on the tier line, not only in the scrollback: an absent toolchain
+    // costs whole projects (marioparty3's 40 rows) and `bench regression` reads them as MISSING.
+    const skipNote = skips ? ` — ⚠ ${skips} row(s) SKIPPED, toolchain unavailable` : '';
     console.log(
-      `${failed ? '✗' : '✓'} ${tier}: ${n} results in ${secs}s${failed ? ` (${failed} shard(s) exited nonzero)` : ''} → results/${tier}.json`,
+      `${failed ? '✗' : '✓'} ${tier}: ${n} results in ${secs}s${failed ? ` (${failed} shard(s) exited nonzero)` : ''} → results/${tier}.json${skipNote}`,
     );
   }
   if (failedShards > 0) {

--- a/apps/benchmark/src/run/runner.ts
+++ b/apps/benchmark/src/run/runner.ts
@@ -62,6 +62,10 @@ export function runCases(cases: Case[], outPath: string, shard: Shard = { idx: 0
   const tag = shard.n > 1 ? ` s${shard.idx}` : '';
   let done = 0;
   const buildFails: string[] = [];
+  // A skipped row is a MISSING measurement, not a decompiler outcome — and 40 of them scroll past
+  // unnoticed among 800 result lines. Counted here and totalled per tier by the orchestrator.
+  const skippedToolchains = new Set<string>();
+  let skips = 0;
 
   const flush = (): void => {
     const out: BenchOutput = { meta: benchMeta(results), results };
@@ -71,6 +75,8 @@ export function runCases(cases: Case[], outPath: string, shard: Shard = { idx: 0
   for (const c of mine) {
     if (!c.toolchain.available()) {
       console.log(`SKIP ${c.id}: toolchain unavailable`);
+      skips++;
+      skippedToolchains.add(c.toolchain.id);
       continue;
     }
     const t0 = Date.now();
@@ -112,6 +118,12 @@ export function runCases(cases: Case[], outPath: string, shard: Shard = { idx: 0
     flush();
   }
   flush();
+  if (skips > 0) {
+    // the shape the orchestrator greps for; keep the prefix and the `n/total` in step with it
+    console.log(
+      `SKIPPED ${skips}/${mine.length} case(s): toolchain unavailable (${[...skippedToolchains].join(', ')})`,
+    );
+  }
   if (buildFails.length > 0) {
     throw new Error(
       `${buildFails.length} target build(s) failed — every case must yield a row: ${buildFails.join(', ')}`,

--- a/scripts/check-artifact-provenance.sh
+++ b/scripts/check-artifact-provenance.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Is the committed benchmark artifact newer than the code it measures?
+#
+# `apps/benchmark/results/results.json` stamps the commit it was generated at
+# (`meta.asmlift.commit`). Every number a PR publishes — the totals in its body, the rows the
+# site renders, what `bench regression` compares against — comes from that file, so a branch
+# that regenerates it and then keeps changing the decompiler is publishing numbers a rule
+# version that no longer exists produced. Four adversarial findings across the last two rounds
+# were this, on two branches — reviewer time spent on repo hygiene because nothing mechanical
+# looks.
+#
+# Fires on commits THIS BRANCH adds after the stamp that touch code the artifact measures.
+# Commits the base branch gained meanwhile are not this branch's problem, so they are excluded.
+# A stamp that is not in this repo's history (main squash-merges, so main's own stamp is always
+# unreachable) is UNKNOWN, not a failure.
+#
+# usage: scripts/check-artifact-provenance.sh [base-ref]      (default: origin/main)
+set -eu
+
+base=${1:-origin/main}
+artifact=apps/benchmark/results/results.json
+
+# what the artifact measures — a commit touching any of these invalidates it
+# (`packages/bench-schema` is deliberately absent: it defines the vocabulary the site RENDERS,
+#  and editing a definition's text moves no row.)
+paths='packages/core/src packages/cli/src packages/toolchains/src apps/benchmark/src apps/benchmark/dataset'
+
+[ -f "$artifact" ] || { echo "provenance: no $artifact — nothing to check"; exit 0; }
+
+stamp=$(sed -n 's/.*"commit": "\([0-9a-f]\{40\}\)".*/\1/p' "$artifact" | head -1)
+[ -n "$stamp" ] || { echo "provenance: $artifact carries no meta.asmlift.commit — UNKNOWN"; exit 0; }
+
+if ! git cat-file -e "$stamp^{commit}" 2>/dev/null || ! git merge-base --is-ancestor "$stamp" HEAD 2>/dev/null; then
+  echo "provenance: artifact stamp $(echo "$stamp" | cut -c1-7) is not an ancestor of HEAD — UNKNOWN, not checked"
+  exit 0
+fi
+
+git rev-parse --verify --quiet "$base^{commit}" >/dev/null || {
+  echo "provenance: base ref '$base' not in this checkout — UNKNOWN, not checked"
+  exit 0
+}
+
+after=$(git log --oneline HEAD --not "$stamp" "$base" -- $paths)
+
+if [ -n "$after" ]; then
+  echo "provenance: FAIL — the artifact was generated at $(echo "$stamp" | cut -c1-7), and this branch"
+  echo "adds $(printf '%s\n' "$after" | wc -l | tr -d ' ') later commit(s) touching what it measures:"
+  printf '%s\n' "$after" | sed 's/^/  /'
+  echo
+  echo "Regenerate it (pnpm bench run && pnpm bench merge) as the LAST commit on the branch."
+  exit 1
+fi
+
+echo "provenance: OK — no commit after $(echo "$stamp" | cut -c1-7) touches what the artifact measures"

--- a/scripts/check-artifact-provenance.sh
+++ b/scripts/check-artifact-provenance.sh
@@ -10,14 +10,28 @@
 # looks.
 #
 # Fires on commits THIS BRANCH adds after the stamp that touch code the artifact measures.
-# Commits the base branch gained meanwhile are not this branch's problem, so they are excluded.
-# A stamp that is not in this repo's history (main squash-merges, so main's own stamp is always
-# unreachable) is UNKNOWN, not a failure.
+# Commits the base branch gained meanwhile are not this branch's problem, so every base ref
+# given is excluded — pass the base BRANCH, not only the sha a webhook payload froze: that sha
+# goes stale while the PR is open, while the merge ref CI checks out is rebuilt against the
+# base's moving tip, so excluding only the sha reports someone else's merged round as a commit
+# this branch added. Merge commits are skipped for the same reason: the one GitHub synthesizes
+# for `refs/pull/N/merge` is TREESAME to neither side once both touched these paths, and it is
+# not a change this branch made. A stamp that is not in this repo's history (main squash-merges,
+# so main's own stamp is always unreachable) is UNKNOWN, not a failure.
 #
-# usage: scripts/check-artifact-provenance.sh [base-ref]      (default: origin/main)
+# usage: scripts/check-artifact-provenance.sh [base-ref…]      (default: origin/main)
 set -eu
 
-base=${1:-origin/main}
+[ $# -gt 0 ] || set -- origin/main
+
+# the paths below are repo-relative, and a run from a subdirectory would find no artifact and
+# report success — the one answer a fail-loud check must never invent
+top=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "provenance: not a git checkout — UNKNOWN, not checked"
+  exit 0
+}
+cd "$top"
+
 artifact=apps/benchmark/results/results.json
 
 # what the artifact measures — a commit touching any of these invalidates it
@@ -35,12 +49,20 @@ if ! git cat-file -e "$stamp^{commit}" 2>/dev/null || ! git merge-base --is-ance
   exit 0
 fi
 
-git rev-parse --verify --quiet "$base^{commit}" >/dev/null || {
-  echo "provenance: base ref '$base' not in this checkout — UNKNOWN, not checked"
+# a ref the checkout does not have is not an error: CI passes both spellings of the base and
+# takes whichever exists, and only "none of them" is unknowable
+bases=''
+for ref in "$@"; do
+  if git rev-parse --verify --quiet "$ref^{commit}" >/dev/null 2>&1; then
+    bases="$bases $ref"
+  fi
+done
+[ -n "$bases" ] || {
+  echo "provenance: no base ref among '$*' is in this checkout — UNKNOWN, not checked"
   exit 0
 }
 
-after=$(git log --oneline HEAD --not "$stamp" "$base" -- $paths)
+after=$(git log --no-merges --oneline HEAD --not "$stamp" $bases -- $paths)
 
 if [ -n "$after" ]; then
   echo "provenance: FAIL — the artifact was generated at $(echo "$stamp" | cut -c1-7), and this branch"
@@ -52,3 +74,4 @@ if [ -n "$after" ]; then
 fi
 
 echo "provenance: OK — no commit after $(echo "$stamp" | cut -c1-7) touches what the artifact measures"
+echo "provenance: base(s) excluded:$bases"

--- a/scripts/check-artifact-provenance.sh
+++ b/scripts/check-artifact-provenance.sh
@@ -44,13 +44,10 @@ paths='packages/core/src packages/cli/src packages/toolchains/src apps/benchmark
 stamp=$(sed -n 's/.*"commit": "\([0-9a-f]\{40\}\)".*/\1/p' "$artifact" | head -1)
 [ -n "$stamp" ] || { echo "provenance: $artifact carries no meta.asmlift.commit — UNKNOWN"; exit 0; }
 
-if ! git cat-file -e "$stamp^{commit}" 2>/dev/null || ! git merge-base --is-ancestor "$stamp" HEAD 2>/dev/null; then
-  echo "provenance: artifact stamp $(echo "$stamp" | cut -c1-7) is not an ancestor of HEAD — UNKNOWN, not checked"
-  exit 0
-fi
-
 # a ref the checkout does not have is not an error: CI passes both spellings of the base and
-# takes whichever exists, and only "none of them" is unknowable
+# takes whichever exists, and only "none of them" is unknowable. Resolved and printed before the
+# verdict, because a check whose failure mode is a silent no-op should always say what it compared
+# against — a run that quietly fell back to the frozen sha looks identical to a correct one.
 bases=''
 for ref in "$@"; do
   if git rev-parse --verify --quiet "$ref^{commit}" >/dev/null 2>&1; then
@@ -61,6 +58,12 @@ done
   echo "provenance: no base ref among '$*' is in this checkout — UNKNOWN, not checked"
   exit 0
 }
+echo "provenance: base(s) excluded:$bases"
+
+if ! git cat-file -e "$stamp^{commit}" 2>/dev/null || ! git merge-base --is-ancestor "$stamp" HEAD 2>/dev/null; then
+  echo "provenance: artifact stamp $(echo "$stamp" | cut -c1-7) is not an ancestor of HEAD — UNKNOWN, not checked"
+  exit 0
+fi
 
 after=$(git log --no-merges --oneline HEAD --not "$stamp" $bases -- $paths)
 
@@ -74,4 +77,3 @@ if [ -n "$after" ]; then
 fi
 
 echo "provenance: OK — no commit after $(echo "$stamp" | cut -c1-7) touches what the artifact measures"
-echo "provenance: base(s) excluded:$bases"


### PR DESCRIPTION
Meta-optimisation iteration 1: five findings from a supervisor pass over the round journals were
put through a hostile re-check. **Three survived, two were rejected, and two proposals turned out
to be already built or already done.** Nothing here can move a benchmark number: the diff is one
new git-only script, a PR-only CI job, console output in the harness, and prompt text.

Two of the supervisor's supporting claims did not check out and are corrected below, because both
were load-bearing for proposals I then dropped.

## What shipped

### `efe37c2` — a branch cannot merge an artifact older than the code it measures

`results.json` stamps `meta.asmlift.commit`, every published number reads from it, and nothing
mechanical checks the stamp is current. Verified counts, not the supervisor's:

* Round 2 produced **two** reviewer findings on it in one wave — the ship agent's own triage table
  records `6 (major) Artifact ten commits behind HEAD — CONFIRMED + fixed (dup of 3)`.
* Round 3 produced **two more**, one a CRITICAL (`stale by three behaviour-changing commits and
  two dataset rows`).
* **`match/switch-arms` is stale right now.** Artifact stamped `cb5b51b`; 9 later commits on that
  branch touch what it measures, two of them (`a2e58d8`, `6914e06`) change emitted C, and the two
  rows `bf74977` authored (`swdefmid`, `swjtorder`) are absent from it. Both reuse existing tags,
  so the whole offline suite is green on it.

`scripts/check-artifact-provenance.sh` is git-only and sub-second. It lists commits **this branch**
adds after the stamp that touch `packages/{core,cli,toolchains}/src`, `apps/benchmark/src`,
`apps/benchmark/dataset`. Commits the base gained meanwhile are excluded, so it never goes red
because main moved.

Run against three real refs, base `origin/main`:

| ref | result |
|---|---|
| `origin/match/switch-arms` | **FAIL**, exit 1 — 9 commits after `cb5b51b` |
| `origin/match/def-home` | OK, exit 0 — final tip, artifact was last |
| `origin/main` | UNKNOWN, exit 0 — squash-merged, stamp unreachable |

`packages/bench-schema` is deliberately **not** in the path list. The first version included it and
went red on `origin/match/def-home` for `248ba54`, which edits one definition's user-facing summary
and nothing else. A rendering-text change moves no row; including it would have made the check its
own expected-red.

The CI job is PR-only with `fetch-depth: 0` (the default depth-1 checkout cannot see the stamp at
all) and needs no pnpm and no toolchain. On this PR it ran in 14s and printed
`provenance: artifact stamp 0e4d191 is not an ancestor of HEAD — UNKNOWN, not checked` — correct,
since this branch's artifact is main's. To prove the CI *shape* also fails, I built the exact
topology GitHub checks out (`git commit-tree <switch-arms tree> -p origin/main -p
origin/match/switch-arms`, i.e. a `refs/pull/N/merge` ref) and ran the check against
`origin/main`'s sha: **exit 1, the same 9 commits, no commits from main leaking into the list**.

### `0e6cef4` — total the skipped rows on the tier line

`runner.ts:73` was the entire SKIP path: log, `continue`. Both round-2 agents that ran a full bench
paid for it in the same round — the implement agent relaunched five minutes in ("the harness
silently SKIPs 40 rows — a regression gate blind on a whole compiler"), and the ship agent re-ran
the tier after the same 40 `marioparty3` rows vanished. Each shard now prints its own tally and the
orchestrator totals them onto the per-tier line. Proved both directions:

```
ASMLIFT_AGBCC valid  ✓ synthetic: 1 results in 1.4s → results/synthetic.json
ASMLIFT_AGBCC bogus  [synthetic 0/8] SKIPPED 1/1 case(s): toolchain unavailable (agbcc)
                     ✓ synthetic: 0 results in 0.4s → … — ⚠ 1 row(s) SKIPPED, toolchain unavailable
```

I did **not** take the proposed "exit 2 unless `--allow-skips`". Skipping is a designed path with a
documented downstream guard (`toolchains.ts:56`: "An unavailable toolchain SKIPS its rows … and
stale-check's coverage guard keeps a skipping run from ever clobbering the dataset"), and a refusal
would break legitimate partial runs — including the cheap synthetic ladder the rounds actually use.
The defect was that 40 skips were *invisible*, not that they were *allowed*.

### `19d8262` — `/match-function`: the repro is a command, not a recollection

Three rules, ~17 lines, each from a defect these rounds produced.

**The flags are part of the number.** `match-function.md` never mentioned `--proto` at all — the
line that does lives in `attribute-function.md`, and round 2's ship agent only saw it by grepping
the sibling file. So this is a *missing* instruction, not an ignored one, which is why a prompt fix
is the right lever here. Round 2's implement agent ran LBG with `--proto`; the remediate and ship
agents each hand-composed their own and did not. The ship agent's runner calls
`decompileRanked(name, asm, target, obj, { backend, symbols, compile })` — no `prototypes` key.

**Never explain a discrepancy — re-run it.** That run gave 557 / 578 against a 547 baseline, and
PR #76 shipped both plus a reason for the gap: *"nothing pins the checkout's `build/` objects or
the symbols ELF between rounds"*. PR #74's merged body already said *"607 without it, 547 with it.
A ranked run without it tops out at 578"* — 578 is the documented no-proto number. Hard rule 5
(*numbers come from commands*) did not stop this, because a command **was** run. The missing rule is
the corollary, now rule 6.

**A sweep's configuration is part of its claim.** Round 2's architect: *"the branch's own
464-function validation could not see it because it was run with the project symbol map, under
which `addressCone` refuses every one of these loads … my no-symbol-map sweep of the identical
corpus finds 17 functions whose output changes, not 7, and one of them loses a byte-exact match."*
The branch learned it, PR #76 records it, the command did not — so the next round starts over.

## What I rejected

**A committed `scripts/rank-function.sh` that bakes the proto file.** Two reasons. (1) The durable
channel for that fact already exists, unmerged: `feat/config-prototypes` (`f0d6e29`,
*"feat(cli): tools.asmlift.prototypes, and refuse a malformed table"*) whose own message names this
exact problem — *"the only channel was `--proto` on the command line, which no published repro
script carries, so the fact was unstatable by the project that knows it"*. A shell wrapper would be
a third channel for the same fact and would rot the day that branch merges. (2) The rationale for
its progress-streaming half is false — see the corrections below.

**`scripts/probe-compile.sh`.** The premise ("agents retype the agbcc line and the copies differ in
ways that changed a round's verdict") is half-true: five agents did hand-roll a wrapper, and round
3's breaker really does use host `cpp -P -nostdinc` with a typedef prelude and no `-Wparentheses`.
But `-Wparentheses` is a diagnostic flag with no codegen effect, and no evidence in the transcripts
shows a *wrong compiler fact* coming out of any of them. The verdict-changing variance the finding
actually evidences is the **symbol-map configuration of the corpus sweep**, which is a different
thing and is what `19d8262` addresses. A shell reimplementation would also have to duplicate
`compileFromCommand`'s template substitution, i.e. introduce exactly the divergence complained of.

**`scripts/corpus-sweep.ts`, and splitting configurations between the two reviewers.** The
configuration rule belongs to the *implementer*, whose Phase 4 sweep is the one that was blind;
assigning it to reviewers finds it a wave later at best. One prompt line beats a new script nothing
depends on.

**Changing `features.test.ts` so the vocabulary check reads the dataset.** Rejected on two grounds.
The proposal as written *breaks the suite*: `authored` carries judgement tags only (asserted at
`features.test.ts:131`), so sourcing "every definition is carried" from it fails immediately for
all 20 `SOURCE_CHECKED` + `CODEGEN_DERIVED` ids, which no dataset row ever authors. And the premise
is wrong — `npx vitest run apps/benchmark/test/features.test.ts apps/web/test/feature-vocabulary.test.ts`
on `main` is **29 passed**, because the red is a bounded in-round transient that the attribution
round's own final step clears. `attribute-function.md` Phase 7 already spells it out: *"Expect the
two tag-vocabulary tests to fail BETWEEN adding the tag and merging the artifacts; they must pass
after"*, and both rounds did land the regeneration commit (`ba9ce44` for round 3). Nothing merged
red. `efe37c2` also gives the same condition a clearer signal than a confusing test failure.

## Two supervisor claims that did not check out

1. **"unlike the real CLI which streams them".** Nothing streams. `packages/cli/src/main.ts` builds
   its `[score]` table with `ranked.candidates.map(…)` *after* `decompileRanked` returns, and
   `grep -rn "console\." packages/core/src/rank.ts packages/cli/src/rank.ts` is empty. The
   hand-rolled script behaved identically to the CLI here; the ~28 minutes were the cost of a
   ranked LBG run with **no** progress signal from **any** entry point. That is a real gap, but it
   cannot be fixed by a shell wrapper.
2. **"correct PR #76's LBG table"** — already done. PR #76 opens with a post-merge correction block
   naming the missing flag and giving the re-measured number (531 from a 547 baseline, 20608
   candidates, 0 dropped). No action left.

## Proposals — measurement-affecting, for sequencing between rounds

1. **Merge `feat/config-prototypes`, then decide about klonoa's `decomp.yaml` separately.** The
   mechanism (`--proto` > `tools.asmlift.prototypes` > DWARF, both validated) is inert until a
   project declares a table. Adding `thunk_HeapFree` to klonoa's `decomp.yaml` **moves the
   `kleod:*` rows** — `f0d6e29` says so explicitly and deliberately left it out. That is the change
   that would retire the flag-omission class for good, and it is a human call.
2. **A progress signal for ranked runs.** An 18k–20k candidate enumeration prints nothing for ten
   minutes, which is what drove one agent to ~20 polling commands and four duplicate background
   launches. Belongs in `packages/core/src/rank.ts` or `packages/cli/src/rank.ts` — out of scope
   here, and worth a look before the next LBG round.
3. **Pre-flight toolchain block for `bench run`** (`--allow-skips` to override), if the partial-run
   ergonomics are judged worth less than the refusal. `0e6cef4` deliberately stops short of it.

## Gates

* `pnpm typecheck` — clean
* `npx vitest run --maxWorkers=3` — 125 files, **1525 passed**
* `npx eslint apps packages` — 0 errors (61 pre-existing warnings, none in touched files;
  `npx eslint` on the two touched files exits 0)
* `pnpm format` — clean
* `scripts/check-artifact-provenance.sh` — proved firing, clean and UNKNOWN on three real refs

---

## Review pass — `f5e708e`, `ea3e101`, `64ca557`

Audited against the round transcripts, the harness sources, and a synthesized `refs/pull/N/merge`
topology; every gate re-run from scratch rather than taken on trust. Two defects in the new check,
both fixed here. Scope re-verified: the diff touches `.claude/commands/match-function.md`,
`.github/workflows/ci.yml`, `apps/benchmark/src/run/{runner,orchestrate}.ts` and
`scripts/check-artifact-provenance.sh` and nothing else — nothing in `packages/core`,
`apps/benchmark/dataset`, `packages/bench-schema`, `apps/benchmark/src/cases/features.ts`,
`apps/benchmark/results/` or either `apps/web` data copy, so neither live track is touched.

### 1. The check reddened on commits this branch did not make

The claim above — "it never goes red because main moved" — held on the branch refs it was proved
on, not on the ref CI checks out. Synthetic topology: a branch regenerates the artifact as its last
commit, main then merges a round touching `packages/core/src`, GitHub rebuilds the merge ref.

| topology | old check | new check |
|---|---|---|
| the probe used above (`commit-tree` with the head's tree) | OK, exit 0 | OK, exit 0 |
| what GitHub actually builds (a real merge, union tree) | **FAIL, exit 1** — lists main's own commit *and* the merge commit | OK, exit 0 |

The probe could not see it: a merge whose tree equals the head's tree is TREESAME to that parent,
so `git log -- <paths>` simplifies the base side away and never walks main. A real merge ref is
TREESAME to neither side once both touched the watched paths.

Two causes, both fixed in `f5e708e`. `github.event.pull_request.base.sha` freezes at the webhook
event while the merge ref is rebuilt against main's moving tip — this PR's own CI run carried
`BASE_SHA: 7f69058` while main was already at `d79ca28` — so the job now passes the base BRANCH too
and every base ref that resolves is excluded (confirmed on the runner:
`provenance: base(s) excluded: origin/main 7f69058…`, so `fetch-depth: 0` does supply
`origin/main`). And the merge commit GitHub synthesizes is not a change this branch made:
`--no-merges`. The three real refs still read exactly as before — `match/switch-arms` FAIL with the
same 9 commits, `match/def-home` OK, `main` UNKNOWN.

### 2. The check passed by finding nothing

The artifact path is repo-relative, so from any subdirectory the check printed
`no apps/benchmark/results/results.json — nothing to check` and exited 0. It resolves the worktree
root first now. `64ca557` also prints the base refs it compared against on every path, including
the UNKNOWN ones: a run that quietly fell back to the frozen sha used to look identical to a
correct one.

### 3. Prompt

Phase 0's new rule said "write the ranked repro down", but `ranked` appears nowhere else in
`match-function.md`, whose own Phase 0 issues `bench run --only` and `bench target`. Generalised to
name both (`ea3e101`) — what it protects, *the flags are part of the number*, is true of every
command the phase runs.

Left alone deliberately: the 578/547 pair checks out (round 2's own baseline section records "607
without the proto, 547 with it … A ranked run *without* it tops out at 578"); hard rule 6 and the
Phase 4 sweep bullet each change behaviour and neither duplicates an existing instruction; and the
`✓` on a tier line that skipped rows stays a tick, since the shards did exit 0 and the ⚠ sits on
the same line.

### Gates, re-run on the review worktree

| gate | result |
|---|---|
| `pnpm typecheck` | exit 0 |
| `npx vitest run --maxWorkers=3` | 125 files, **1525 passed**, exit 0 |
| `pnpm test:matching` | 32 files, **283 passed**, exit 0 |
| `npx eslint apps packages` | 0 errors, 61 warnings — all pre-existing, none in touched files |
| `npx prettier --check .` | "All matched files use Prettier code style!" |

And the skip totals, live on real rows rather than a synthetic one — toolchain present:
`✓ real: 1 results in 3.9s → results/real.json`, no warning; `ASMLIFT_GCC272_DIR` pointed at a
missing directory: `✓ real: 0 results in 0.7s … — ⚠ 3 row(s) SKIPPED, toolchain unavailable`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
