### PR TITLE
Meta-optimisation 1: the ranked run gets a compile pool and a pulse, and the loop gets its neutrality command

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -129,14 +129,17 @@ attribution line for every decline naming its first blocker. Constraints learned
 ## Phase 7 — Gates and commits
 
 1. Source commit first (dataset + tag). Then `pnpm bench run` (all tiers) → `pnpm bench:merge` →
-   `pnpm bench regression`. **Regression without a preceding run+merge compares stale results and
-   is vacuous** — the order is the gate.
+   `pnpm bench regression --base origin/main`. **Regression without a preceding run+merge compares
+   stale results and is vacuous** — the order is the gate; and without `--base`, a branch that has
+   already committed its own artifact compares it against itself, which is vacuous the other way.
 2. Expect the two tag-vocabulary tests to fail BETWEEN adding the tag and merging the artifacts;
    they must pass after. `npx vitest run`, `pnpm test:matching`, `pnpm typecheck`,
    `npx eslint apps packages` (not `pnpm lint`), `pnpm format` check.
 3. Artifacts (`apps/benchmark/results/results.json`, both web copies) regenerated at the source
    commit's HEAD (`meta.asmlift.dirty` must be false) and committed separately.
 4. Zero-flip over the previously committed rows blocks the branch, same as `/match-function`.
+   `pnpm bench diff --base origin/main` is that check by row and field, and its output is the
+   report's list of what moved.
 
 ## Phase 8 — Write it down and report
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -94,9 +94,10 @@ match blocks the branch.** Pass the base ref: both gates read the COMMITTED arti
 branch that has already committed its own they compare it against itself and pass vacuously.
 `regression` answers "did a match break"; `diff` names every row and field that moved
 (`asmlift.{outcome,score,candidateLabel,source}`, `m2c.{outcome,score,source}`) — that list is the
-PR body's inventory of what the round did, and for a commit claiming to move nothing it is the gate. If a match is lost, either tighten the gate on your lever or drop
-the lever — do not rationalize a trade unless the user explicitly approves it. Report the totals
-(asmlift vs m2c) before and after.
+PR body's inventory of what the round did, and for a commit claiming to move nothing it is the
+gate. If a match is lost, either tighten the gate on your lever or drop the lever — do not
+rationalize a trade unless the user explicitly approves it. Report the totals (asmlift vs m2c)
+before and after.
 
 Three things this gate does not catch by itself:
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -31,7 +31,10 @@ you looked at this function's diff is a failure, even if the row flips to MATCH.
    are part of the number: a callee still written in assembly has no DWARF signature, so
    `LoadBGTilemapData` without `--proto '{"thunk_HeapFree":{"params":1}}'` scores 578 where the
    round's baseline is 547 — a plausible number that is comparable to nothing. Quote the candidate
-   and dropped counts beside every ranked score.
+   and dropped counts beside every ranked score. Add `--jobs 6 --progress`: the candidate compiles
+   are ~85% of a ranked run and pool cleanly (LBG, measured: 20.7 min serial → ~8), and the
+   `asmlift: [progress]` liveness lines are what makes a later claim about the run checkable from
+   its own log. Compare two runs on their `[score]` lines — `[progress]` is timing, not measurement.
 
 ## Phase 1 — Diagnose the gap honestly
 
@@ -85,8 +88,13 @@ Per commit:
 
 ## Phase 4 — Full-bench zero-flip gate
 
-Before declaring the branch done: `pnpm bench run` (all tiers) and `pnpm bench regression`. **Any
-lost match blocks the branch.** If a match is lost, either tighten the gate on your lever or drop
+Before declaring the branch done: `pnpm bench run` (all tiers), `pnpm bench:merge`, then
+`pnpm bench regression --base origin/main` and `pnpm bench diff --base origin/main`. **Any lost
+match blocks the branch.** Pass the base ref: both gates read the COMMITTED artifact, so on a
+branch that has already committed its own they compare it against itself and pass vacuously.
+`regression` answers "did a match break"; `diff` names every row and field that moved
+(`asmlift.{outcome,score,candidateLabel,source}`, `m2c.{outcome,score,source}`) — that list is the
+PR body's inventory of what the round did, and for a commit claiming to move nothing it is the gate. If a match is lost, either tighten the gate on your lever or drop
 the lever — do not rationalize a trade unless the user explicitly approves it. Report the totals
 (asmlift vs m2c) before and after.
 
@@ -102,10 +110,11 @@ Three things this gate does not catch by itself:
   row the regression gate cannot see it move — so remediation rewrites what it measures with
   nothing to notice. Re-run it at the branch's final commit and publish *that* number; "the
   primary output is byte-identical" is a claim about one candidate out of tens of thousands, not
-  about the best score. Launch it beside the final `pnpm bench run`, not after it. If you skip it
-  anyway, the cost you skipped it for is a number under Hard rule 5 — quote the log you read it
-  off. A round once skipped it on a re-score that "had not finished after 2h", written in a
-  session under an hour long that had run no ranked command at all.
+  about the best score. Launch it beside the final `pnpm bench run`, not after it, with
+  `--jobs 6 --progress`. Skipping it is now unquotable: the `[progress]` lines timestamp the run's
+  own cost, so "it had not finished" is checkable against the log — a round once wrote that of a
+  re-score "not finished after 2h", in a session under an hour long that had run no ranked
+  command at all.
 - **A corpus sweep's configuration is part of its claim.** Sweeping a project's functions with the
   new rule ON vs OFF proves nothing about the configuration you did not run: with a symbol map
   every absolute pool constant lifts to a `gaddr`, so a symbol-map sweep is blind to a rule that

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -32,9 +32,16 @@ you looked at this function's diff is a failure, even if the row flips to MATCH.
    `LoadBGTilemapData` without `--proto '{"thunk_HeapFree":{"params":1}}'` scores 578 where the
    round's baseline is 547 — a plausible number that is comparable to nothing. Quote the candidate
    and dropped counts beside every ranked score. Add `--jobs 6 --progress`: the candidate compiles
-   are ~85% of a ranked run and pool cleanly (LBG, measured: 20.7 min serial → ~8), and the
-   `asmlift: [progress]` liveness lines are what makes a later claim about the run checkable from
-   its own log. Compare two runs on their `[score]` lines — `[progress]` is timing, not measurement.
+   are ~85% of a ranked run and pool cleanly, and the `asmlift: [progress]` liveness lines are what
+   makes a later claim about the run checkable from its own log. Two LBG runs launched together
+   measured **36m10s serial against 21m32s at `--jobs 6`** (20608 candidates, 0 dropped, identical
+   winner) — but that machine was also running two full benches and both test suites, and a quieter
+   pair measured 31m55s against 11m16s. The ratio is the machine's, not the code's: re-time on your
+   own log and quote that, never these. Compare two runs on their `[score]` lines, and filter with
+   a FIXED string — `diff <(grep -F '[score]' a.err) <(grep -F '[score]' b.err)`. `grep '[progress]'` is a bracket
+   EXPRESSION matching any one of `p r o g e s`, so `grep -v '[progress]'` deletes almost every
+   line including every `[score]` one, and the diff passes having compared nothing. A neutrality
+   check that filters away what it is comparing is worse than none.
 
 ## Phase 1 — Diagnose the gap honestly
 

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -112,6 +112,8 @@ pnpm bench:merge                      # = bench merge: tiers -> results/results.
 pnpm bench publish                    # re-stage results.json into the web app alone
 pnpm bench:smoke                      # one trivial fn through every available toolchain
 pnpm bench verify apps/benchmark/dataset/real/<p>.json   # compile-check loop for manifests
