### PR TITLE
Meta-optimisation 2: the headline gets re-measured, the second wave gets re-briefed, and an asmlift claim gets run

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -108,11 +108,11 @@ attribution line for every decline naming its first blocker. Constraints learned
   Phase-3/4 probes so the row measures exactly what you measured. Never tune it toward either
   decompiler.
 - **Every row the comment names must exist, and every claim about one you did not run is a
-  prediction.** Paste the `grep -n "sym: '<name>'"` that proves each cited row is real before
-  resting an attribution on it, and mark a claim about a row you did not measure as a prediction
-  with the command that would falsify it. A family comment once rested its whole attribution on a
-  contrasting row nobody had written, and asserted a second row's score would move without
-  flipping — it flipped to MATCH the next round.
+  prediction.** Paste into your report the `grep -n "sym: '<name>'"` that proves each cited row is
+  real before resting an attribution on it, and mark a claim about a row you did not measure as a
+  prediction with the command that would falsify it. A family comment once rested its whole
+  attribution on a contrasting row nobody had written, and asserted a second row's score would
+  move without flipping — it flipped to MATCH the next round.
 - `features`: judgement tags only (source/codegen tags are derived). A new tag needs a
   `FeatureDef` in `packages/bench-schema/src/features.ts` and at least one row carrying it;
   a floor is optional and several tags deliberately have none.

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -107,6 +107,12 @@ attribution line for every decline naming its first blocker. Constraints learned
 - The reference source in `src` is the definition of the target. Keep it verbatim from your
   Phase-3/4 probes so the row measures exactly what you measured. Never tune it toward either
   decompiler.
+- **Every row the comment names must exist, and every claim about one you did not run is a
+  prediction.** Paste the `grep -n "sym: '<name>'"` that proves each cited row is real before
+  resting an attribution on it, and mark a claim about a row you did not measure as a prediction
+  with the command that would falsify it. A family comment once rested its whole attribution on a
+  contrasting row nobody had written, and asserted a second row's score would move without
+  flipping — it flipped to MATCH the next round.
 - `features`: judgement tags only (source/codegen tags are derived). A new tag needs a
   `FeatureDef` in `packages/bench-schema/src/features.ts` and at least one row carrying it;
   a floor is optional and several tags deliberately have none.
@@ -149,9 +155,13 @@ attribution line for every decline naming its first blocker. Constraints learned
 
 1. **Numbers come from commands.** Never state a score, a pool count, or a compiler behavior you
    did not just observe in tool output.
-2. **Every compiler claim is verified by compiling.** The diff suggests; only the compiler
-   confirms. A plausible mechanism read from source but not reproduced is a hypothesis, not a
-   finding.
+2. **Every compiler claim is verified by compiling — and every claim about asmlift's own code by
+   running asmlift.** The diff suggests; only the compiler confirms. The same asymmetry bites on
+   this side: name the site that declines by instrumenting it (print which `return null` fires) or
+   by ablating it and watching the row move, never by reading the source and inferring. A guard
+   you did not watch fire is a hypothesis, and one printed as a mechanism aims the next round at
+   the wrong guard — a round once attributed a decline to a refusal that fires zero times on the
+   whole corpus.
 3. **Never edit the benchmark to make a row look better** — the reference source defines the
    target; manifests and results are never tuned. Harness defects (a hang, a missing timeout)
    are fixed or documented as their own labelled change.

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -90,8 +90,16 @@ lost match blocks the branch.** If a match is lost, either tighten the gate on y
 the lever — do not rationalize a trade unless the user explicitly approves it. Report the totals
 (asmlift vs m2c) before and after.
 
-Two things this gate does not catch by itself:
+Three things this gate does not catch by itself:
 
+- **A number measured OUTSIDE the harness goes stale the same way, and nothing checks it.** The
+  ranked run from Phase 0 measures the commit it ran at, and when the target is not a benchmark
+  row the regression gate cannot see it move — so remediation rewrites what it measures with
+  nothing to notice. Re-run it at the branch's final commit and publish *that* number; "the
+  primary output is byte-identical" is a claim about one candidate out of tens of thousands, not
+  about the best score. Launch it beside the final `pnpm bench run`, not after it. If you skip it
+  anyway, the cost you skipped it for is a number under Hard rule 5 — quote the log you read it
+  off. Twice now a round has declined this re-run on a duration nothing had timed.
 - **The regenerated artifact is the LAST commit on the branch.** `results.json` stamps the commit
   it was generated at, and every number you publish reads from it — so a commit that touches core,
   cli, the harness or the dataset after it silently republishes numbers a rule version that no
@@ -121,9 +129,19 @@ ad-hoc patch shaped like this one function. Read `docs/level-tower.md` and
 structure it introduced; is it data where it should be data; does it duplicate an existing pass;
 would a reviewer who has never seen $1 understand why it exists? Name the redesign if there is one."
 
-Then: **remediate every confirmed finding as new commits**, and **re-run both agents on the fixes**.
-Precedent from this repo's history: a remediation itself introduced a silent-wrong-address bug that
-only the second pass caught. One round is not enough.
+Then: **remediate every confirmed finding as new commits**, and **re-brief and re-run both agents
+on the fixes**. Precedent from this repo's history: a remediation itself introduced a
+silent-wrong-address bug that only the second pass caught. One round is not enough.
+
+Re-running them means **re-briefing** them. The second brief carries the first round's triage
+ledger — every finding, its verdict, and the reason behind each DECLINE or NOT-REPRODUCED — and
+any premise this round has since falsified is struck from it, not restated. Reissuing the first
+brief with the round number changed spends the second wave re-finding the first wave's work: one
+round did exactly that, and its second breaker built a semantic-differential rig to re-report a
+pre-existing defect the first breaker's rig had already found and remediation had confirmed and
+declined with three reasons — while the brief still aimed its hunt list at a guard that round's
+own instrumentation had shown fires zero times on the corpus. A finding already triaged is not a
+new finding unless it falsifies the triage.
 
 ## Phase 6 — Audit the commentary you introduced
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -92,6 +92,11 @@ the lever — do not rationalize a trade unless the user explicitly approves it.
 
 Three things this gate does not catch by itself:
 
+- **The regenerated artifact is the LAST commit on the branch.** `results.json` stamps the commit
+  it was generated at, and every number you publish reads from it — so a commit that touches core,
+  cli, the harness or the dataset after it silently republishes numbers a rule version that no
+  longer exists produced. Regenerate after Phase 5's remediation, and run
+  `scripts/check-artifact-provenance.sh` before opening the PR.
 - **A number measured OUTSIDE the harness goes stale the same way, and nothing checks it.** The
   ranked run from Phase 0 measures the commit it ran at, and when the target is not a benchmark
   row the regression gate cannot see it move — so remediation rewrites what it measures with
@@ -99,12 +104,8 @@ Three things this gate does not catch by itself:
   primary output is byte-identical" is a claim about one candidate out of tens of thousands, not
   about the best score. Launch it beside the final `pnpm bench run`, not after it. If you skip it
   anyway, the cost you skipped it for is a number under Hard rule 5 — quote the log you read it
-  off. Twice now a round has declined this re-run on a duration nothing had timed.
-- **The regenerated artifact is the LAST commit on the branch.** `results.json` stamps the commit
-  it was generated at, and every number you publish reads from it — so a commit that touches core,
-  cli, the harness or the dataset after it silently republishes numbers a rule version that no
-  longer exists produced. Regenerate after Phase 5's remediation, and run
-  `scripts/check-artifact-provenance.sh` before opening the PR.
+  off. A round once skipped it on a re-score that "had not finished after 2h", written in a
+  session under an hour long that had run no ranked command at all.
 - **A corpus sweep's configuration is part of its claim.** Sweeping a project's functions with the
   new rule ON vs OFF proves nothing about the configuration you did not run: with a symbol map
   every absolute pool constant lifts to a `gaddr`, so a symbol-map sweep is blind to a rule that
@@ -133,15 +134,14 @@ Then: **remediate every confirmed finding as new commits**, and **re-brief and r
 on the fixes**. Precedent from this repo's history: a remediation itself introduced a
 silent-wrong-address bug that only the second pass caught. One round is not enough.
 
-Re-running them means **re-briefing** them. The second brief carries the first round's triage
-ledger — every finding, its verdict, and the reason behind each DECLINE or NOT-REPRODUCED — and
-any premise this round has since falsified is struck from it, not restated. Reissuing the first
-brief with the round number changed spends the second wave re-finding the first wave's work: one
-round did exactly that, and its second breaker built a semantic-differential rig to re-report a
-pre-existing defect the first breaker's rig had already found and remediation had confirmed and
-declined with three reasons — while the brief still aimed its hunt list at a guard that round's
-own instrumentation had shown fires zero times on the corpus. A finding already triaged is not a
-new finding unless it falsifies the triage.
+The second brief carries the first round's triage ledger — every finding, its verdict, and the
+reason behind each DECLINE or NOT-REPRODUCED — and any premise this round has since falsified is
+struck from it, not restated. Reissuing the first brief with the round number changed spends the
+second wave re-finding the first wave's work: one round did exactly that, and its second breaker
+built a semantic-differential rig to re-report a pre-existing defect the first breaker's rig had
+already found and remediation had confirmed and declined with three reasons — while the brief
+still aimed its hunt list at a guard that round's own instrumentation had shown fires zero times
+on the corpus. A finding already triaged is not a new finding unless it falsifies the triage.
 
 ## Phase 6 — Audit the commentary you introduced
 