+pnpm bench regression --base origin/main   # gate: exit 1 on any lost match or vanished row
+pnpm bench diff --base origin/main         # gate: exit 1 if ANY compared field moved, row by row
 cd apps/web && pnpm run build         # the site (the Benchmark view renders results.json)
 ```
 
@@ -170,7 +172,7 @@ Host prerequisites (macOS; verified empirically):
 | `compile/`         | one module per toolchain — real-tier build + candidate steps shared (candidate-compile commands live in `dataset/toolchains/`)                                                  |
 | `eval/`            | `evaluate.ts` (both decompilers on one case), `asmlift.ts`, `m2c.ts`, `m2c-normalizer.ts` (objdump-to-GNU-as normalizer), `outcome.ts` (the symmetric classifier), `quality.ts` |
 | `run/`             | `runner.ts` (the ONE case loop), `orchestrate.ts` (spawns the shards, merges their partial results), `fidelity.ts` (the script-fidelity gate), `smoke.ts`, `verify.ts`          |
-| `report/`          | `merge.ts` (pure: tiers -> results.json), `gap-size.ts`, `repro-scripts.ts` (the embedded per-row scripts), `stale-check.ts`, `publish.ts` (the named cross-app step)           |
+| `report/`          | `merge.ts` (pure: tiers -> results.json), `gap-size.ts`, `repro-scripts.ts`, the three gates (`stale-check`/`regression`/`diff`) over `committed.ts`, `publish.ts`              |
 | `toolchains.ts`    | 4 toolchain adapters over `@asmlift/toolchains` (`buildTarget` + `score`)                                                                                                       |
 | `decomp-config.ts` | candidate compilation through the real `decomp.yaml` user path                                                                                                                  |
 | `cache.ts`         | content-keyed result cache (tmp-then-rename; m2c dirty-checkout fail-closed; versioned key)                                                                                     |

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -14,8 +14,9 @@
 //                                        # pre-publish gate: re-run BOTH repro scripts, every function
 //   pnpm bench merge                     # tiers → results.json, then publish
 //   pnpm bench publish                   # re-stage results.json into the web app
-//   pnpm bench stale-check               # committed vs fresh results (measurement-level)
-//   pnpm bench regression                # committed vs fresh MATCH gate: exit 1 on any lost match
+//   pnpm bench stale-check [--base ref]  # committed vs fresh results (measurement-level)
+//   pnpm bench regression [--base ref]   # committed vs fresh MATCH gate: exit 1 on any lost match
+//   pnpm bench diff [--base ref]         # committed vs fresh per-ROW, per-FIELD: exit 1 on any move
 //   pnpm bench smoke                     # one trivial fn through every available toolchain
 //   pnpm bench verify <manifest.json>    # compile-check loop for authoring real manifests
 //   pnpm bench vendor [--project p]      # freeze the real tier's preprocessed TUs (needs checkouts)
@@ -58,6 +59,10 @@ const { values: opts, positionals } = parseArgs({
     build: { type: 'boolean', default: false },
     out: { type: 'string' },
     'project-root': { type: 'string' },
+    // which committed artifact the comparison gates read. HEAD by default; a branch that has
+    // already committed its own results.json must name its branch point (origin/main), or it
+    // compares itself against itself and every gate passes vacuously.
+    base: { type: 'string' },
   },
 });
 
@@ -233,7 +238,7 @@ switch (command) {
     // exit 0 either way; a thrown safety refusal (shrunk coverage / dirty provenance) exits 1.
     // Emits `stale=true|false` for GitHub Actions when GITHUB_OUTPUT is set.
     const { staleCheck } = await import('./report/stale-check');
-    const verdict = staleCheck();
+    const verdict = staleCheck(opts.base);
     console.log(`stale=${verdict === 'stale'}`);
     if (process.env.GITHUB_OUTPUT) {
       const { appendFileSync } = await import('node:fs');
@@ -245,7 +250,16 @@ switch (command) {
     // The refactor/feature gate `run` deliberately isn't: exit 1 on any match→non-match flip or
     // any committed row missing from the fresh run. Needs a merged results/results.json.
     const { regressionGate } = await import('./report/regression');
-    process.exit(regressionGate());
+    process.exit(regressionGate(opts.base));
+    break;
+  }
+  case 'diff': {
+    // The NEUTRALITY gate: exit 1 if any row's asmlift {outcome,score,candidateLabel,source} or
+    // m2c {outcome,score,source} moved, or if the row set changed. What a refactor, a harness
+    // change or a tooling change has to prove, and what `regression` (outcome only) and
+    // `stale-check` (one word, no row named) each answer half of.
+    const { diffGate } = await import('./report/diff');
+    process.exit(diffGate(opts.base));
     break;
   }
   case 'smoke':
@@ -267,7 +281,7 @@ switch (command) {
   }
   default:
     console.error(
-      `usage: bench <run|target|setup|fidelity|merge|publish|stale-check|regression|smoke|verify|vendor> — got ${JSON.stringify(command)}`,
+      `usage: bench <run|target|setup|fidelity|merge|publish|stale-check|regression|diff|smoke|verify|vendor> — got ${JSON.stringify(command)}`,
     );
     process.exit(2);
 }

--- a/apps/benchmark/src/compile/agbcc.ts
+++ b/apps/benchmark/src/compile/agbcc.ts
@@ -3,13 +3,12 @@
 // @asmlift/toolchains; the decomp.yaml candidate command lives in
 // dataset/toolchains/agbcc/decomp.yaml.
 import { TOOLCHAIN } from '@asmlift/toolchains';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { BuiltTarget } from '../toolchains';
 import type { RealCompile, RealProjectCfg } from './types';
-import { compilerDiagnostics, contentDir, run } from './util';
+import { compilerDiagnostics, contentDir, run, scratchSlot } from './util';
 
 /** .i → agbcc → .s (asmlift ARM input) with the canonical .text/.align tail → as → .o. */
 function assemble(iPath: string, sPath: string, oPath: string): void {
@@ -24,6 +23,11 @@ function assemble(iPath: string, sPath: string, oPath: string): void {
   }
 }
 
+// One scratch dir each, reused per compile (util.ts scratchSlot) instead of one mkdtemp per
+// candidate.
+const candScratch = scratchSlot('bench-cand-');
+const vendorScratch = scratchSlot('bench-vendor-');
+
 export const agbccReal: RealCompile = {
   buildTarget(iText): BuiltTarget {
     const dir = contentDir('arm', iText);
@@ -35,7 +39,7 @@ export const agbccReal: RealCompile = {
     return { obj: oPath, asm: readFileSync(sPath, 'utf8') };
   },
   compileCandidate(tu, sym): string {
-    const dir = mkdtempSync(join(tmpdir(), 'bench-cand-'));
+    const dir = candScratch();
     const cPath = join(dir, 'c.c'),
       iPath = join(dir, 'c.i'),
       sPath = join(dir, 'c.s'),
@@ -51,7 +55,7 @@ export const agbccReal: RealCompile = {
     return oPath;
   },
   preprocess(cfg: RealProjectCfg, tu: string): string {
-    const dir = mkdtempSync(join(tmpdir(), 'bench-vendor-'));
+    const dir = vendorScratch();
     const cPath = join(dir, 'u.c'),
       iPath = join(dir, 'u.i');
     writeFileSync(cPath, tu);

--- a/apps/benchmark/src/compile/gcc272.ts
+++ b/apps/benchmark/src/compile/gcc272.ts
@@ -4,14 +4,14 @@
 // linux/386 container via the pooled helper (gcc272Compile) that score.ts also uses. The object
 // is disassembled + scored with the native host binutils/objdiff.
 import { GCC272_TOOLCHAIN, gcc272Compile } from '@asmlift/toolchains';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { CPP } from '../config';
 import type { BuiltTarget } from '../toolchains';
 import { stripPrototype } from './agbcc';
 import type { RealCompile, RealProjectCfg } from './types';
-import { compilerDiagnostics, contentDir, run, scratchSlot } from './util';
+import { compilerDiagnostics, contentDir, run } from './util';
 
 /** .i → pooled docker GCC 2.7.2 → .o (same helper score.ts uses). */
 function compile(dir: string, iName: string, oName: string): void {
@@ -30,11 +30,6 @@ function disasm(oPath: string): string {
   return dis.stdout;
 }
 
-// One scratch dir each, reused per compile (util.ts scratchSlot) instead of one mkdtemp per
-// candidate — under /tmp, the container pool mount.
-const candScratch = scratchSlot('bench-cand-', '/tmp');
-const vendorScratch = scratchSlot('bench-vendor-', '/tmp');
-
 export const gcc272Real: RealCompile = {
   buildTarget(iText): BuiltTarget {
     const dir = contentDir('gcc272', iText);
@@ -44,7 +39,11 @@ export const gcc272Real: RealCompile = {
     return { obj: oPath, asm: disasm(oPath) };
   },
   compileCandidate(tu, sym): string {
-    const dir = candScratch();
+    // candidate scratch must live under /tmp (the container pool's mount) — and stays ONE
+    // DIRECTORY PER CANDIDATE, leak and all: reusing a path the container reaches through
+    // that shared mount fails ~30% of compiles with `c.o: No such file or directory`
+    // (util.ts scratchSlot carries the measurement)
+    const dir = mkdtempSync(join('/tmp', 'bench-cand-'));
     const cPath = join(dir, 'c.c'),
       iPath = join(dir, 'c.i'),
       oPath = join(dir, 'c.o');
@@ -58,7 +57,7 @@ export const gcc272Real: RealCompile = {
     return oPath;
   },
   preprocess(cfg: RealProjectCfg, tu: string): string {
-    const dir = vendorScratch();
+    const dir = mkdtempSync(join('/tmp', 'bench-vendor-'));
     const cPath = join(dir, 'u.c'),
       iPath = join(dir, 'u.i');
     writeFileSync(cPath, tu);

--- a/apps/benchmark/src/compile/gcc272.ts
+++ b/apps/benchmark/src/compile/gcc272.ts
@@ -4,14 +4,14 @@
 // linux/386 container via the pooled helper (gcc272Compile) that score.ts also uses. The object
 // is disassembled + scored with the native host binutils/objdiff.
 import { GCC272_TOOLCHAIN, gcc272Compile } from '@asmlift/toolchains';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { CPP } from '../config';
 import type { BuiltTarget } from '../toolchains';
 import { stripPrototype } from './agbcc';
 import type { RealCompile, RealProjectCfg } from './types';
-import { compilerDiagnostics, contentDir, run } from './util';
+import { compilerDiagnostics, contentDir, run, scratchSlot } from './util';
 
 /** .i → pooled docker GCC 2.7.2 → .o (same helper score.ts uses). */
 function compile(dir: string, iName: string, oName: string): void {
@@ -30,6 +30,11 @@ function disasm(oPath: string): string {
   return dis.stdout;
 }
 
+// One scratch dir each, reused per compile (util.ts scratchSlot) instead of one mkdtemp per
+// candidate — under /tmp, the container pool mount.
+const candScratch = scratchSlot('bench-cand-', '/tmp');
+const vendorScratch = scratchSlot('bench-vendor-', '/tmp');
+
 export const gcc272Real: RealCompile = {
   buildTarget(iText): BuiltTarget {
     const dir = contentDir('gcc272', iText);
@@ -39,8 +44,7 @@ export const gcc272Real: RealCompile = {
     return { obj: oPath, asm: disasm(oPath) };
   },
   compileCandidate(tu, sym): string {
-    // candidate scratch must live under /tmp (the container pool's mount)
-    const dir = mkdtempSync(join('/tmp', 'bench-cand-'));
+    const dir = candScratch();
     const cPath = join(dir, 'c.c'),
       iPath = join(dir, 'c.i'),
       oPath = join(dir, 'c.o');
@@ -54,7 +58,7 @@ export const gcc272Real: RealCompile = {
     return oPath;
   },
   preprocess(cfg: RealProjectCfg, tu: string): string {
-    const dir = mkdtempSync(join('/tmp', 'bench-vendor-'));
+    const dir = vendorScratch();
     const cPath = join(dir, 'u.c'),
       iPath = join(dir, 'u.i');
     writeFileSync(cPath, tu);

--- a/apps/benchmark/src/compile/ido.ts
+++ b/apps/benchmark/src/compile/ido.ts
@@ -1,15 +1,14 @@
 // IDO / MIPS (N64) — every harness-side spelling of "compile C with IDO": real-tier target
 // build, real-tier candidate compile (shared cc step). Flags come from @asmlift/toolchains.
 import { IDO_TOOLCHAIN } from '@asmlift/toolchains';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { CPP } from '../config';
 import type { BuiltTarget } from '../toolchains';
 import { stripPrototype } from './agbcc';
 import type { RealCompile, RealProjectCfg } from './types';
-import { compilerDiagnostics, contentDir, run } from './util';
+import { compilerDiagnostics, contentDir, run, scratchSlot } from './util';
 
 /** .i → IDO cc → .o. Shared by target and candidate. */
 function compile(iPath: string, oPath: string): void {
@@ -27,6 +26,11 @@ function disasm(oPath: string): string {
   return dis.stdout;
 }
 
+// One scratch dir each, reused per compile (util.ts scratchSlot) instead of one mkdtemp per
+// candidate.
+const candScratch = scratchSlot('bench-cand-');
+const vendorScratch = scratchSlot('bench-vendor-');
+
 export const idoReal: RealCompile = {
   buildTarget(iText): BuiltTarget {
     const dir = contentDir('ido', iText);
@@ -37,7 +41,7 @@ export const idoReal: RealCompile = {
     return { obj: oPath, asm: disasm(oPath) };
   },
   compileCandidate(tu, sym): string {
-    const dir = mkdtempSync(join(tmpdir(), 'bench-cand-'));
+    const dir = candScratch();
     const cPath = join(dir, 'c.c'),
       iPath = join(dir, 'c.i'),
       oPath = join(dir, 'c.o');
@@ -51,7 +55,7 @@ export const idoReal: RealCompile = {
     return oPath;
   },
   preprocess(cfg: RealProjectCfg, tu: string): string {
-    const dir = mkdtempSync(join(tmpdir(), 'bench-vendor-'));
+    const dir = vendorScratch();
     const cPath = join(dir, 'u.c'),
       iPath = join(dir, 'u.i');
     writeFileSync(cPath, tu);

--- a/apps/benchmark/src/compile/kmc.ts
+++ b/apps/benchmark/src/compile/kmc.ts
@@ -3,14 +3,14 @@
 // cannot express the container pool, so the harness strips this toolchain's decomp.yaml
 // compiler — the registry built-in serves candidate scoring).
 import { GCC_KMC_TOOLCHAIN, kmcCompile } from '@asmlift/toolchains';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { CPP } from '../config';
 import type { BuiltTarget } from '../toolchains';
 import { stripPrototype } from './agbcc';
 import type { RealCompile, RealProjectCfg } from './types';
-import { compilerDiagnostics, contentDir, run, scratchSlot } from './util';
+import { compilerDiagnostics, contentDir, run } from './util';
 
 /** .i → pooled docker KMC gcc → .o (same helper score.ts uses). */
 function compile(dir: string, iName: string, oName: string): void {
@@ -29,11 +29,6 @@ function disasm(oPath: string): string {
   return dis.stdout;
 }
 
-// One scratch dir each, reused per compile (util.ts scratchSlot) instead of one mkdtemp per
-// candidate — under /tmp, the container pool mount.
-const candScratch = scratchSlot('bench-cand-', '/tmp');
-const vendorScratch = scratchSlot('bench-vendor-', '/tmp');
-
 export const kmcReal: RealCompile = {
   buildTarget(iText): BuiltTarget {
     const dir = contentDir('gcc', iText);
@@ -44,7 +39,11 @@ export const kmcReal: RealCompile = {
     return { obj: oPath, asm: disasm(oPath) };
   },
   compileCandidate(tu, sym): string {
-    const dir = candScratch();
+    // candidate scratch must live under /tmp (the container pool's mount) — and stays ONE
+    // DIRECTORY PER CANDIDATE, leak and all: reusing a path the container reaches through
+    // that shared mount fails ~30% of compiles with `c.o: No such file or directory`
+    // (util.ts scratchSlot carries the measurement)
+    const dir = mkdtempSync(join('/tmp', 'bench-cand-'));
     const cPath = join(dir, 'c.c'),
       iPath = join(dir, 'c.i'),
       oPath = join(dir, 'c.o');
@@ -58,7 +57,7 @@ export const kmcReal: RealCompile = {
     return oPath;
   },
   preprocess(cfg: RealProjectCfg, tu: string): string {
-    const dir = vendorScratch();
+    const dir = mkdtempSync(join('/tmp', 'bench-vendor-'));
     const cPath = join(dir, 'u.c'),
       iPath = join(dir, 'u.i');
     writeFileSync(cPath, tu);

--- a/apps/benchmark/src/compile/kmc.ts
+++ b/apps/benchmark/src/compile/kmc.ts
@@ -3,14 +3,14 @@
 // cannot express the container pool, so the harness strips this toolchain's decomp.yaml
 // compiler — the registry built-in serves candidate scoring).
 import { GCC_KMC_TOOLCHAIN, kmcCompile } from '@asmlift/toolchains';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { CPP } from '../config';
 import type { BuiltTarget } from '../toolchains';
 import { stripPrototype } from './agbcc';
 import type { RealCompile, RealProjectCfg } from './types';
-import { compilerDiagnostics, contentDir, run } from './util';
+import { compilerDiagnostics, contentDir, run, scratchSlot } from './util';
 
 /** .i → pooled docker KMC gcc → .o (same helper score.ts uses). */
 function compile(dir: string, iName: string, oName: string): void {
@@ -29,6 +29,11 @@ function disasm(oPath: string): string {
   return dis.stdout;
 }
 
+// One scratch dir each, reused per compile (util.ts scratchSlot) instead of one mkdtemp per
+// candidate — under /tmp, the container pool mount.
+const candScratch = scratchSlot('bench-cand-', '/tmp');
+const vendorScratch = scratchSlot('bench-vendor-', '/tmp');
+
 export const kmcReal: RealCompile = {
   buildTarget(iText): BuiltTarget {
     const dir = contentDir('gcc', iText);
@@ -39,8 +44,7 @@ export const kmcReal: RealCompile = {
     return { obj: oPath, asm: disasm(oPath) };
   },
   compileCandidate(tu, sym): string {
-    // candidate scratch must live under /tmp (the container pool's mount)
-    const dir = mkdtempSync(join('/tmp', 'bench-cand-'));
+    const dir = candScratch();
     const cPath = join(dir, 'c.c'),
       iPath = join(dir, 'c.i'),
       oPath = join(dir, 'c.o');
@@ -54,7 +58,7 @@ export const kmcReal: RealCompile = {
     return oPath;
   },
   preprocess(cfg: RealProjectCfg, tu: string): string {
-    const dir = mkdtempSync(join('/tmp', 'bench-vendor-'));
+    const dir = vendorScratch();
     const cPath = join(dir, 'u.c'),
       iPath = join(dir, 'u.i');
     writeFileSync(cPath, tu);

--- a/apps/benchmark/src/compile/util.ts
+++ b/apps/benchmark/src/compile/util.ts
@@ -3,7 +3,8 @@ import { C_TYPEDEFS } from '@asmlift/core/target';
 import { spawnFailure } from '@asmlift/toolchains';
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 /** Throws the named setup error when the binary itself couldn't spawn (ENOENT/timeout) —
@@ -78,6 +79,27 @@ export function contentDir(tag: string, tu: string): string {
   const d = join('/tmp', `bench-real-${tag}-${createHash('sha256').update(tu).digest('hex').slice(0, 16)}`);
   mkdirSync(d, { recursive: true });
   return d;
+}
+
+/** A scratch directory REUSED across calls: made once, EMPTIED before each use. mkdtemp removes
+ *  nothing, so the natural per-compile spelling leaks one directory per candidate — a full bench
+ *  run leaves one per candidate compile behind, and they had accumulated into the millions.
+ *  Emptied rather than reused in place, so a step that exits 0 without writing its output still
+ *  fails LOUD on the missing file instead of silently reading the previous candidate's.
+ *
+ *  `root` is `/tmp` for the DOCKERIZED toolchains — that is the container pool's mount, not a
+ *  stylistic choice — and the OS temp dir for everything else. */
+export function scratchSlot(prefix: string, root: string = tmpdir()): () => string {
+  let dir: string | undefined;
+  return () => {
+    if (dir === undefined) {
+      dir = mkdtempSync(join(root, prefix));
+      return dir;
+    }
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir);
+    return dir;
+  };
 }
 
 export const shq = (s: string): string => `'${s.replaceAll("'", `'\\''`)}'`;