### PR DESCRIPTION
Meta-optimisation iteration 2. A supervisor pass over the round journals produced four findings;
each was put through a hostile re-check against the transcripts, logs and commits it cited.
**Three survived (one in narrowed form), one was rejected outright.** The diff is 36 added lines
across two prompt files — `.claude/commands/**` cannot move a benchmark number, and nothing else
is touched.

Two of the supervisor's supporting claims did not check out and are corrected below, because both
were load-bearing. One replacement fact I found while checking is stronger than the finding it
came from, and is what the first rule is now written around.

## What shipped — `1b4d8e9`

### 1. The ranked headline is re-measured at the branch's final commit

Phase 4 already says the artifact must be regenerated at the last commit. The number the PR
*leads* with is measured outside the harness, and nothing gates it — worse, when the target is not
a benchmark row (`LoadBGTilemapData` is not) `pnpm bench regression` structurally **cannot** see it
move, so remediation can rewrite what the headline measures with nothing to notice. Phase 4 gains
a third bullet beside the artifact one.

The supervisor framed this as "published from a mid-branch commit three rounds running". That
overstates it and I am not shipping it that way:

* **Round 3 is not an instance.** Its ranked run started 16:29:26, after 7 of the round's 8
  behaviour commits (`9a96553` 16:19:25); only `578ed0c` (16:43:21) landed later. PR #80 discloses
  exactly that and backs it with a hash-identity measurement. The published 473 is the ship agent's
  own run (`/tmp/lbg-run.log`, 20608 `[score]` lines, best 473) — not, as the finding says, "the
  pre-remediation one".
* **Round 2's wrong headline was a dropped flag, not staleness.** Its ship agent *did* re-run at
  final code; it got 557/578 because `--proto` was missing. Iteration 1 already closed that.

What is real, and is what the rule is written around, is the reason the re-run gets skipped —
**a cost figure nobody ever timed**:

* Round 2's remediate agent declined it in writing: *"my own ranked re-score of it had not finished
  after 2h."* That transcript's first and last timestamps are `05:11:55Z → 06:08:34Z` — **57
  minutes** — and across its 221 Bash calls there is no ranked command at all, only
  `bench run --only LoadBGTilemapData`. The 2h is a number it could not have observed.
* Round 3's remediate agent ran **zero** ranked commands in 155 Bash calls, and its safety net was
  a corpus sweep, which cannot cover a function that is not a row.
* The memory every brief scoped around said **"the LBG ranked run at 45–90 min"**, in a section
  whose own closing rule is *"never put a timing in an agent brief that you have not read off a
  log."*

Measured, four runs of the identical command, all 20608 candidates with `--proto`:

| log | window | wall | conditions |
|---|---|---|---|
| `run4.err` | 04:22:05→04:43:20 | **21m15s** | concurrent with run5 |
| `run5.err` | 04:22:22→04:43:39 | **21m17s** | concurrent with run4 |
| `run6.err` | 08:55:20→09:15:04 | **19m44s** | solo |
| `lbg-run.log` | 16:29:26→16:50:30 | **21m04s** | overlapped a full `bench run --jobs 4` |

Two in parallel cost ~7% more than one, and one overlapping a full bench costs about the same — so
the rule says launch the re-measure *beside* the final bench, not after it. A skip is still allowed,
but the cost it is skipped for is a number under Hard rule 5 and must be quoted off a log.

### 2. The second adversarial wave is re-briefed, not re-issued

Phase 5 said "re-run both agents on the fixes". Round 3 did exactly that, literally: I extracted
both waves' first user messages and diffed them — the wave-2 briefs are **byte-for-byte identical**
to wave-1's except for one line, `Round 1` → `Round 2` (7197 bytes architect, 7700 breaker, both
waves).

Measured cost in that one round:

* Wave 2's breaker built a semantic-differential rig (**1248 sweep fixtures**) and re-reported the
  unsigned range check that wave 1's breaker had already found with its own rig (**74 randomised
  programs × 98 input pairs**) and that remediation had **CONFIRMED-and-DECLINED with three
  reasons**. PR #80 declines it a second time.
* Both wave-2 briefs still assert *"The trigger is the phi, not the missing default"* and order
  hunt item 3 at that guard — **five hours after** the round's own implement agent instrumented
  every `return null` in `recognizeSwitch` and reported the real site is `defaults.length > 1`,
  and that the phi guard *"fires **0 times** across all 823 benchmark rows"*.

Phase 5 now requires the second brief to carry the first round's triage ledger — every finding, its
verdict, and the reason behind each DECLINE or NOT-REPRODUCED — and to strike any premise the round
has since falsified.