--- a/apps/benchmark/src/compile/util.ts
+++ b/apps/benchmark/src/compile/util.ts
@@ -93,11 +93,11 @@ export function contentDir(tag: string, tu: string): string {
  *  failures reusing the path, 0/160 with a fresh mkdtemp each time (emptying the CONTENTS and
  *  keeping the inode fails identically, so it is the shared mount's view of the path, not the
  *  inode). gcc272.ts and kmc.ts therefore keep mkdtemp-per-candidate and keep the leak. */
-export function scratchSlot(prefix: string, root: string = tmpdir()): () => string {
+export function scratchSlot(prefix: string): () => string {
   let dir: string | undefined;
   return () => {
     if (dir === undefined) {
-      dir = mkdtempSync(join(root, prefix));
+      dir = mkdtempSync(join(tmpdir(), prefix));
       return dir;
     }
     rmSync(dir, { recursive: true, force: true });

--- a/apps/benchmark/src/compile/util.ts
+++ b/apps/benchmark/src/compile/util.ts
@@ -83,12 +83,16 @@ export function contentDir(tag: string, tu: string): string {
 
 /** A scratch directory REUSED across calls: made once, EMPTIED before each use. mkdtemp removes
  *  nothing, so the natural per-compile spelling leaks one directory per candidate — a full bench
- *  run leaves one per candidate compile behind, and they had accumulated into the millions.
+ *  run leaves one behind per candidate compile, and they had accumulated into the millions.
  *  Emptied rather than reused in place, so a step that exits 0 without writing its output still
  *  fails LOUD on the missing file instead of silently reading the previous candidate's.
  *
- *  `root` is `/tmp` for the DOCKERIZED toolchains — that is the container pool's mount, not a
- *  stylistic choice — and the OS temp dir for everything else. */
+ *  NOT for a directory the DOCKERIZED toolchains compile in. Those reach their scratch through a
+ *  bind mount of the host `/tmp`, and reusing one path there fails ~30% of compiles with
+ *  `c.o: No such file or directory` — measured, 4 concurrent workers × 40 compiles: 50/160
+ *  failures reusing the path, 0/160 with a fresh mkdtemp each time (emptying the CONTENTS and
+ *  keeping the inode fails identically, so it is the shared mount's view of the path, not the
+ *  inode). gcc272.ts and kmc.ts therefore keep mkdtemp-per-candidate and keep the leak. */
 export function scratchSlot(prefix: string, root: string = tmpdir()): () => string {
   let dir: string | undefined;
   return () => {

--- a/apps/benchmark/src/eval/m2c.ts
+++ b/apps/benchmark/src/eval/m2c.ts
@@ -6,10 +6,10 @@
 // DECLINE marker, classified by the caller via outcome.ts); this runner scans only for m2c's
 // hard-failure report.
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { scratchSlot } from '../compile/util';
 import { M2C_DIR, M2C_PINNED_COMMIT } from '../config';
 import type { Toolchain } from '../toolchains';
 import { disasmToM2c, m2cTarget } from './m2c-normalizer';
@@ -42,6 +42,10 @@ export interface M2cOptions {
   lang?: 'c' | 'c++'; // 'c++' switches the mwcc target to ppc-mwcc-c++; no effect elsewhere
 }
 
+// One scratch dir, reused per invocation (compile/util.ts scratchSlot) instead of one mkdtemp
+// per row.
+const m2cScratch = scratchSlot('bench-m2c-');
+
 /** Feed a function to m2c. `asm` is the objdump text (MIPS/PPC) or agbcc `.s` (ARM); `asmKind`
  *  selects whether to normalize. Output classification (failed vs declined vs compile+score) is
  *  the caller's job via outcome.ts — this runner only detects "produced no usable output at all". */
@@ -55,7 +59,7 @@ export function runM2c(tc: Toolchain, sym: string, asm: string, opts: M2cOptions
     );
   }
   const asmText = tc.asmKind === 'objdump' ? disasmToM2c(asm, tc.isa === 'ppc' ? 'ppc' : 'mips', opts.asmDump) : asm; // agbcc .s is already GNU-as
-  const dir = mkdtempSync(join(tmpdir(), 'bench-m2c-'));
+  const dir = m2cScratch();
   const asmPath = join(dir, 'in.s');
   writeFileSync(asmPath, asmText);
   const args = ['m2c.py', '-t', m2cTarget(tc.compiler, opts.lang), '-f', sym, '--no-cache'];

--- a/apps/benchmark/src/report/committed.ts
+++ b/apps/benchmark/src/report/committed.ts
@@ -4,7 +4,7 @@
 // ITSELF and every gate passes vacuously — which is why the real check is against the branch
 // POINT (`origin/main`), and why every gate here takes a `--base`.
 import type { BenchOutput, FunctionResult } from '@asmlift/bench-schema';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 import { REPO_ROOT } from '../config';
 
@@ -14,7 +14,15 @@ export const RESULTS_PATH = 'apps/benchmark/results/results.json';
 export function readCommitted(ref = 'HEAD'): BenchOutput {
   let raw: string;
   try {
-    raw = execSync(`git show ${ref}:${RESULTS_PATH}`, { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 256e6 });
+    // execFile, not a shell string: `ref` comes straight from `--base`, and a shell would have to
+    // be trusted with whatever it contains — a ref with a space, a `$` or a `;` in it would
+    // otherwise be re-split, expanded or run rather than read.
+    raw = execFileSync('git', ['show', `${ref}:${RESULTS_PATH}`], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 256e6,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
   } catch (e) {
     throw new Error(
       `cannot read ${RESULTS_PATH} at '${ref}' — fetch the ref first (git fetch origin) or pass a --base that exists: ${

--- a/apps/benchmark/src/report/committed.ts
+++ b/apps/benchmark/src/report/committed.ts
@@ -1,0 +1,37 @@
+// Reading the COMMITTED results.json, for the three gates that compare a fresh run against it
+// (stale-check, regression, diff). One place, because the ref they read is part of the answer:
+// on a branch that has already committed its own artifact, `HEAD` compares the branch against
+// ITSELF and every gate passes vacuously — which is why the real check is against the branch
+// POINT (`origin/main`), and why every gate here takes a `--base`.
+import type { BenchOutput, FunctionResult } from '@asmlift/bench-schema';
+import { execSync } from 'node:child_process';
+
+import { REPO_ROOT } from '../config';
+
+export const RESULTS_PATH = 'apps/benchmark/results/results.json';
+
+/** The artifact as of `ref` (a commit, tag or branch — `HEAD` by default). */
+export function readCommitted(ref = 'HEAD'): BenchOutput {
+  let raw: string;
+  try {
+    raw = execSync(`git show ${ref}:${RESULTS_PATH}`, { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 256e6 });
+  } catch (e) {
+    throw new Error(
+      `cannot read ${RESULTS_PATH} at '${ref}' — fetch the ref first (git fetch origin) or pass a --base that exists: ${
+        e instanceof Error ? e.message.split('\n')[0] : e
+      }`,
+    );
+  }
+  return JSON.parse(raw) as BenchOutput;
+}
+
+/** Scratch-dir names and machine temp paths are run-local noise, not measurement: a cold run
+ *  re-mints them inside embedded asm comments, so comparing them raw reports a change that no
+ *  reader could act on. */
+export const scrub = (s: string): string =>
+  s
+    .replace(/(?:asmlift|bench)-[A-Za-z0-9-]+-[A-Za-z0-9]{6}/g, '<scratch>')
+    .replace(/\/host-tmp\S*|\/var\/folders\S*|\/tmp\/\S*/g, '<tmp>');
+
+/** Every row keyed by id — the shape all three gates walk. */
+export const byId = (o: BenchOutput): Map<string, FunctionResult> => new Map(o.results.map((r) => [r.id, r]));

--- a/apps/benchmark/src/report/diff.ts
+++ b/apps/benchmark/src/report/diff.ts
@@ -1,0 +1,112 @@
+// The MEASUREMENT-NEUTRALITY gate: did anything a reader would quote move, per row, per field?
+//
+// `regression` answers "did a match get lost" and `stale-check` answers "may this run replace the
+// dataset". Neither answers the question a refactor, a harness change or a tooling change has to
+// answer — "did this change ANY number at all" — because `regression` compares `outcome` only (a
+// row that slid from diff:12 to diff:14 passes it) and `stale-check` collapses the whole artifact
+// to one 'stale'/'fresh' word with no row and no field named.
+//
+// So every branch that had to prove neutrality wrote its own comparator, against its own idea of
+// which fields count. This is that comparison, once: for every row in the base artifact, the six
+// fields a published claim is made of, named individually when they move.
+import type { BenchOutput, FunctionResult } from '@asmlift/bench-schema';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { RESULTS_DIR } from '../config';
+import { byId, readCommitted, scrub } from './committed';
+
+/** The fields a published claim is made of. `source` is in the list because a change that moves
+ *  no score can still rewrite what the report shows, and `candidateLabel` because the ranked
+ *  WINNER can change identity at an unchanged score (a tie-break moving is a real change). */
+const FIELDS = {
+  asmlift: ['outcome', 'score', 'candidateLabel', 'source'],
+  m2c: ['outcome', 'score', 'source'],
+} as const;
+
+export interface FieldChange {
+  id: string;
+  field: string; // e.g. "asmlift.score"
+  from: string;
+  to: string;
+}
+export interface DiffReport {
+  changed: FieldChange[];
+  added: string[];
+  removed: string[];
+  baseRows: number;
+  freshRows: number;
+  ok: boolean;
+}
+
+// Long text is reported by its shape, not pasted: a 40-line C body in a gate's output buries the
+// one line that says which row moved.
+const show = (field: string, v: unknown): string => {
+  if (v === undefined || v === null) {
+    return String(v);
+  }
+  if (field.endsWith('source')) {
+    return `${String(v).length} bytes`;
+  }
+  return typeof v === 'string' ? v : JSON.stringify(v);
+};
+
+export function compareMeasurements(base: BenchOutput, fresh: BenchOutput): DiffReport {
+  const freshById = byId(fresh);
+  const baseIds = new Set(base.results.map((r) => r.id));
+  const changed: FieldChange[] = [];
+  const removed: string[] = [];
+
+  for (const was of base.results) {
+    const now = freshById.get(was.id);
+    if (!now) {
+      removed.push(was.id);
+      continue;
+    }
+    for (const side of ['asmlift', 'm2c'] as const) {
+      for (const f of FIELDS[side]) {
+        const a = (was[side] as unknown as Record<string, unknown>)[f];
+        const b = (now[side] as unknown as Record<string, unknown>)[f];
+        // sources are compared SCRUBBED, the same measurement-level equality stale-check uses:
+        // a cold run re-mints scratch-dir names inside embedded asm comments
+        const [x, y] = f === 'source' ? [scrub(String(a ?? '')), scrub(String(b ?? ''))] : [a, b];
+        if (x !== y) {
+          changed.push({ id: was.id, field: `${side}.${f}`, from: show(f, a), to: show(f, b) });
+        }
+      }
+    }
+  }
+  const added = fresh.results.filter((r: FunctionResult) => !baseIds.has(r.id)).map((r) => r.id);
+  return {
+    changed,
+    added,
+    removed,
+    baseRows: base.results.length,
+    freshRows: fresh.results.length,
+    ok: changed.length === 0 && added.length === 0 && removed.length === 0,
+  };
+}
+
+/** CLI entry: the artifact at `base` vs the freshly merged one. Returns the process exit code —
+ *  0 iff not one compared field moved and the row set is identical. */
+export function diffGate(base = 'HEAD'): number {
+  const report = compareMeasurements(
+    readCommitted(base),
+    JSON.parse(readFileSync(join(RESULTS_DIR, 'results.json'), 'utf8')) as BenchOutput,
+  );
+
+  for (const c of report.changed) {
+    console.log(`CHANGED ${c.id} ${c.field}: ${c.from} → ${c.to}`);
+  }
+  for (const id of report.removed) {
+    console.log(`REMOVED ${id} — present at ${base}, absent from the fresh run (toolchain skipped?)`);
+  }
+  for (const id of report.added) {
+    console.log(`ADDED   ${id}`);
+  }
+  console.log(
+    `diff vs ${base}: ${report.changed.length} field change(s), ${report.added.length} added, ` +
+      `${report.removed.length} removed (${report.baseRows} base rows, ${report.freshRows} fresh rows)`,
+  );
+  return report.ok ? 0 : 1;
+}

--- a/apps/benchmark/src/report/regression.ts
+++ b/apps/benchmark/src/report/regression.ts
@@ -7,11 +7,11 @@
 // row missing from the fresh run (a silently-skipped toolchain reads as "no regression" without
 // this), exits non-zero.
 import type { BenchOutput, DecompilerId, Outcome } from '@asmlift/bench-schema';
-import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { REPO_ROOT, RESULTS_DIR } from '../config';
+import { RESULTS_DIR } from '../config';
+import { readCommitted } from './committed';
 
 export interface OutcomeFlip {
   id: string;
@@ -66,16 +66,12 @@ export function compareOutcomes(committed: BenchOutput, fresh: BenchOutput): Reg
   return { missing, lost, gained, changed, ok: missing.length === 0 && lost.length === 0 };
 }
 
-/** CLI entry: committed HEAD results.json vs the freshly merged one. Returns the process exit
- *  code — 0 iff no match was lost AND no committed row vanished. */
-export function regressionGate(): number {
-  const committed = JSON.parse(
-    execSync('git show HEAD:apps/benchmark/results/results.json', {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-      maxBuffer: 256e6,
-    }),
-  ) as BenchOutput;
+/** CLI entry: the committed results.json at `base` vs the freshly merged one. Returns the process
+ *  exit code — 0 iff no match was lost AND no committed row vanished. `base` defaults to HEAD;
+ *  a branch that has already committed its own artifact must pass its branch point instead, or
+ *  this compares the branch against itself. */
+export function regressionGate(base = 'HEAD'): number {
+  const committed = readCommitted(base);
   const fresh = JSON.parse(readFileSync(join(RESULTS_DIR, 'results.json'), 'utf8')) as BenchOutput;
   const report = compareOutcomes(committed, fresh);
 

--- a/apps/benchmark/src/report/stale-check.ts
+++ b/apps/benchmark/src/report/stale-check.ts
@@ -7,17 +7,11 @@
 //     were skipped): committing would destroy data, not refresh it
 //   - dirty provenance: numbers from uncommitted code must never be published
 import type { BenchOutput, FunctionResult } from '@asmlift/bench-schema';
-import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { REPO_ROOT, RESULTS_DIR } from '../config';
-
-/** Scratch-dir names and machine temp paths are run-local noise, not measurement. */
-const scrub = (s: string): string =>
-  s
-    .replace(/(?:asmlift|bench)-[A-Za-z0-9-]+-[A-Za-z0-9]{6}/g, '<scratch>')
-    .replace(/\/host-tmp\S*|\/var\/folders\S*|\/tmp\/\S*/g, '<tmp>');
+import { RESULTS_DIR } from '../config';
+import { readCommitted, scrub } from './committed';
 
 const rowKey = (r: FunctionResult): string =>
   JSON.stringify({
@@ -28,14 +22,8 @@ const rowKey = (r: FunctionResult): string =>
     refSource: r.refSource,
   });
 
-export function staleCheck(): 'stale' | 'fresh' {
-  const committed = JSON.parse(
-    execSync('git show HEAD:apps/benchmark/results/results.json', {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-      maxBuffer: 256e6,
-    }),
-  ) as BenchOutput;
+export function staleCheck(base = 'HEAD'): 'stale' | 'fresh' {
+  const committed = readCommitted(base);
   const fresh = JSON.parse(readFileSync(join(RESULTS_DIR, 'results.json'), 'utf8')) as BenchOutput;
 
   if (fresh.meta.asmlift?.dirty !== false) {

--- a/apps/benchmark/test/compile-util.test.ts
+++ b/apps/benchmark/test/compile-util.test.ts
@@ -1,8 +1,10 @@
 // Pin tests for compilerDiagnostics — the compile modules embed its output in the Error
 // messages that become row error markers, so it must surface real diagnostics, not banners.
+import { existsSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, test } from 'vitest';
 
-import { compilerDiagnostics, pickDiagnostics } from '../src/compile/util';
+import { compilerDiagnostics, pickDiagnostics, scratchSlot } from '../src/compile/util';
 
 describe('compilerDiagnostics (pinned)', () => {
   test('pre-3.0 gcc diagnostics (no "error" keyword) survive via their file:line prefix', () => {
@@ -76,5 +78,24 @@ describe('compilerDiagnostics is machine-independent', () => {
 
   test('a relative path is left alone', () => {
     expect(compilerDiagnostics('c.i:12: parse error')).toBe('c.i:12: parse error');
+  });
+});
+
+describe('scratchSlot (the leak fix)', () => {
+  test('one directory across calls, EMPTIED each time — so a stale sibling can never be read', () => {
+    const slot = scratchSlot('bench-slot-test-');
+    const first = slot();
+    writeFileSync(join(first, 'left-behind'), 'x');
+    const second = slot();
+    expect(second).toBe(first); // one directory, not one per call
+    expect(existsSync(join(second, 'left-behind'))).toBe(false); // emptied, so a missing output stays LOUD
+    rmSync(first, { recursive: true, force: true });
+  });
+
+  test('the root is honoured — the dockerized toolchains need /tmp, the container pool mount', () => {
+    const slot = scratchSlot('bench-slot-root-', '/tmp');
+    const dir = slot();
+    expect(dir.startsWith('/tmp/bench-slot-root-') || dir.startsWith('/private/tmp/bench-slot-root-')).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/apps/benchmark/test/compile-util.test.ts
+++ b/apps/benchmark/test/compile-util.test.ts
@@ -91,11 +91,4 @@ describe('scratchSlot (the leak fix)', () => {
     expect(existsSync(join(second, 'left-behind'))).toBe(false); // emptied, so a missing output stays LOUD
     rmSync(first, { recursive: true, force: true });
   });
-
-  test('the root is honoured — the dockerized toolchains need /tmp, the container pool mount', () => {
-    const slot = scratchSlot('bench-slot-root-', '/tmp');
-    const dir = slot();
-    expect(dir.startsWith('/tmp/bench-slot-root-') || dir.startsWith('/private/tmp/bench-slot-root-')).toBe(true);
-    rmSync(dir, { recursive: true, force: true });
-  });
 });

--- a/apps/benchmark/test/diff.test.ts
+++ b/apps/benchmark/test/diff.test.ts
@@ -1,0 +1,77 @@
+// Pin tests for the measurement-neutrality gate: which fields it watches, and the two kinds of
+// difference it must NOT report (provenance, and run-local scratch names inside a source).
+import type { BenchOutput, DecompilerResult, FunctionResult, Outcome } from '@asmlift/bench-schema';
+import { describe, expect, test } from 'vitest';
+
+import { compareMeasurements } from '../src/report/diff';
+
+const res = (over: Partial<DecompilerResult> = {}): DecompilerResult =>
+  ({
+    decompiler: 'asmlift',
+    outcome: 'nonmatch' as Outcome,
+    source: 'void f(void) {}',
+    score: 12,
+    maxScore: 40,
+    compileErrors: null,
+    quality: { score: 0, lines: 0, gotos: 0, casts: 0, unkGlue: 0, rawMem: 0, addrDeref: 0 },
+    ...over,
+  }) as DecompilerResult;
+
+const row = (
+  id: string,
+  asmlift: Partial<DecompilerResult> = {},
+  m2c: Partial<DecompilerResult> = {},
+): FunctionResult => ({ id, asmlift: res(asmlift), m2c: { ...res(m2c), decompiler: 'm2c' } }) as FunctionResult;
+
+const out = (...results: FunctionResult[]): BenchOutput =>
+  ({ meta: { generatedAt: 'whenever' }, results }) as unknown as BenchOutput;
+
+describe('compareMeasurements', () => {
+  test('identical rows: nothing moved', () => {
+    const r = compareMeasurements(out(row('a')), out(row('a')));
+    expect(r.ok).toBe(true);
+    expect(r.changed).toEqual([]);
+  });
+
+  test('a score that moves without changing the outcome is caught — the case `regression` misses', () => {
+    const r = compareMeasurements(out(row('a', { score: 12 })), out(row('a', { score: 14 })));
+    expect(r.ok).toBe(false);
+    expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.score', from: '12', to: '14' }]);
+  });
+
+  test('the ranked WINNER changing identity at an equal score is a change', () => {
+    const r = compareMeasurements(
+      out(row('a', { candidateLabel: 'signed' })),
+      out(row('a', { candidateLabel: 'signed/flip-join' })),
+    );
+    expect(r.changed.map((c) => c.field)).toEqual(['asmlift.candidateLabel']);
+  });
+
+  test('both decompilers are watched, and source is reported by size not pasted', () => {
+    const r = compareMeasurements(out(row('a')), out(row('a', {}, { source: 'void f(void) { /* longer */ }' })));
+    expect(r.changed).toEqual([{ id: 'a', field: 'm2c.source', from: '15 bytes', to: '29 bytes' }]);
+  });
+
+  test('a run-local scratch name inside a source is NOT a measurement change', () => {
+    const r = compareMeasurements(
+      out(row('a', { source: '/* asmlift-usercc-Ab12Cd/cand.c */ void f(void) {}' })),
+      out(row('a', { source: '/* asmlift-usercc-Zz98Yx/cand.c */ void f(void) {}' })),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('a vanished row is REMOVED, a new row is ADDED, and either fails the gate', () => {
+    const r = compareMeasurements(out(row('a'), row('b')), out(row('a'), row('c')));
+    expect(r.removed).toEqual(['b']);
+    expect(r.added).toEqual(['c']);
+    expect(r.ok).toBe(false);
+  });
+
+  test('provenance and timings are not compared — only the six fields', () => {
+    const base = out(row('a'));
+    const fresh = out(row('a'));
+    (fresh.meta as Record<string, unknown>).generatedAt = 'much later';
+    (fresh.results[0].asmlift as unknown as Record<string, unknown>).maxScore = 999;
+    expect(compareMeasurements(base, fresh).ok).toBe(true);
+  });
+});

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,6 +35,7 @@ usage: asmlift <file.s|file.asm|file.o|-> [--target <agbcc|ido7.1|gcc2.7.2kmc|gc
                 [--name <symbol>] [--backend <c|pascal>] [--strict]
                 [--config <decomp.yaml>] [--score-against <target.o>]
                 [--asm-data <dump.txt>] [--proto <proto.json>]
+                [--jobs <n>] [--progress]
 ```
 
 | Flag              | Meaning                                                                                                                                                                                                                                                                                                    |
@@ -47,6 +48,8 @@ usage: asmlift <file.s|file.asm|file.o|-> [--target <agbcc|ido7.1|gcc2.7.2kmc|gc
 | `--score-against` | Compile the output (and every ranked candidate) and objdiff-score it against this object. Implies strict; the per-candidate score table goes to stderr                                                                                                                                                     |
 | `--asm-data`      | For text input: an `objdump -s -r -t` dump of the object the asm came from, supplying the data sections text lacks (jump tables, anonymous constants). Object-file input extracts this itself and does not take the flag                                                                                   |
 | `--proto`         | Function prototypes as JSON (`{"sym": {"params": N \| ["u8", ...], "returnsVoid": true}, ...}`): a callee's params drives its call-argument recovery; the decompiled function's own entry supplies its void-ness. Every entry is validated — a malformed one is refused (exit `64`), never quietly ignored |
+| `--jobs`          | With `--score-against`: compile `n` candidates at a time (default `1`). Candidate compiles are the bulk of a ranked run and are independent; the ranking is unchanged — the schedule cannot choose the winner                                                                                              |
+| `--progress`      | With `--score-against`: an `asmlift: [progress] i/n candidates scored` liveness line on stderr every few seconds. The `[score]` table is unchanged, so two runs still compare on their `[score]` lines                                                                                                     |
 
 Exit codes: `0` clean (or byte-exact match when scoring) · `1` gaps, declined, or nonmatch —
 the stderr tag says which (`[declined]` = principled refusal, `[internal error]` = bug) ·

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,6 +51,10 @@ usage: asmlift <file.s|file.asm|file.o|-> [--target <agbcc|ido7.1|gcc2.7.2kmc|gc
 | `--jobs`          | With `--score-against`: compile `n` candidates at a time (default `1`). Candidate compiles are the bulk of a ranked run and are independent; the ranking is unchanged — the schedule cannot choose the winner                                                                                              |
 | `--progress`      | With `--score-against`: an `asmlift: [progress] i/n candidates scored` liveness line on stderr every few seconds. The `[score]` table is unchanged, so two runs still compare on their `[score]` lines                                                                                                     |
 
+Above `--jobs 1` it is YOUR `compiler` template that runs concurrently. Each worker gets its own
+`{{inputPath}}`/`{{outputPath}}` scratch directory, but every worker runs from the config's
+directory, so a template that writes to a fixed path inside the project races itself.
+
 Exit codes: `0` clean (or byte-exact match when scoring) · `1` gaps, declined, or nonmatch —
 the stderr tag says which (`[declined]` = principled refusal, `[internal error]` = bug) ·
 `64` usage error · `66` unreadable input.

--- a/packages/cli/src/compile-command.ts
+++ b/packages/cli/src/compile-command.ts
@@ -185,8 +185,14 @@ export function compilersFromCommand(template: string, opts: CompileCommandOptio
       const p = spawn('sh', ['-ec', cmd], { cwd: opts.cwd });
       let out = '',
         err = '';
-      p.stdout.on('data', (d) => (out += d));
-      p.stderr.on('data', (d) => (err += d));
+      // DECODED as it arrives, not concatenated as Buffers: `'' + buf` decodes each chunk on its
+      // own, so a multi-byte character straddling a chunk boundary would come out as replacement
+      // characters here and not in the sync runner (spawnSync decodes the whole buffer at once).
+      // The two must report a failed compile with the same text.
+      p.stdout.setEncoding('utf8');
+      p.stderr.setEncoding('utf8');
+      p.stdout.on('data', (d: string) => (out += d));
+      p.stderr.on('data', (d: string) => (err += d));
       // A shell that never starts is reported like any other failed compile, not as a rejected
       // promise: the ranked driver reads a THROWN compile the same way whichever runner produced
       // it, and a second `res` after `close` is a no-op.

--- a/packages/cli/src/compile-command.ts
+++ b/packages/cli/src/compile-command.ts
@@ -126,6 +126,12 @@ export function compilersFromCommand(template: string, opts: CompileCommandOptio
   // 1.5M. Emptied rather than reused: a step that exits 0 without writing its output must still
   // fail LOUD, and a surviving sibling from the previous candidate is exactly what would let it
   // pass (the same class of silent truncation the `sh -ec` note above is about).
+  //
+  // Reuse is safe HERE because the template runs a fresh process per compile against the host
+  // filesystem. It is NOT safe for a template that keeps a long-lived container with this
+  // directory's parent bind-mounted: the benchmark's dockerized toolchains measured ~30% of
+  // compiles failing on a reused path (apps/benchmark/src/compile/util.ts `scratchSlot`), which
+  // is why they still mkdtemp per candidate.
   const slot = (): (() => string) => {
     let dir: string | undefined;
     return () => {

--- a/packages/cli/src/compile-command.ts
+++ b/packages/cli/src/compile-command.ts
@@ -9,8 +9,8 @@
 // This module is deliberately free of score.ts/objdiff imports so the CLI can build a compiler
 // from config without loading the objdiff wasm, and so its tests stay offline.
 import { C_TYPEDEFS } from '@asmlift/core/target';
-import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -60,6 +60,25 @@ const PROBE_DECLS = renderDeclarations([
  *  simply ignore the argument — their context IS the headers world. */
 export type CandidateCompiler = (source: string, symbol: string, backendId: string, declarations?: string) => string;
 
+/** The same contract, run without blocking the event loop, so several candidates can compile at
+ *  once. Each worker owns its own scratch slot, so one worker's object survives exactly until
+ *  that worker compiles its next candidate — the caller must consume it before asking for
+ *  another (`rank.ts`'s pool scores each object the moment it lands). */
+export type AsyncCandidateCompiler = (
+  source: string,
+  symbol: string,
+  backendId: string,
+  declarations?: string,
+) => Promise<string>;
+
+/** One compiler instance in both flavours. `compile` is the synchronous contract every existing
+ *  caller uses; `worker()` mints an INDEPENDENT async compiler with its own scratch slot — call
+ *  it once per pool worker. Both share the one cached world probe below. */
+export interface CommandCompilers {
+  compile: CandidateCompiler;
+  worker: () => AsyncCandidateCompiler;
+}
+
 export interface CompileCommandOptions {
   /** Working directory for the command — the decomp.yaml's directory, so project-relative
    *  paths (`./tools/agbcc/bin/agbcc`) resolve regardless of where asmlift was invoked. */
@@ -89,7 +108,7 @@ const safe = (value: string, what: string): string => {
  *  TRUNCATED object gets scored (found scoring real 22/28/38 phantoms in the klonoa dogfood).
  *  A non-zero exit or a missing output object throws with the full command + its stderr —
  *  configured means configured, there is no fallback. */
-export function compileFromCommand(template: string, opts: CompileCommandOptions = {}): CandidateCompiler {
+export function compilersFromCommand(template: string, opts: CompileCommandOptions = {}): CommandCompilers {
   if (!template.includes('{{inputPath}}') || !template.includes('{{outputPath}}')) {
     throw new Error(`compiler command must contain {{inputPath}} and {{outputPath}} placeholders — got: ${template}`);
   }
@@ -101,9 +120,29 @@ export function compileFromCommand(template: string, opts: CompileCommandOptions
       `compiler command has an unknown placeholder ${unknown[0]} — supported: {{inputPath}}, {{outputPath}}, {{symbol}}`,
     );
   }
-  // One template execution: write `content`, substitute, run under `sh -ec`, demand the object.
-  const execute = (content: string, symbol: string, ext: 'c' | 'p'): { ok: boolean; cmd: string; err: string } => {
-    const dir = mkdtempSync(join(tmpdir(), 'asmlift-usercc-'));
+  // ONE scratch directory per WORKER, emptied before each compile — not one per candidate.
+  // mkdtemp never removes anything, so a per-candidate directory leaked one per compile: a
+  // ranked run over 20k candidates left 20k of them behind, and the temp dir had accumulated
+  // 1.5M. Emptied rather than reused: a step that exits 0 without writing its output must still
+  // fail LOUD, and a surviving sibling from the previous candidate is exactly what would let it
+  // pass (the same class of silent truncation the `sh -ec` note above is about).
+  const slot = (): (() => string) => {
+    let dir: string | undefined;
+    return () => {
+      if (dir === undefined) {
+        dir = mkdtempSync(join(tmpdir(), 'asmlift-usercc-'));
+        return dir;
+      }
+      rmSync(dir, { recursive: true, force: true });
+      mkdirSync(dir);
+      return dir;
+    };
+  };
+
+  // One template execution, in two halves: `stage` writes the input and builds the command,
+  // `verdict` reads the exit status — shared verbatim by the sync and async runners so the two
+  // can never diverge on what counts as a failed compile or on how it is reported.
+  const stage = (dir: string, content: string, symbol: string, ext: 'c' | 'p') => {
     const inPath = join(dir, `cand.${ext}`);
     const outPath = join(dir, 'cand.o');
     writeFileSync(inPath, content);
@@ -111,19 +150,43 @@ export function compileFromCommand(template: string, opts: CompileCommandOptions
       .replaceAll('{{inputPath}}', safe(inPath, '{{inputPath}}'))
       .replaceAll('{{outputPath}}', safe(outPath, '{{outputPath}}'))
       .replaceAll('{{symbol}}', safe(symbol, 'the symbol name'));
-    const r = spawnSync('sh', ['-ec', cmd], { encoding: 'utf8', cwd: opts.cwd });
-    if (r.status !== 0) {
-      return {
-        ok: false,
-        cmd,
-        err: `compile command failed (exit ${r.status ?? 'signal'}): ${cmd}\n${(r.stderr || r.stdout).trim()}`,
-      };
+    return { outPath, cmd };
+  };
+  const verdict = (
+    status: number | null,
+    output: string,
+    cmd: string,
+    outPath: string,
+  ): { ok: boolean; cmd: string; err: string } => {
+    if (status !== 0) {
+      return { ok: false, cmd, err: `compile command failed (exit ${status ?? 'signal'}): ${cmd}\n${output.trim()}` };
     }
     if (!existsSync(outPath)) {
       return { ok: false, cmd, err: `compile command exited 0 but produced no object at {{outputPath}}: ${cmd}` };
     }
     return { ok: true, cmd: outPath, err: '' };
   };
+
+  const mainSlot = slot();
+  const execute = (content: string, symbol: string, ext: 'c' | 'p'): { ok: boolean; cmd: string; err: string } => {
+    const { outPath, cmd } = stage(mainSlot(), content, symbol, ext);
+    const r = spawnSync('sh', ['-ec', cmd], { encoding: 'utf8', cwd: opts.cwd });
+    return verdict(r.status, r.stderr || r.stdout, cmd, outPath);
+  };
+  const executeIn = (dir: string, content: string, symbol: string, ext: 'c' | 'p') =>
+    new Promise<{ ok: boolean; cmd: string; err: string }>((res) => {
+      const { outPath, cmd } = stage(dir, content, symbol, ext);
+      const p = spawn('sh', ['-ec', cmd], { cwd: opts.cwd });
+      let out = '',
+        err = '';
+      p.stdout.on('data', (d) => (out += d));
+      p.stderr.on('data', (d) => (err += d));
+      // A shell that never starts is reported like any other failed compile, not as a rejected
+      // promise: the ranked driver reads a THROWN compile the same way whichever runner produced
+      // it, and a second `res` after `close` is a no-op.
+      p.on('error', (e) => res({ ok: false, cmd, err: `compile command failed to start: ${cmd}\n${e.message}` }));
+      p.on('close', (code) => res(verdict(code, err || out, cmd, outPath)));
+    });
 
   // Which WORLD candidates compile in — PROBED, never configured. Two worlds exist:
   //   • SELF-DECLARED: a bare template compiles the candidate alone, so it needs asmlift's
@@ -148,24 +211,58 @@ export function compileFromCommand(template: string, opts: CompileCommandOptions
     }
     return !execute(PROBE, symbol, 'c').ok;
   };
+  // The async twin, memoized as a PROMISE: N workers starting together would otherwise each see
+  // an unset `preludeOk` and probe the world N times.
+  let probing: Promise<boolean> | undefined;
+  const probeAsync = (symbol: string): Promise<boolean> =>
+    (probing ??= (async () => {
+      const probeSlot = slot();
+      if ((await executeIn(probeSlot(), C_TYPEDEFS + PROBE_DECLS + PROBE, symbol, 'c')).ok) {
+        return true;
+      }
+      return !(await executeIn(probeSlot(), PROBE, symbol, 'c')).ok;
+    })());
 
-  return (source, symbol, backendId, declarations) => {
-    let prelude = '';
-    if (backendId !== 'pascal') {
-      preludeOk ??= probePrelude(symbol);
-      // headers world ⇒ BOTH the prelude and the synthesized declarations drop — the injected
-      // headers own the types and every declaration (a second copy is a C89 collision).
-      // EXCEPT the address-cast macro defines: a duplicate `#define` with an identical body is
-      // legal C (unlike a duplicate typedef or struct), and the headers world does NOT
-      // necessarily supply them — a PREPROCESSED context has no macros left at all, so dropping
-      // these turns a macro-named candidate into `undeclared identifier`. They are emitted in
-      // both worlds for that reason.
-      prelude = preludeOk ? C_TYPEDEFS + (declarations ?? '') : macroDefinesOf(declarations);
-    }
-    const r = execute(prelude + source, symbol, backendId === 'pascal' ? 'p' : 'c');
+  // headers world ⇒ BOTH the prelude and the synthesized declarations drop — the injected
+  // headers own the types and every declaration (a second copy is a C89 collision).
+  // EXCEPT the address-cast macro defines: a duplicate `#define` with an identical body is
+  // legal C (unlike a duplicate typedef or struct), and the headers world does NOT
+  // necessarily supply them — a PREPROCESSED context has no macros left at all, so dropping
+  // these turns a macro-named candidate into `undeclared identifier`. They are emitted in
+  // both worlds for that reason.
+  const preludeFor = (world: boolean, declarations?: string): string =>
+    world ? C_TYPEDEFS + (declarations ?? '') : macroDefinesOf(declarations);
+  const unwrap = (r: { ok: boolean; cmd: string; err: string }): string => {
     if (!r.ok) {
       throw new Error(r.err);
     }
     return r.cmd;
   };
+
+  return {
+    compile: (source, symbol, backendId, declarations) => {
+      let prelude = '';
+      if (backendId !== 'pascal') {
+        preludeOk ??= probePrelude(symbol);
+        prelude = preludeFor(preludeOk, declarations);
+      }
+      return unwrap(execute(prelude + source, symbol, backendId === 'pascal' ? 'p' : 'c'));
+    },
+    worker: () => {
+      const mine = slot();
+      return async (source, symbol, backendId, declarations) => {
+        let prelude = '';
+        if (backendId !== 'pascal') {
+          preludeOk ??= await probeAsync(symbol);
+          prelude = preludeFor(preludeOk, declarations);
+        }
+        return unwrap(await executeIn(mine(), prelude + source, symbol, backendId === 'pascal' ? 'p' : 'c'));
+      };
+    },
+  };
+}
+
+/** The synchronous candidate compiler alone — the shape every non-pooled caller wants. */
+export function compileFromCommand(template: string, opts: CompileCommandOptions = {}): CandidateCompiler {
+  return compilersFromCommand(template, opts).compile;
 }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -30,7 +30,7 @@ import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { type CandidateCompiler, compileFromCommand } from './compile-command';
+import { type CommandCompilers, compilersFromCommand } from './compile-command';
 import { type AsmliftToolConfig, loadDecompConfig, resolveTarget } from './config';
 import { ObjectInputUnsupportedError, asmDataForObject, disasmObject, isElfObject } from './objfile';
 
@@ -51,8 +51,19 @@ const BACKENDS: Record<string, LanguageBackend> = {
 
 // Every flag the CLI understands. An unknown flag is a HARD usage error — silently ignoring
 // `--nmae foo` or `--backned pascal` would quietly discard the user's intent.
-const KNOWN_FLAGS = new Set(['target', 'name', 'backend', 'strict', 'config', 'score-against', 'asm-data', 'proto']);
-const BOOL_FLAGS = new Set(['strict']);
+const KNOWN_FLAGS = new Set([
+  'target',
+  'name',
+  'backend',
+  'strict',
+  'config',
+  'score-against',
+  'asm-data',
+  'proto',
+  'jobs',
+  'progress',
+]);
+const BOOL_FLAGS = new Set(['strict', 'progress']);
 // The emitted source embeds the name verbatim; a non-identifier would be silently invalid C.
 const IDENT = /^[A-Za-z_$][A-Za-z0-9_$.]*$/;
 
@@ -60,6 +71,7 @@ const USAGE = `usage: asmlift <file.s|file.asm|file.o|-> [--target <${Object.key
                 [--name <symbol>] [--backend <c|pascal>] [--strict]
                 [--config <decomp.yaml>] [--score-against <target.o>]
                 [--asm-data <dump.txt>] [--proto <proto.json>]
+                [--jobs <n>] [--progress]
 
 Decompiles a function to source on stdout.
 Input: GBA .s text (agbcc output or pret-style splits), objdump -d text, or a
@@ -75,6 +87,9 @@ Gaps are annotated in-source as ASMLIFT_ERROR markers, diagnostics on stderr.
   --asm-data       for text input: objdump -s -r -t dump of the source object
                    (jump tables, anonymous constants)
   --proto          callee prototypes JSON, e.g. {"sym":{"params":2|["u8","s32"]}}
+  --jobs           with --score-against: compile n candidates at a time (default 1)
+  --progress       with --score-against: stream a liveness line to stderr while
+                   scoring; the [score] table it prints at the end is unchanged
 
 Exit codes: 0 clean/match · 1 gaps/declined/nonmatch · 64 usage · 66 unreadable input.
 Full reference (flags, decomp.yaml integration): the @asmlift/cli README.`;
@@ -100,6 +115,10 @@ export async function runCli(
   argv: string[],
   readInput: (path: string) => string | Uint8Array = defaultRead,
   objInput?: ObjInput,
+  /** where `--progress` writes. Absent (every non-process caller, including the tests) ⇒ the
+   *  flag has nothing to write to and the run is silent, so `runCli`'s result stays the whole
+   *  output. The process entry point below supplies stderr. */
+  progressSink?: (line: string) => void,
 ): Promise<CliResult> {
   const usage = (msg: string) => ({ code: 64, stdout: '', stderr: `asmlift: ${msg}\n${USAGE}\n` });
   const args = [...argv];
@@ -302,6 +321,36 @@ export async function runCli(
   // gap is a decline, never a scored stub. score.ts (objdiff-wasm) loads only on this path,
   // keeping plain decompiles toolchain-light.
   const scoreAgainst = flags.get('score-against') as string | undefined;
+  // Candidate compiles are ~85% of a ranked run's wall time and independent of one another, so
+  // --jobs runs n of them at once. Ranking is unaffected (rank.ts). Both flags belong to the
+  // ranked path alone: accepting them elsewhere would silently discard what the user asked for.
+  const jobsFlag = flags.get('jobs') as string | undefined;
+  if ((jobsFlag !== undefined || flags.has('progress')) && scoreAgainst === undefined) {
+    return usage('--jobs/--progress apply to --score-against runs only');
+  }
+  let jobs = 1;
+  if (jobsFlag !== undefined) {
+    jobs = Number(jobsFlag);
+    if (!Number.isInteger(jobs) || jobs < 1) {
+      return usage(`--jobs must be a positive integer (got ${JSON.stringify(jobsFlag)})`);
+    }
+  }
+  // At most one line every few seconds: enough to tell a 20-minute run from a hung one, few
+  // enough that the log stays readable. The `[progress]` prefix keeps it separable from the
+  // `[score]` lines two ranked logs are compared on.
+  let lastTick = 0;
+  const onProgress =
+    flags.has('progress') && progressSink
+      ? (doneN: number, total: number, bestSoFar: number | undefined) => {
+          const now = Date.now();
+          if (doneN < total && now - lastTick < 5000) {
+            return;
+          }
+          lastTick = now;
+          const best = bestSoFar === undefined ? '' : `, best so far ${bestSoFar}`;
+          progressSink(`asmlift: [progress] ${doneN}/${total} candidates scored${best}\n`);
+        }
+      : undefined;
   if (scoreAgainst !== undefined) {
     const targetObj = resolve(scoreAgainst);
     if (!existsSync(targetObj)) {
@@ -316,15 +365,26 @@ export async function runCli(
         "--score-against needs tools.asmlift.compiler in decomp.yaml — scoring must use YOUR project's compiler and flags",
       );
     }
-    let compile: CandidateCompiler;
+    let compilers: CommandCompilers;
     try {
-      compile = compileFromCommand(toolCfg.compiler, { cwd: configDir });
+      compilers = compilersFromCommand(toolCfg.compiler, { cwd: configDir });
     } catch (e) {
       return usage(`tools.asmlift.compiler: ${e instanceof Error ? e.message : e}`);
     }
+    const compile = compilers.compile;
     try {
-      const { decompileRanked } = await import('./rank');
-      const ranked = decompileRanked(name, asm, target, targetObj, { backend, asmData, prototypes, symbols, compile });
+      const { decompileRanked, decompileRankedParallel } = await import('./rank');
+      const rankOpts = { backend, asmData, prototypes, symbols, compile, ...(onProgress ? { onProgress } : {}) };
+      // jobs > 1 pools the candidate COMPILES; the ranking itself is the same code either way
+      // (rank.ts), so the two differ in scheduling only.
+      const ranked =
+        jobs > 1
+          ? await decompileRankedParallel(name, asm, target, targetObj, {
+              ...rankOpts,
+              jobs,
+              worker: compilers.worker,
+            })
+          : decompileRanked(name, asm, target, targetObj, rankOpts);
       const table = ranked.candidates
         .map((c) => `asmlift: [score] ${c.label}: ${c.score.score}${c.score.match ? ' (match)' : ''}\n`)
         .join('');
@@ -379,7 +439,9 @@ const invokedDirectly =
     pathToFileURL(realpathSync(process.argv[1])).href;
 
 if (invokedDirectly) {
-  const { code, stdout, stderr } = await runCli(process.argv.slice(2));
+  const { code, stdout, stderr } = await runCli(process.argv.slice(2), undefined, undefined, (line) =>
+    process.stderr.write(line),
+  );
   if (stdout) {
     process.stdout.write(stdout);
   }

--- a/packages/cli/src/rank.ts
+++ b/packages/cli/src/rank.ts
@@ -8,16 +8,55 @@ import type { AsmData } from '@asmlift/core/frontend/asmdata';
 import type { LanguageBackend } from '@asmlift/core/l3/ast';
 import { RewritePattern } from '@asmlift/core/pattern/engine';
 import type { Prototypes } from '@asmlift/core/proto';
-import { type RankedResult as CoreRankedResult, type Scored, enumerateCandidates, rankBy } from '@asmlift/core/rank';
+import {
+  type Candidate,
+  type RankedResult as CoreRankedResult,
+  type Scored,
+  enumerateCandidates,
+  rankBy,
+} from '@asmlift/core/rank';
 import type { SymbolMap } from '@asmlift/core/symbols';
 import { type TargetDescription } from '@asmlift/core/target';
 
+import type { AsyncCandidateCompiler } from './compile-command';
 import { renderDeclarations } from './declare';
-import { type CandidateCompiler, MatchScore, scoreSource } from './score';
+import { type CandidateCompiler, MatchScore, scoreObjects, scoreSource } from './score';
 
 // The cli's candidate/result shapes are the core generics pinned to the objdiff MatchScore.
 export type RankedCandidate = Scored<MatchScore>;
 export type RankedResult = CoreRankedResult<MatchScore>;
+
+export interface RankOptions {
+  patterns?: RewritePattern[];
+  backend?: LanguageBackend;
+  prototypes?: Prototypes;
+  asmData?: AsmData;
+  /** address→symbol map (core symbols.ts) — same contract as DecompileOptions.symbols */
+  symbols?: SymbolMap;
+  /** a project's own toolchain — overrides the compiler registry */
+  compile?: CandidateCompiler;
+  /** Liveness only, never a measurement: called once per candidate as it is scored, carrying the
+   *  lowest score seen SO FAR. The ranking below is what decides the winner. */
+  onProgress?: (done: number, total: number, bestSoFar: number | undefined) => void;
+}
+
+// Self-declaring candidates: a candidate that names map-derived symbols carries their refs
+// (Candidate.symbolRefs) — rendered here into its per-candidate declaration block. The
+// compiler seam decides whether the block is USED (probed self-declared world) or ignored
+// (headers world / context-injecting compilers) — see compile-command.ts.
+const declarationsOf = (cand: Candidate): string | undefined =>
+  cand.symbolRefs?.length ? renderDeclarations(cand.symbolRefs) : undefined;
+
+// ONE enumeration for both drivers below: they must rank the same candidate set, or the pooled
+// run would be answering a different question than the serial one.
+const enumerate = (name: string, asm: string, target: TargetDescription, opts: RankOptions): Candidate[] =>
+  enumerateCandidates(name, asm, target, {
+    patterns: opts.patterns,
+    backend: opts.backend ?? cBackend,
+    prototypes: opts.prototypes,
+    asmData: opts.asmData,
+    symbols: opts.symbols,
+  });
 
 /** Enumerate each type/branch-sense candidate, recompile + objdiff-score it, and rank by the score. */
 export function decompileRanked(
@@ -25,38 +64,87 @@ export function decompileRanked(
   asm: string,
   target: TargetDescription,
   targetObj: string,
-  opts: {
-    patterns?: RewritePattern[];
-    backend?: LanguageBackend;
-    prototypes?: Prototypes;
-    asmData?: AsmData;
-    /** address→symbol map (core symbols.ts) — same contract as DecompileOptions.symbols */
-    symbols?: SymbolMap;
-    /** a project's own toolchain — overrides the compiler registry */
-    compile?: CandidateCompiler;
-  } = {},
+  opts: RankOptions = {},
 ): RankedResult {
   const backend = opts.backend ?? cBackend;
-  const candidates = enumerateCandidates(name, asm, target, {
-    patterns: opts.patterns,
-    backend,
-    prototypes: opts.prototypes,
-    asmData: opts.asmData,
-    symbols: opts.symbols,
+  const candidates = enumerate(name, asm, target, opts);
+  let done = 0;
+  let best: number | undefined;
+  return rankBy(candidates, name, (source, symbol, cand) => {
+    try {
+      const s = scoreSource(source, symbol, targetObj, target, backend.id, opts.compile, declarationsOf(cand));
+      best = best === undefined || s.score < best ? s.score : best;
+      return s;
+    } finally {
+      // a candidate the scorer REFUSED still counts as processed: progress must not stall on a
+      // lever whose every spelling fails to build
+      opts.onProgress?.(++done, candidates.length, best);
+    }
   });
-  // Self-declaring candidates: a candidate that names map-derived symbols carries their refs
-  // (Candidate.symbolRefs) — rendered here into its per-candidate declaration block. The
-  // compiler seam decides whether the block is USED (probed self-declared world) or ignored
-  // (headers world / context-injecting compilers) — see compile-command.ts.
-  return rankBy(candidates, name, (source, symbol, cand) =>
-    scoreSource(
-      source,
-      symbol,
-      targetObj,
-      target,
-      backend.id,
-      opts.compile,
-      cand.symbolRefs?.length ? renderDeclarations(cand.symbolRefs) : undefined,
-    ),
+}
+
+/** The same ranking with the candidate COMPILES run `jobs` at a time.
+ *
+ *  A ranked run is ~85% subprocess — one LBG-sized candidate measures ~50 ms to compile against
+ *  ~11 ms to score — and `rankBy`'s driver is synchronous, so today tens of thousands of
+ *  candidates compile one at a time on one core. Here each worker owns a scratch slot
+ *  (compile-command.ts `worker()`), takes the next unclaimed candidate, and scores its object the
+ *  moment it lands; the score runs on the main thread and overlaps the other workers' subprocesses.
+ *
+ *  ONLY the compile moves. The ordering is still core's `rankBy` over the same enumeration, run
+ *  afterwards against the memoized scores — so the winner, every tie-break and the `dropped` list
+ *  are what the serial path would have produced. The benchmark deliberately keeps calling
+ *  `decompileRanked`: a published measurement must not depend on a scheduler. */
+export async function decompileRankedParallel(
+  name: string,
+  asm: string,
+  target: TargetDescription,
+  targetObj: string,
+  opts: RankOptions & {
+    jobs: number;
+    /** mints one INDEPENDENT async compiler per worker (compile-command.ts `worker()`) */
+    worker: () => AsyncCandidateCompiler;
+  },
+): Promise<RankedResult> {
+  const backend = opts.backend ?? cBackend;
+  const candidates = enumerate(name, asm, target, opts);
+  // keyed by source, which core's enumeration has already deduped on — so it identifies a candidate
+  const scored = new Map<string, MatchScore | Error>();
+  let next = 0;
+  let done = 0;
+  let best: number | undefined;
+  await Promise.all(
+    Array.from({ length: Math.max(1, opts.jobs) }, async () => {
+      const compile = opts.worker();
+      for (;;) {
+        const i = next++;
+        if (i >= candidates.length) {
+          return;
+        }
+        const cand = candidates[i];
+        let result: MatchScore | Error;
+        try {
+          const obj = await compile(cand.source, name, backend.id, declarationsOf(cand));
+          result = scoreObjects(targetObj, obj, name);
+          best = best === undefined || result.score < best ? result.score : best;
+        } catch (e) {
+          // recorded, not thrown: `rankBy` below is what decides whether a refused candidate is
+          // survivable (a sibling scored) or fatal (every one failed)
+          result = e instanceof Error ? e : new Error(String(e));
+        }
+        scored.set(cand.source, result);
+        opts.onProgress?.(++done, candidates.length, best);
+      }
+    }),
   );
+  return rankBy(candidates, name, (source) => {
+    const r = scored.get(source);
+    if (r === undefined) {
+      throw new Error(`internal: a candidate reached ranking unscored (${source.length} bytes)`);
+    }
+    if (r instanceof Error) {
+      throw r;
+    }
+    return r;
+  });
 }

--- a/packages/cli/test/matching/ranked-parallel.test.ts
+++ b/packages/cli/test/matching/ranked-parallel.test.ts
@@ -9,7 +9,10 @@
 // scores in identical order, identical drops.
 import { ARMV4T_AGBCC } from '@asmlift/core/target';
 import { assembleTarget, compileCandAgbcc, compileTargetAsm } from '@asmlift/toolchains';
-import { describe, expect, test } from 'vitest';
+import { copyFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, test } from 'vitest';
 
 import { decompileRanked, decompileRankedParallel } from '../../src/rank';
 
@@ -47,6 +50,37 @@ describe('the pooled ranked run is the serial ranked run', () => {
     expect(many.best.label).toBe(one.best.label);
     expect(many.candidates.map((c) => [c.label, c.score.score])).toEqual(
       one.candidates.map((c) => [c.label, c.score.score]),
+    );
+  });
+
+  // The lifetime the real pool runs under: `compilersFromCommand`'s `worker()` hands out ONE
+  // scratch directory per worker and EMPTIES it before each compile, so a worker's object is
+  // valid only until that worker asks for the next one. The driver is what has to honour that —
+  // it must score each object the moment it lands. `compileCandAgbcc` above mkdtemps per call and
+  // would therefore keep every object alive, hiding a driver that batched the compiles and scored
+  // afterwards; this worker reproduces the real lifetime so that shape cannot pass.
+  const slotDirs: string[] = [];
+  const slotWorker = () => {
+    const dir = mkdtempSync(join(tmpdir(), 'asmlift-ranklife-'));
+    slotDirs.push(dir);
+    const obj = join(dir, 'cand.o');
+    return async (source: string) => {
+      rmSync(obj, { force: true });
+      copyFileSync(compileCandAgbcc(source), obj);
+      return obj;
+    };
+  };
+  afterAll(() => slotDirs.forEach((d) => rmSync(d, { recursive: true, force: true })));
+
+  test('a worker whose object is wiped by its NEXT compile still ranks identically', async () => {
+    const asm = compileTargetAsm('int ifor(int a, int b){ if (a || b) return 42; return 7; }');
+    const obj = assembleTarget(asm);
+    const serial = decompileRanked('ifor', asm, ARMV4T_AGBCC, obj);
+    const pooled = await decompileRankedParallel('ifor', asm, ARMV4T_AGBCC, obj, { jobs: 3, worker: slotWorker });
+    expect(pooled.dropped).toEqual(serial.dropped); // a stale/absent object would land here
+    expect(pooled.best.label).toBe(serial.best.label);
+    expect(pooled.candidates.map((c) => [c.label, c.score.score])).toEqual(
+      serial.candidates.map((c) => [c.label, c.score.score]),
     );
   });
 

--- a/packages/cli/test/matching/ranked-parallel.test.ts
+++ b/packages/cli/test/matching/ranked-parallel.test.ts
@@ -1,0 +1,72 @@
+// `decompileRankedParallel` must be the SAME ranking as `decompileRanked` — only the candidate
+// compiles move off the main thread. A pooled run is what the out-of-harness ranked enumeration
+// uses (a 20k-candidate function is ~85% subprocess), so a divergence here would mean a round
+// planning on a number the benchmark's serial path never produces.
+//
+// The pool's own concurrency (one scratch slot per worker, one shared world probe) is pinned
+// offline in test/offline/compile-command.test.ts; what THIS suite can pin, with the real
+// toolchain, is the property that matters downstream: identical winner, identical per-candidate
+// scores in identical order, identical drops.
+import { ARMV4T_AGBCC } from '@asmlift/core/target';
+import { assembleTarget, compileCandAgbcc, compileTargetAsm } from '@asmlift/toolchains';
+import { describe, expect, test } from 'vitest';
+
+import { decompileRanked, decompileRankedParallel } from '../../src/rank';
+
+// the registered agbcc candidate compiler, handed to the pool as its per-worker compiler
+const worker = () => async (source: string) => compileCandAgbcc(source);
+
+const bothWays = async (sym: string, src: string) => {
+  const asm = compileTargetAsm(src);
+  const obj = assembleTarget(asm);
+  const serial = decompileRanked(sym, asm, ARMV4T_AGBCC, obj);
+  const pooled = await decompileRankedParallel(sym, asm, ARMV4T_AGBCC, obj, { jobs: 4, worker });
+  return { serial, pooled };
+};
+
+describe('the pooled ranked run is the serial ranked run', () => {
+  test('a multi-candidate function ranks identically, candidate for candidate', async () => {
+    // `||` short-circuit: both branch senses are emitted, so the set is genuinely multi-candidate
+    // and the winner is decided by score rather than by being the only survivor
+    const { serial, pooled } = await bothWays('ifor', 'int ifor(int a, int b){ if (a || b) return 42; return 7; }');
+    expect(pooled.candidates.length).toBeGreaterThan(1);
+    expect(pooled.best.label).toBe(serial.best.label);
+    expect(pooled.best.source).toBe(serial.best.source);
+    expect(pooled.best.score).toEqual(serial.best.score);
+    expect(pooled.candidates.map((c) => [c.label, c.score.score])).toEqual(
+      serial.candidates.map((c) => [c.label, c.score.score]),
+    );
+    expect(pooled.dropped).toEqual(serial.dropped);
+  });
+
+  test('jobs: 1 is the same answer as jobs: 8 — the schedule cannot choose the winner', async () => {
+    const asm = compileTargetAsm('int half(int x){ return x / 2; }');
+    const obj = assembleTarget(asm);
+    const one = await decompileRankedParallel('half', asm, ARMV4T_AGBCC, obj, { jobs: 1, worker });
+    const many = await decompileRankedParallel('half', asm, ARMV4T_AGBCC, obj, { jobs: 8, worker });
+    expect(many.best.label).toBe(one.best.label);
+    expect(many.candidates.map((c) => [c.label, c.score.score])).toEqual(
+      one.candidates.map((c) => [c.label, c.score.score]),
+    );
+  });
+
+  test('a candidate that fails to build is DROPPED the same way, not fatal', async () => {
+    // one worker whose compiler refuses every other candidate: the survivors must still rank,
+    // and the refusals must land in `dropped` in enumeration order
+    let n = 0;
+    const flaky = () => async (source: string) => {
+      if (n++ % 2 === 1) {
+        throw new Error('synthetic compile failure');
+      }
+      return compileCandAgbcc(source);
+    };
+    const asm = compileTargetAsm('int ifor(int a, int b){ if (a || b) return 42; return 7; }');
+    const r = await decompileRankedParallel('ifor', asm, ARMV4T_AGBCC, assembleTarget(asm), {
+      jobs: 3,
+      worker: flaky,
+    });
+    expect(r.dropped.length).toBeGreaterThan(0);
+    expect(r.dropped.every((d) => d.error.includes('synthetic compile failure'))).toBe(true);
+    expect(r.candidates.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/test/offline/cli.test.ts
+++ b/packages/cli/test/offline/cli.test.ts
@@ -125,3 +125,19 @@ test('--proto: unreadable file and non-object JSON stay distinguishable (66 vs 6
   expect(scalar.code).toBe(64);
   expect(scalar.stderr).toContain('must be an object mapping a symbol name to its prototype');
 });
+
+test('--jobs/--progress belong to the ranked path and are refused elsewhere, not ignored', async () => {
+  for (const flag of [['--jobs', '4'], ['--progress']]) {
+    const r = await run('agbcc-clamp0.s', '--target', 'agbcc', ...flag);
+    expect(r.code).toBe(64);
+    expect(r.stderr).toContain('--jobs/--progress apply to --score-against runs only');
+  }
+});
+
+test('--jobs must be a positive integer', async () => {
+  for (const bad of ['0', '-2', '2.5', 'six', '']) {
+    const r = await run('agbcc-clamp0.s', '--target', 'agbcc', '--score-against', '/nonexistent.o', '--jobs', bad);
+    expect(r.code).toBe(64);
+    expect(r.stderr).toContain('--jobs must be a positive integer');
+  }
+});

--- a/packages/cli/test/offline/compile-command.test.ts
+++ b/packages/cli/test/offline/compile-command.test.ts
@@ -1,7 +1,7 @@
 // The candidate-compile command factory (src/compile-command.ts) — the seam a project fills
 // with its own toolchain. Offline: the "compilers" here are plain sh commands.
 import { C_TYPEDEFS } from '@asmlift/core/target';
-import { readFileSync } from 'node:fs';
+import { readFileSync, rmSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { expect, test } from 'vitest';
 
@@ -47,7 +47,10 @@ test('a typedef-rejecting template (header-injecting project) drops the prelude 
 test('a prelude-tolerant template keeps the prelude (probe verdict cached across candidates)', () => {
   // the counter file records every template execution: 1 probe + 2 candidates = 3, not 4 —
   // the verdict is cached per compiler instance
+  // pid-keyed and APPENDED to: pids are reused, so a file left by an earlier run under the same
+  // pid would make this count too high and fail a clean tree. Start from empty.
   const counter = `${process.env.TMPDIR ?? '/tmp'}/asmlift-probe-count-${process.pid}`;
+  rmSync(counter, { force: true });
   const compile = compileFromCommand(`echo x >> ${counter} && cp {{inputPath}} {{outputPath}}`);
   const first = compile('s32 f(void) { return 1; }\n', 'f', 'c');
   expect(readFileSync(first, 'utf8').startsWith(C_TYPEDEFS)).toBe(true);
@@ -162,6 +165,7 @@ test('the world is probed ONCE across every worker, not once per worker', async 
   // N workers starting together each see an unset probe verdict; without a shared in-flight
   // promise they all probe, and a slow template pays for it N times
   const counter = `${process.env.TMPDIR ?? '/tmp'}/asmlift-worker-probe-${process.pid}`;
+  rmSync(counter, { force: true }); // appended to, and pids are reused — see the sync twin above
   const { worker } = compilersFromCommand(`echo x >> ${counter} && cp {{inputPath}} {{outputPath}}`);
   const workers = [worker(), worker(), worker(), worker()];
   await Promise.all(workers.map((w, i) => w(`s32 f${i}(void) { return ${i}; }\n`, `f${i}`, 'c')));

--- a/packages/cli/test/offline/compile-command.test.ts
+++ b/packages/cli/test/offline/compile-command.test.ts
@@ -2,9 +2,10 @@
 // with its own toolchain. Offline: the "compilers" here are plain sh commands.
 import { C_TYPEDEFS } from '@asmlift/core/target';
 import { readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { expect, test } from 'vitest';
 
-import { compileFromCommand } from '../../src/compile-command';
+import { compileFromCommand, compilersFromCommand } from '../../src/compile-command';
 
 test('missing {{inputPath}}/{{outputPath}} placeholders is a construction-time error', () => {
   expect(() => compileFromCommand('cc -O2 -o out.o')).toThrow(/\{\{inputPath\}\} and \{\{outputPath\}\}/);
@@ -144,4 +145,58 @@ test('no declarations argument ⇒ exactly the historical prelude behavior', () 
   const obj = compile('s32 f(void) { return 1; }\n', 'f', 'c');
   const written = readFileSync(obj, 'utf8');
   expect(written).toBe(C_TYPEDEFS + 's32 f(void) { return 1; }\n');
+});
+
+// ── the pooled flavour: `worker()` mints an independent async compiler per pool worker ──
+
+test('an async worker compiles exactly like the sync compiler', async () => {
+  const { compile, worker } = compilersFromCommand('cp {{inputPath}} {{outputPath}}');
+  const src = 's32 f(s32 a0) { return a0; }\n';
+  const sync = readFileSync(compile(src, 'f', 'c'), 'utf8');
+  const async1 = readFileSync(await worker()(src, 'f', 'c'), 'utf8');
+  expect(async1).toBe(sync);
+  expect(async1.startsWith(C_TYPEDEFS)).toBe(true);
+});
+
+test('the world is probed ONCE across every worker, not once per worker', async () => {
+  // N workers starting together each see an unset probe verdict; without a shared in-flight
+  // promise they all probe, and a slow template pays for it N times
+  const counter = `${process.env.TMPDIR ?? '/tmp'}/asmlift-worker-probe-${process.pid}`;
+  const { worker } = compilersFromCommand(`echo x >> ${counter} && cp {{inputPath}} {{outputPath}}`);
+  const workers = [worker(), worker(), worker(), worker()];
+  await Promise.all(workers.map((w, i) => w(`s32 f${i}(void) { return ${i}; }\n`, `f${i}`, 'c')));
+  // 1 probe + 4 candidates, not 4 probes + 4 candidates
+  expect(readFileSync(counter, 'utf8').trim().split('\n')).toHaveLength(5);
+});
+
+test('each worker gets its OWN scratch slot, so concurrent compiles cannot clobber each other', async () => {
+  const { worker } = compilersFromCommand('cp {{inputPath}} {{outputPath}}');
+  const a = worker(),
+    b = worker();
+  const [oa, ob] = await Promise.all([
+    a('s32 f(void) { return 1; }\n', 'f', 'c'),
+    b('s32 g(void) { return 2; }\n', 'g', 'c'),
+  ]);
+  expect(dirname(oa)).not.toBe(dirname(ob));
+  expect(readFileSync(oa, 'utf8')).toContain('return 1;');
+  expect(readFileSync(ob, 'utf8')).toContain('return 2;');
+});
+
+test('ONE scratch dir per worker across candidates — emptied, so a lying compiler still fails loud', async () => {
+  const { worker } = compilersFromCommand('test ! -e {{outputPath}} && cp {{inputPath}} {{outputPath}}');
+  const w = worker();
+  const first = await w('s32 f(void) { return 1; }\n', 'f', 'c');
+  const second = await w('s32 g(void) { return 2; }\n', 'g', 'c');
+  // same directory reused (the leak fix) — and the `test ! -e` above only passes because it was
+  // EMPTIED, which is what keeps "exited 0 but produced no object" reachable
+  expect(dirname(second)).toBe(dirname(first));
+  expect(readFileSync(second, 'utf8')).toContain('return 2;');
+});
+
+test('an async worker reports a failed compile as a THROW, exactly like the sync one', async () => {
+  const { compile, worker } = compilersFromCommand(
+    "echo 'version 2.4.2 required' >&2; false # {{inputPath}} {{outputPath}}",
+  );
+  expect(() => compile('int x;', 'f', 'c')).toThrow(/exit 1[\s\S]*version 2\.4\.2 required/);
+  await expect(worker()('int x;', 'f', 'c')).rejects.toThrow(/exit 1[\s\S]*version 2\.4\.2 required/);
 });

--- a/scripts/tmp-janitor.sh
+++ b/scripts/tmp-janitor.sh
@@ -38,22 +38,29 @@ PREFIXES='asmlift-usercc- asmlift-score- asmlift-ref- asmlift-target- asmlift-mi
 MINUTES=$((HOURS * 60))
 ROOTS="${TMPDIR:-/tmp} /tmp"
 
+# ONE traversal per root, not one per prefix: `find` stats every entry, and a temp dir with a
+# million of them takes minutes per pass.
+match=''
+for p in $PREFIXES; do
+  [ -z "$match" ] && match="-name $p*" || match="$match -o -name $p*"
+done
+
 total=0
 for root in $ROOTS; do
   [ -d "$root" ] || continue
-  for p in $PREFIXES; do
-    # -mmin bounds the sweep by age; -maxdepth 1 keeps it to the temp root itself. `-print` is
-    # counted rather than listed: there can be a million of them.
-    n=$(find "$root" -maxdepth 1 -name "$p*" -mmin +"$MINUTES" -print 2>/dev/null | wc -l | tr -d ' ')
-    [ "$n" -eq 0 ] && continue
-    total=$((total + n))
-    if [ "$APPLY" -eq 1 ]; then
-      find "$root" -maxdepth 1 -name "$p*" -mmin +"$MINUTES" -exec rm -rf {} + 2>/dev/null || true
-      echo "removed  $n	$root/$p*"
-    else
-      echo "would remove  $n	$root/$p*"
-    fi
-  done
+  # -mmin bounds the sweep by age; -maxdepth 1 keeps it to the temp root itself. Counted rather
+  # than listed: there can be a million of them.
+  # shellcheck disable=SC2086  # $match is a built find expression, word splitting is the point
+  n=$(find "$root" -maxdepth 1 \( $match \) -mmin +"$MINUTES" -print 2>/dev/null | wc -l | tr -d ' ')
+  [ "$n" -eq 0 ] && continue
+  total=$((total + n))
+  if [ "$APPLY" -eq 1 ]; then
+    # shellcheck disable=SC2086
+    find "$root" -maxdepth 1 \( $match \) -mmin +"$MINUTES" -exec rm -rf {} + 2>/dev/null || true
+    echo "removed       $n	$root"
+  else
+    echo "would remove  $n	$root"
+  fi
 done
 
 if [ "$APPLY" -eq 1 ]; then

--- a/scripts/tmp-janitor.sh
+++ b/scripts/tmp-janitor.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Sweep the harness's leaked scratch directories.
+#
+# Every compile the CLI, the benchmark and the toolchains do used to mkdtemp a directory and
+# never remove it: one per CANDIDATE, so a ranked run over 20k candidates left 20k behind and a
+# full bench run left one per candidate compile. The compile seams now reuse ONE directory per
+# worker (packages/cli/src/compile-command.ts, apps/benchmark/src/compile/util.ts `scratchSlot`),
+# but @asmlift/toolchains still leaks, and the directories already on disk stay until something
+# removes them — this is that something.
+#
+# DRY RUN by default: prints what it would remove. Pass --apply to actually remove.
+#
+#   scripts/tmp-janitor.sh                 # count what is sweepable, remove nothing
+#   scripts/tmp-janitor.sh --apply         # remove it
+#   scripts/tmp-janitor.sh --apply --hours 1
+#
+# Only directories whose name starts with one of the harness's own mkdtemp prefixes are ever
+# touched, only directly inside a temp root, and only when older than --hours (default 6) — a
+# run in flight owns a scratch dir, and this must never delete out from under it.
+#
+# `bench-real-*` is deliberately NOT in the list: those are the CONTENT-KEYED reference builds
+# (apps/benchmark/src/compile/util.ts `contentDir`), a cache keyed by TU sha, not a leak.
+set -eu
+
+APPLY=0
+HOURS=6
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) APPLY=1 ;;
+    --hours) HOURS="$2"; shift ;;
+    -h | --help) sed -n '2,22p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+PREFIXES='asmlift-usercc- asmlift-score- asmlift-ref- asmlift-target- asmlift-mips-score- asmlift-mips-pas- bench-cand- bench-vendor- bench-m2c- bench-fidelity-'
+MINUTES=$((HOURS * 60))
+ROOTS="${TMPDIR:-/tmp} /tmp"
+
+total=0
+for root in $ROOTS; do
+  [ -d "$root" ] || continue
+  for p in $PREFIXES; do
+    # -mmin bounds the sweep by age; -maxdepth 1 keeps it to the temp root itself. `-print` is
+    # counted rather than listed: there can be a million of them.
+    n=$(find "$root" -maxdepth 1 -name "$p*" -mmin +"$MINUTES" -print 2>/dev/null | wc -l | tr -d ' ')
+    [ "$n" -eq 0 ] && continue
+    total=$((total + n))
+    if [ "$APPLY" -eq 1 ]; then
+      find "$root" -maxdepth 1 -name "$p*" -mmin +"$MINUTES" -exec rm -rf {} + 2>/dev/null || true
+      echo "removed  $n	$root/$p*"
+    else
+      echo "would remove  $n	$root/$p*"
+    fi
+  done
+done
+
+if [ "$APPLY" -eq 1 ]; then
+  echo "swept $total directories older than ${HOURS}h"
+else
+  echo "$total directories older than ${HOURS}h are sweepable — re-run with --apply to remove them"
+fi

--- a/scripts/tmp-janitor.sh
+++ b/scripts/tmp-janitor.sh
@@ -27,16 +27,30 @@ HOURS=6
 while [ $# -gt 0 ]; do
   case "$1" in
     --apply) APPLY=1 ;;
-    --hours) HOURS="$2"; shift ;;
+    --hours)
+      if [ $# -lt 2 ]; then echo "--hours needs a value" >&2; exit 2; fi
+      HOURS="$2"; shift ;;
     -h | --help) sed -n '2,22p' "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
   shift
 done
 
+# A non-numeric --hours must NOT fall through: `$((abc * 60))` is 0 in POSIX arithmetic, which
+# would turn the age bound off entirely and let --apply delete the scratch dir of a run in flight.
+case "$HOURS" in
+  '' | *[!0-9]*) echo "--hours wants a whole number of hours, got '${HOURS}'" >&2; exit 2 ;;
+esac
+
 PREFIXES='asmlift-usercc- asmlift-score- asmlift-ref- asmlift-target- asmlift-mips-score- asmlift-mips-pas- bench-cand- bench-vendor- bench-m2c- bench-fidelity-'
 MINUTES=$((HOURS * 60))
-ROOTS="${TMPDIR:-/tmp} /tmp"
+# TMPDIR is /tmp on most Linux hosts and CI images, where listing both would sweep — and, in the
+# dry run, COUNT — the same root twice.
+ROOTS="${TMPDIR:-/tmp}"
+case "${TMPDIR:-/tmp}" in
+  /tmp | /tmp/) ;;
+  *) ROOTS="$ROOTS /tmp" ;;
+esac
 
 # ONE traversal per root, not one per prefix: `find` stats every entry, and a temp dir with a
 # million of them takes minutes per pass.


### PR DESCRIPTION
The loop's dominant recurring cost is the LBG ranked run, and its dominant recurring friction is
that nobody can check what a branch's numbers cost or whether they moved. This does both, and
proves it moved no measurement.

**Output neutrality — mechanical, on the final tree** (stamp `01d9a6c`, `dirty: false`, 834 rows,
**0 SKIPs**):

```
pnpm bench run  →  ✓ synthetic: 594  ✓ real: 240        (391 s)
pnpm bench:merge → Merged 834 results

pnpm bench diff --base origin/main
  diff vs origin/main: 0 field change(s), 0 added, 0 removed (834 base rows, 834 fresh rows)
pnpm bench stale-check --base origin/main   → stale=false
pnpm bench regression --base origin/main    → 0 lost, 0 missing, 0 gained, 0 other flips
```

`diff` compares every row's `asmlift.{outcome,score,candidateLabel,source}` and
`m2c.{outcome,score,source}`; `stale-check` goes further and compares the WHOLE row — `stale=false`
means not one field of one row moved. Nothing differed, so `results.json` is **not committed**:
`stale-check` is the repo's own answer to "does the artifact need replacing", and it says no.

---

## What is in it

### 1. The ranked run is 87% serial candidate compiles — `--jobs` pools them

Measured on the real seam (klonoa's own `decomp.yaml` template through `compileFromCommand`, an
LBG-sized 9.7 KB candidate, 3 interleaved rounds of 20, machine at load ~40):

```
compile ms/candidate : 49.1 49.8 50.9   median 49.8
score   ms/candidate : 13.3 10.7 10.2   median 10.7
compile share 82.3 %      projected 20608 candidates: 20.8 min
```

which matches the 19m44s–21m17s the LBG runs actually took. `rankBy`'s driver is synchronous, so
all of it ran on one core. Pooling the compiles alone (same template, min of 2 interleaved rounds
of 40): serial 49.7 ms/candidate, **p2 1.98× · p4 3.52× · p6 4.30× · p8 4.92×**.

`decompileRankedParallel` gives each worker a scratch slot, takes the next unclaimed candidate and
scores its object the moment it lands, so the objdiff score (main thread) overlaps the other
workers' subprocesses. **Only the compile moves**: the ordering is still core's `rankBy` over the
same enumeration, replayed afterwards against the memoized scores. The benchmark keeps calling
`decompileRanked` (default `--jobs 1`), so neutrality here is true by construction.

**Proved on the real thing** — LBG, 20,608 candidates, `--jobs 6` vs serial, launched together:

```
stdout (the winning source)  md5 fc2f2e5afa33d54f4069a2be4238ff96  ==  fc2f2e5afa33d54f4069a2be4238ff96
[score] lines                20608  ==  20608
diff <(grep -v '[progress]' ser.err) <(grep -v '[progress]' par.err)   →  0 lines
best                         473, same label, 0 dropped, both runs
wall                         serial 31m55s   ·   pooled 11m16s
```

Both ran concurrently with each other and with other workflows (load peaked at 175), so 2.83× is a
floor, not the isolated figure. `test/matching/ranked-parallel.test.ts` pins the equality
mechanically — it fails if the ranking is replayed in a different order.

### 2. A 20-minute ranked run printed nothing — `--progress`

Directly observed on this branch: the serial LBG run had written **0 bytes** to stdout and stderr
at 13 minutes, while the pooled run beside it was self-reporting
`asmlift: [progress] 18506/20608 candidates scored, best so far 473`. That silence is what the
round transcripts spent 30 minutes polling for and what made the same job get launched four times
concurrently. Opt-in, at most one line every 5 s, prefixed `[progress]` so two ranked logs still
compare on their `[score]` lines.

### 3. `bench diff --base`, and a base ref for the two gates that had none

`regression` and `stale-check` both hardcoded `git show HEAD:…results.json`, so on a branch that
has already committed its own artifact they compared it against **itself**. Both now take `--base`
(default `HEAD`, so today's behaviour is unchanged), through one `committed.ts`.

Neither answered the neutrality question anyway: `regression` compares `outcome` only (diff:12 →
diff:14 passes it), `stale-check` returns one word naming no row. So everyone rebuilt it —
`origin/main:apps/benchmark/results/results.json` appears **23 times across 7 agents'** own ad-hoc
Python and Node diffs in the round transcripts, each with its own idea of which fields count.
`bench diff` is that comparison once, and this PR's own proof is that command.

### 4. 1.5 M leaked scratch directories

Counted with a scandir over `$TMPDIR`: **1,570,099 entries** — 754,734 `asmlift-usercc-*`, 682,726
`bench-cand-*`, 28,419 `asmlift-score-*`, 28,295 `asmlift-ref-*`, 22,653 `asmlift-target-*`, 12,251
`asmlift-mips-score-*`, 9,775 `bench-vendor-*`, 7,504 `bench-m2c-*`. Every compile mkdtemp'd one and
removed none.

The CLI seam and the NATIVE benchmark modules now keep one directory per worker, **emptied** before
each compile — a step that exits 0 without writing its output must still fail loud on the missing
object, which reuse-in-place would hide. `scripts/tmp-janitor.sh` sweeps what is already there
(dry run by default, prefix- and age-bounded, `bench-real-*` deliberately excluded — that is the
content-keyed cache, not a leak). It reports 1,407,331 sweepable directories.

### 5. …and the one place that fix does NOT work, which this PR's own gate caught

The first full-bench neutrality run moved three `gcc2.7.2` rows, all with container-level errors
(`Can't open ccRzdNu2.s for reading`, `c.o: No such file or directory`, `OCI runtime exec failed …
nsexec`). A/B on the real module, 4 concurrent workers × 40 candidate compiles:

```
reused scratch path   : 50 / 160 FAILED
fresh mkdtemp (main)  :  0 / 160 failed
```

`gcc272` and `kmc` reach their scratch through the pool container's bind mount of the host `/tmp`,
and that mount does not survive the path being emptied and rewritten — emptying the CONTENTS and
keeping the inode fails identically (14/40, 14/40, 14/40, 13/40), so it is the shared mount's view
of the path, not the inode. Those two keep mkdtemp-per-candidate and now say why. The native
modules keep the fix and were stressed the same way: agbcc 160/160 ok, ido 160/160 ok.

### 6. The prompts

`/match-function` Phase 0 gets `--jobs 6 --progress` with the measured reason; Phase 4 names
`--base origin/main` on both gates and adds `bench diff` with the split stated once (`regression`
= did a match break, `diff` = what moved, row and field). `/attribute-function` Phase 7 gets the
same two lines. Net +23 and +7 lines.

---

## Gates

```
pnpm typecheck                     clean
npx vitest run --maxWorkers=3      127 files, 1563 tests passed
pnpm test:matching                 286 tests passed  (EXIT=0, 106.7 s)
npx eslint apps packages           0 errors (61 pre-existing warnings, none in changed files)
npx prettier --check .             clean
scripts/check-artifact-provenance.sh origin/main   OK
```

## Rejected, with the reason

- **An opt-in content-addressed candidate-object cache.** The key a proposal can actually compute
  (source + template + compiler binary) cannot see the project's headers or include dirs, so a
  rebuild silently serves stale objects — a wrong score, which is this repo's worst defect class.
  Its payoff is also the one the pool already takes: a repeated identical run.
- **Normalising `gcc272`/`kmc` off `/tmp` onto `os.tmpdir()`.** The code says why they are there
  ("the container pool's mount"); moving them would break the dockerized compile outright.
- **Hoisting the per-candidate re-parse of the target object.** Already falsified upstream of this
  work (7.35 ms vs 7.40 ms) and consistent with what I measured: the objdiff half is 10.7 ms of a
  60 ms candidate.

## Proposals — not implemented here, because each would move a measurement

1. **A transient container failure is CACHED into the artifact.** `cachedM2cResult` stores the whole
   `DecompilerResult`, so a one-off `Can't open ccXXXX.s for reading` becomes a permanent
   `m2c: noncompile` for that row, re-served on every later run. It cost this PR two blocked
   neutrality proofs before I found it; I purged the poisoned entries by hand. The harness already
   holds the principle — "a missing m2c is a SETUP defect, never an m2c result" — and a
   container-level failure during the scoring compile is the same thing.
2. **The five `mkdtemp` sites in `packages/toolchains/src/compile.ts`** leak exactly like the ones
   fixed here (the `asmlift-score-`/`-ref-`/`-target-`/`-mips-score-` counts above). Out of scope
   for this branch.
3. **`--jobs` for the pooled ranked run interacts with the machine, not the code**: six concurrent
   agbcc processes is right for a quiet machine and wrong when three workflows are running. Worth a
   line in the round brief if the loop ever runs more tracks at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