Note for the orchestrator: the two same-wave duplicates the supervisor also counted
(`switch-recover.ts:69` in wave 1, the stale artifact in wave 2) are **not** fixable this way —
those are two agents running in parallel, and re-briefing cannot deduplicate them. The recoverable
loss is the cross-wave kind, and that is what the rule targets.

### 3. `/attribute-function` verifies asmlift claims by running asmlift

Hard rule 2 required every **compiler** claim to be verified by compiling. There was no symmetric
rule for claims about asmlift's own source, and Phase 4 requires naming the first blocker only for
`declined` rows — `swarms` was `diff:10`, so nothing applied. The round-2 attribution therefore
shipped into `dataset/synthetic.ts` three claims the next round falsified:

* the decline is the *"default entry with a phi"* guard — the guard fires zero times on the corpus;
* *"`swtail`, the same dispatch with a phi-free merge, IS recovered today"* — `git grep swtail
  origin/main -- apps packages docs` returns **nothing**; the control row never existed;
* closing the arm grouping would move `uninit_sw`'s score *without* changing its outcome — it
  flipped to MATCH.

That text sat on `main` for a full round and four merged PRs, cost the next round its opening phase
(*"The finding's attribution was wrong… I instrumented every `return null`"*), a reviewer finding
slot, and two remediation commits. Rule 2 now covers both halves; Phase 6 requires the
`grep -n "sym: '<name>'"` that proves a cited row is real, and marks a claim about a row you did not
run as a prediction.

## What was rejected

### Finding 4 — commit the fast-loop instrument as `scripts/` tooling. REJECTED.

Its central harm claim is **false**. The finding says round-3 attribution `a1d71c6f` ran
`/tmp/lbg8/one.mts` unrepointed and so "measured main's decompiler while reporting its branch's
number", citing a plain `cp -r` at call [2]. Call **[7]** of that same transcript overwrites it:

```
sed 's#/Users/macabeus/…/asmlift/packages/#/tmp/wt-attr3/packages/#' /tmp/lbg8/one.mts \
  > /tmp/attr3-scratch/one.mts
grep -n "wt-attr3" /tmp/attr3-scratch/one.mts
```

— repointed at its own worktree and grep-verified, before the runs at [29]/[30]. Every one of the
six agents repointed correctly. The wrong-tree hazard has never fired.

The finding's other pillar, the disagreeing compile wrappers, is disclaimed by the supervisor
itself (*"the exposure is latent, not demonstrated"* — and its own probe found all three agbcc
binaries emit identical `.s`).

The residual — ~15–20 setup calls per agent — is real but does not justify the instrument as
designed, and the design is actively harmful next to rule 1: **re-scoring last round's winning
label is not the branch's best score.** A committed 2-minute "check" that answers a different
question than the 21-minute run is precisely the substitution that produced PR #76's wrong headline.
Now that the true cost is measured at ~21 min and parallelisable at ~7%, the correct instrument is
the run itself, which is already one documented command.

### Finding 1(b) — a ranked-run receipt + a provenance check over it. REJECTED (proposed instead).

Emitting the receipt belongs in `packages/cli` (`main.ts` / `rank.ts`), which is not in this
branch's scope, and a receipt proves only that *a* run happened at HEAD — the failure here was
skipping the run outright, which the prompt rule addresses directly. Worth sequencing later, beside
`scripts/check-artifact-provenance.sh`, if a round skips it again under the new rule.

### Finding 2(b) — a new `docs/known-gaps.md`. REJECTED (redirected).

One entry, and no cross-**round** recurrence was demonstrated — both re-reports were inside one
round, which the Phase 5 ledger closes. A new doc that must be maintained for one row is churn. The
declined range-check is recorded instead in the `asmlift-adversarial-validation` memory file, which
Phase 7 already directs every round to update, under a new **Standing DECLINES** heading the Phase 5
ledger can be built from.

## Out of scope, done anyway, and named

Two memory-file edits, outside the repo and incapable of touching a measurement:

* `asmlift-parallel-worktree-harness.md` — the `45–90 min` figure replaced with the four measured
  runs above, the parallel-cost fact, and the two unmeasured skip-justifications.
* `asmlift-adversarial-validation.md` — the **Standing DECLINES** register, seeded with the unsigned
  range check and PR #80's three reasons.

## Still open — for the human to sequence, not this loop

The unsigned range check (`cfamily.ts:322` / `structure.ts:571`) is a confirmed silent-wrong-answer
on `main`, reproduced by two independent differential rigs, declined twice. By this project's own
`/uns-cmp` precedent a change there is an emission axis and needs its own LBG-scale ranked run. It
wants a round.

## Gates

```
npx vitest run --maxWorkers=3     126 files, 1547 passed
pnpm typecheck                    clean
npx eslint apps packages          0 errors (61 pre-existing warnings)
npx prettier --check              clean
```

No benchmark command was run, and none is affected: the diff is two markdown files under
`.claude/commands/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
