### PR TITLE
Meta-optimisation, iteration 2: the provenance check survives a rebase, an empty filter stops being a tick, and the ranked repro gets one home

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -20,9 +20,12 @@ one) is an unfinished finding.
 
 1. Resolve the row: `pnpm bench run --tier real --only $1`. Record the outcome verbatim for both
    decompilers.
-2. Reproduce outside the harness: run the CLI from the project checkout with `--config decomp.yaml
-   --score-against <target.o>` (add `--proto` if a callee's arity is known to matter — say so).
-   The best `[score]` line is the number every later claim is measured against.
+2. Reproduce outside the harness with **the command in
+   [`docs/ranked-repro.md`](../../docs/ranked-repro.md), verbatim** — its flags (`--proto` when a
+   callee's arity matters, `--jobs 6 --progress`) are part of the number, and its `grep -F
+   '[score]'` recipe is how two such runs get compared. That file is shared with
+   `/match-function`; correct it there, never here. The best `[score]` line is the number every
+   later claim is measured against, and it goes into your report verbatim, flags included.
 3. State the baseline in your first user-facing message.
 
 ## Phase 1 — Capture what was actually compiled
@@ -136,7 +139,10 @@ attribution line for every decline naming its first blocker. Constraints learned
    they must pass after. `npx vitest run`, `pnpm test:matching`, `pnpm typecheck`,
    `npx eslint apps packages` (not `pnpm lint`), `pnpm format` check.
 3. Artifacts (`apps/benchmark/results/results.json`, both web copies) regenerated at the source
-   commit's HEAD (`meta.asmlift.dirty` must be false) and committed separately.
+   commit's HEAD (`meta.asmlift.dirty` must be false) and committed separately — **after** your
+   final rebase, as the last commit. A rebase rewrites the commit the artifact's stamp names, and
+   it can slide a base commit that changes the decompiler underneath numbers measured without one.
+   `scripts/check-artifact-provenance.sh` fails both; run it before opening the PR.
 4. Zero-flip over the previously committed rows blocks the branch, same as `/match-function`.
    `pnpm bench diff --base origin/main` is that check by row and field, and its output is the
    report's list of what moved.

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -27,21 +27,12 @@ you looked at this function's diff is a failure, even if the row flips to MATCH.
    before/after pair of real command output.
 5. **Write every repro command down verbatim, flags included** — the `--only` line above, and any
    ranked enumeration you run outside the harness. Every later measurement (each reviewer's, each
-   remediation's, the PR body's) re-runs *that* command, not one recomposed from memory. The flags
-   are part of the number: a callee still written in assembly has no DWARF signature, so
-   `LoadBGTilemapData` without `--proto '{"thunk_HeapFree":{"params":1}}'` scores 578 where the
-   round's baseline is 547 — a plausible number that is comparable to nothing. Quote the candidate
-   and dropped counts beside every ranked score. Add `--jobs 6 --progress`: the candidate compiles
-   are ~85% of a ranked run and pool cleanly, and the `asmlift: [progress]` liveness lines are what
-   makes a later claim about the run checkable from its own log. Two LBG runs launched together
-   measured **36m10s serial against 21m32s at `--jobs 6`** (20608 candidates, 0 dropped, identical
-   winner) — but that machine was also running two full benches and both test suites, and a quieter
-   pair measured 31m55s against 11m16s. The ratio is the machine's, not the code's: re-time on your
-   own log and quote that, never these. Compare two runs on their `[score]` lines, and filter with
-   a FIXED string — `diff <(grep -F '[score]' a.err) <(grep -F '[score]' b.err)`. `grep '[progress]'` is a bracket
-   EXPRESSION matching any one of `p r o g e s`, so `grep -v '[progress]'` deletes almost every
-   line including every `[score]` one, and the diff passes having compared nothing. A neutrality
-   check that filters away what it is comparing is worse than none.
+   remediation's, the PR body's) re-runs *that* command, not one recomposed from memory. For the
+   ranked enumeration that means **the command in [`docs/ranked-repro.md`](../../docs/ranked-repro.md),
+   verbatim**: its flags (`--proto`, `--jobs 6 --progress`) are part of the number, and so is its
+   `grep -F '[score]'` comparison recipe. That file is shared with `/attribute-function` — the last
+   time this command was described in two prompts they drifted and a round published a number
+   comparable to nothing, so correct it there and never here.
 
 ## Phase 1 — Diagnose the gap honestly
 
@@ -108,18 +99,21 @@ before and after.
 
 Three things this gate does not catch by itself:
 
-- **The regenerated artifact is the LAST commit on the branch.** `results.json` stamps the commit
-  it was generated at, and every number you publish reads from it — so a commit that touches core,
-  cli, the harness or the dataset after it silently republishes numbers a rule version that no
-  longer exists produced. Regenerate after Phase 5's remediation, and run
-  `scripts/check-artifact-provenance.sh` before opening the PR.
+- **The regenerated artifact is the LAST commit on the branch — after the final rebase.**
+  `results.json` stamps the commit it was generated at, and every number you publish reads from it,
+  so a commit that touches core, cli, the harness or the dataset after it silently republishes
+  numbers a rule version that no longer exists produced. Rebasing counts twice over: it rewrites
+  the commit the stamp names, and it can slide a base commit that changes the decompiler underneath
+  numbers measured without it — which a per-row diff against the base then credits to your branch.
+  So the order is rebase → gates → regenerate → push. `scripts/check-artifact-provenance.sh` fails
+  all three shapes; run it before opening the PR.
 - **A number measured OUTSIDE the harness goes stale the same way, and nothing checks it.** The
   ranked run from Phase 0 measures the commit it ran at, and when the target is not a benchmark
   row the regression gate cannot see it move — so remediation rewrites what it measures with
   nothing to notice. Re-run it at the branch's final commit and publish *that* number; "the
   primary output is byte-identical" is a claim about one candidate out of tens of thousands, not
-  about the best score. Launch it beside the final `pnpm bench run`, not after it, with
-  `--jobs 6 --progress`. Skipping it is now unquotable: the `[progress]` lines timestamp the run's
+  about the best score. Launch it beside the final `pnpm bench run`, not after it, with the same
+  `docs/ranked-repro.md` flags. Skipping it is now unquotable: the `[progress]` lines timestamp the run's
   own cost, so "it had not finished" is checkable against the log — a round once wrote that of a
   re-score "not finished after 2h", in a session under an hour long that had run no ranked
   command at all.

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -40,7 +40,7 @@ import { RESULTS_DIR } from './config';
 import { materializeScoringContext, writeScoreConfig } from './decomp-config';
 import { merge } from './report/merge';
 import { publish } from './report/publish';
-import { type Tier, orchestrate } from './run/orchestrate';
+import { type Tier, emptySelectionError, orchestrate, tierIsFiltered } from './run/orchestrate';
 import { parseShard, runCases } from './run/runner';
 import { smoke } from './run/smoke';
 import { verify } from './run/verify';
@@ -115,11 +115,33 @@ switch (command) {
     if (opts.serial) {
       mkdirSync(RESULTS_DIR, { recursive: true });
       const shard = opts.shard ? parseShard(opts.shard) : { idx: 0, n: 1 };
+      // The same empty-selection verdict the fanned-out path takes, because this path writes
+      // <tier>.json DIRECTLY: `--tier synthetic --only <typo> --toolchain agbcc --serial` — the
+      // per-toolchain smoke shape /attribute-function instructs — replaced a 594-row
+      // synthetic.json with an empty one and exited 0, and the next `bench merge` published the
+      // other tier alone. A shard CHILD is exempt: it always writes its part file (even 0 rows —
+      // the stitcher owns <tier>.json), and a filter narrower than the shard count legitimately
+      // leaves most shards empty.
+      let selected: number | null = null;
+      const untouched: Tier[] = [];
       for (const tier of tiers) {
-        // a spawned shard child ALWAYS writes its part file (even 0/1) — the stitcher owns <tier>.json
         const out = join(RESULTS_DIR, opts.shard ? `${tier}.part${shard.idx}.json` : `${tier}.json`);
-        const n = runCases(casesFor(tier), out, shard).length;
+        const filtered = !opts.shard && tierIsFiltered(tier, opts);
+        const cases = casesFor(tier);
+        if (filtered && cases.length === 0) {
+          selected = selected ?? 0;
+          untouched.push(tier);
+          console.log(`\nNo ${tier} row selected — ${out} left unchanged`);
+          continue;
+        }
+        const n = runCases(cases, out, shard).length;
+        if (filtered) {
+          selected = (selected ?? 0) + n;
+        }
         console.log(`\nWrote ${n} ${tier} results → ${out}`);
+      }
+      if (selected === 0) {
+        throw emptySelectionError(opts, untouched);
       }
     } else {
       const jobs = Number(opts.jobs ?? Math.min(8, cpus().length));

--- a/apps/benchmark/src/run/orchestrate.ts
+++ b/apps/benchmark/src/run/orchestrate.ts
@@ -71,8 +71,17 @@ function runShard(tier: Tier, shard: string, extra: string[]): Promise<ShardOutc
   });
 }
 
-/** Stitch `${tier}.part{0..n-1}.json` back into the canonical `${tier}.json`, delete the parts. */
-function stitch(tier: Tier, n: number): number {
+/** Which of the three filters can select a row in `tier`. `--only` is the one both tiers read, so
+ *  an `--only` naming a synthetic row selects nothing in `real` and that is an answer, not a typo
+ *  — which is why the empty-selection verdict is taken over the whole run, never per tier.
+ *  Exported for the test: this predicate is the whole rule. */
+export function tierIsFiltered(tier: Tier, opts: Pick<OrchestrateOptions, 'only' | 'project' | 'toolchain'>): boolean {
+  return Boolean(opts.only) || Boolean(tier === 'synthetic' ? opts.toolchain : opts.project);
+}
+
+/** Stitch `${tier}.part{0..n-1}.json` back into the canonical `${tier}.json`, delete the parts.
+ *  `filtered` says a filter could have selected rows here, which makes an empty result a typo. */
+function stitch(tier: Tier, n: number, filtered: boolean): number {
   const results: FunctionResult[] = [];
   let parts = 0;
   for (let i = 0; i < n; i++) {
@@ -89,6 +98,12 @@ function stitch(tier: Tier, n: number): number {
     // keep the last good canonical file instead of clobbering it with an empty set
     return 0;
   }
+  if (filtered && results.length === 0) {
+    // Same reason, one step earlier: a filter that selects nothing still has every shard write
+    // its own (empty) part file, so this is reached with parts > 0 and the write would replace a
+    // good 240-row `real.json` with `results: []` — which is what `bench merge` reads next.
+    return 0;
+  }
   const out: BenchOutput = { meta: benchMeta(results), results };
   writeFileSync(join(RESULTS_DIR, `${tier}.json`), JSON.stringify(out, null, 2));
   return results.length;
@@ -97,6 +112,9 @@ function stitch(tier: Tier, n: number): number {
 export async function orchestrate(opts: OrchestrateOptions): Promise<void> {
   mkdirSync(RESULTS_DIR, { recursive: true });
   let failedShards = 0;
+  // Rows selected across every tier a filter could have selected in. Stays null on an unfiltered
+  // run, which is the only kind that reaches a branch — so this verdict cannot move a number.
+  let selected: number | null = null;
   for (const tier of opts.tiers) {
     const extra: string[] = [];
     if (opts.only) {
@@ -116,18 +134,39 @@ export async function orchestrate(opts: OrchestrateOptions): Promise<void> {
     const failed = outcomes.filter((o) => o.code !== 0).length;
     failedShards += failed;
     const skips = outcomes.reduce((sum, o) => sum + o.skips, 0);
-    const n = stitch(tier, opts.jobs);
+    const filtered = tierIsFiltered(tier, opts);
+    const n = stitch(tier, opts.jobs, filtered);
+    if (filtered) {
+      selected = (selected ?? 0) + n;
+    }
     const secs = ((Date.now() - t0) / 1000).toFixed(1);
     // A skip total belongs on the tier line, not only in the scrollback: an absent toolchain
     // costs whole projects (marioparty3's 40 rows) and `bench regression` reads them as MISSING.
     const skipNote = skips ? ` — ⚠ ${skips} row(s) SKIPPED, toolchain unavailable` : '';
+    // `→ results/<tier>.json` is a claim about a write, so it goes only where one happened.
+    const empty = filtered && n === 0;
+    const wrote = empty ? ` — no row selected, results/${tier}.json left unchanged` : ` → results/${tier}.json`;
     console.log(
-      `${failed ? '✗' : '✓'} ${tier}: ${n} results in ${secs}s${failed ? ` (${failed} shard(s) exited nonzero)` : ''} → results/${tier}.json${skipNote}`,
+      `${failed ? '✗' : empty ? '–' : '✓'} ${tier}: ${n} results in ${secs}s${failed ? ` (${failed} shard(s) exited nonzero)` : ''}${wrote}${skipNote}`,
     );
   }
   if (failedShards > 0) {
     // all tiers stitched (partial results persist for debugging), but the run itself failed
     throw new Error(`${failedShards} shard(s) exited nonzero — see BUILD-FAIL/error lines above`);
+  }
+  if (selected === 0) {
+    // A green tick on a row that does not exist is how an attribution once rested on a control
+    // row nobody had written. `--only` is a SUBSTRING of the symbol, not the row id.
+    const shown = [
+      opts.only && `--only ${opts.only}`,
+      opts.project && `--project ${opts.project}`,
+      opts.toolchain && `--toolchain ${opts.toolchain}`,
+    ].filter(Boolean);
+    throw new Error(
+      `no row matched ${shown.join(' ')} in tier(s) ${opts.tiers.join('+')} — nothing was measured, ` +
+        `and results/*.json were left as they were. Check the symbol with ` +
+        `\`grep -rn "sym: '<name>'" apps/benchmark/dataset\`.`,
+    );
   }
   console.log(`\nDone. Next: pnpm bench:merge`);
 }

--- a/apps/benchmark/src/run/orchestrate.ts
+++ b/apps/benchmark/src/run/orchestrate.ts
@@ -79,6 +79,31 @@ export function tierIsFiltered(tier: Tier, opts: Pick<OrchestrateOptions, 'only'
   return Boolean(opts.only) || Boolean(tier === 'synthetic' ? opts.toolchain : opts.project);
 }
 
+/** The verdict itself, shared by both run paths — the fanned-out one below and the `--serial` one
+ *  in cli.ts, which writes `<tier>.json` directly and so empties it exactly the same way.
+ *  `untouched` names the tier files that were left alone, because the OTHER tier in the same run
+ *  may legitimately have been rewritten (`--toolchain` filters only synthetic, `--project` only
+ *  real, so the unfiltered tier runs whole) — and a fail-loud message must not claim a write did
+ *  not happen when it did. */
+export function emptySelectionError(
+  opts: Pick<OrchestrateOptions, 'only' | 'project' | 'toolchain'>,
+  untouched: Tier[],
+): Error {
+  // `--only` is a SUBSTRING of the symbol, not the row id. A green tick on a row that does not
+  // exist is how an attribution once rested on a control row nobody had written.
+  const shown = [
+    opts.only && `--only ${opts.only}`,
+    opts.project && `--project ${opts.project}`,
+    opts.toolchain && `--toolchain ${opts.toolchain}`,
+  ].filter(Boolean);
+  const files = untouched.map((t) => `results/${t}.json`).join(' and ');
+  return new Error(
+    `no row matched ${shown.join(' ')} in tier(s) ${untouched.join('+')} — nothing was measured ` +
+      `there, and ${files} left unchanged. Check the symbol with ` +
+      `\`grep -rn "sym: '<name>'" apps/benchmark/dataset\`.`,
+  );
+}
+
 /** Stitch `${tier}.part{0..n-1}.json` back into the canonical `${tier}.json`, delete the parts.
  *  `filtered` says a filter could have selected rows here, which makes an empty result a typo. */
 function stitch(tier: Tier, n: number, filtered: boolean): number {
@@ -115,6 +140,7 @@ export async function orchestrate(opts: OrchestrateOptions): Promise<void> {
   // Rows selected across every tier a filter could have selected in. Stays null on an unfiltered
   // run, which is the only kind that reaches a branch — so this verdict cannot move a number.
   let selected: number | null = null;
+  const untouched: Tier[] = [];
   for (const tier of opts.tiers) {
     const extra: string[] = [];
     if (opts.only) {
@@ -145,6 +171,9 @@ export async function orchestrate(opts: OrchestrateOptions): Promise<void> {
     const skipNote = skips ? ` — ⚠ ${skips} row(s) SKIPPED, toolchain unavailable` : '';
     // `→ results/<tier>.json` is a claim about a write, so it goes only where one happened.
     const empty = filtered && n === 0;
+    if (empty) {
+      untouched.push(tier);
+    }
     const wrote = empty ? ` — no row selected, results/${tier}.json left unchanged` : ` → results/${tier}.json`;
     console.log(
       `${failed ? '✗' : empty ? '–' : '✓'} ${tier}: ${n} results in ${secs}s${failed ? ` (${failed} shard(s) exited nonzero)` : ''}${wrote}${skipNote}`,
@@ -155,18 +184,7 @@ export async function orchestrate(opts: OrchestrateOptions): Promise<void> {
     throw new Error(`${failedShards} shard(s) exited nonzero — see BUILD-FAIL/error lines above`);
   }
   if (selected === 0) {
-    // A green tick on a row that does not exist is how an attribution once rested on a control
-    // row nobody had written. `--only` is a SUBSTRING of the symbol, not the row id.
-    const shown = [
-      opts.only && `--only ${opts.only}`,
-      opts.project && `--project ${opts.project}`,
-      opts.toolchain && `--toolchain ${opts.toolchain}`,
-    ].filter(Boolean);
-    throw new Error(
-      `no row matched ${shown.join(' ')} in tier(s) ${opts.tiers.join('+')} — nothing was measured, ` +
-        `and results/*.json were left as they were. Check the symbol with ` +
-        `\`grep -rn "sym: '<name>'" apps/benchmark/dataset\`.`,
-    );
+    throw emptySelectionError(opts, untouched);
   }
   console.log(`\nDone. Next: pnpm bench:merge`);
 }

--- a/apps/benchmark/test/orchestrate-filter.test.ts
+++ b/apps/benchmark/test/orchestrate-filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { tierIsFiltered } from '../src/run/orchestrate';
+import { emptySelectionError, tierIsFiltered } from '../src/run/orchestrate';
 
 // A filter that selects no row used to print `✓ real: 0 results` and exit 0, having replaced a
 // good 240-row `real.json` with `results: []` — the file `bench merge` reads next. The verdict is
@@ -22,5 +22,25 @@ describe('tierIsFiltered', () => {
     expect(tierIsFiltered('real', { toolchain: 'agbcc' })).toBe(false);
     expect(tierIsFiltered('real', { project: 'klonoa' })).toBe(true);
     expect(tierIsFiltered('synthetic', { project: 'klonoa' })).toBe(false);
+  });
+});
+
+// The message is fail-loud output, so it must not claim a write did not happen when it did:
+// `--project <typo>` with the default `--tier both` leaves real.json alone but runs synthetic
+// WHOLE and rewrites it, because --project does not filter synthetic at all.
+describe('emptySelectionError', () => {
+  it('names only the tier files that were actually left alone', () => {
+    expect(emptySelectionError({ project: 'nosuch' }, ['real']).message).toContain(
+      'in tier(s) real — nothing was measured there, and results/real.json left unchanged',
+    );
+    expect(emptySelectionError({ only: 'Nope' }, ['synthetic', 'real']).message).toContain(
+      'results/synthetic.json and results/real.json left unchanged',
+    );
+  });
+
+  it('quotes back every filter that was in force', () => {
+    const m = emptySelectionError({ only: 'Nope', toolchain: 'agbcc' }, ['synthetic']).message;
+    expect(m).toContain('--only Nope');
+    expect(m).toContain('--toolchain agbcc');
   });
 });

--- a/apps/benchmark/test/orchestrate-filter.test.ts
+++ b/apps/benchmark/test/orchestrate-filter.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { tierIsFiltered } from '../src/run/orchestrate';
+
+// A filter that selects no row used to print `✓ real: 0 results` and exit 0, having replaced a
+// good 240-row `real.json` with `results: []` — the file `bench merge` reads next. The verdict is
+// taken over the whole run because `--toolchain` only selects in `synthetic` and `--project` only
+// in `real`, so "0 rows in this tier" is a legitimate answer for a filter that is not this tier's.
+describe('tierIsFiltered', () => {
+  it('is false with no filter at all — an unfiltered run can never reach the empty verdict', () => {
+    expect(tierIsFiltered('synthetic', {})).toBe(false);
+    expect(tierIsFiltered('real', {})).toBe(false);
+  });
+
+  it('reads --only in both tiers', () => {
+    expect(tierIsFiltered('synthetic', { only: 'Foo' })).toBe(true);
+    expect(tierIsFiltered('real', { only: 'Foo' })).toBe(true);
+  });
+
+  it('scopes --toolchain to synthetic and --project to real', () => {
+    expect(tierIsFiltered('synthetic', { toolchain: 'agbcc' })).toBe(true);
+    expect(tierIsFiltered('real', { toolchain: 'agbcc' })).toBe(false);
+    expect(tierIsFiltered('real', { project: 'klonoa' })).toBe(true);
+    expect(tierIsFiltered('synthetic', { project: 'klonoa' })).toBe(false);
+  });
+});

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -17,8 +17,10 @@ npx tsx <repo>/packages/cli/src/main.ts <asm/nonmatchings/…/Fn.s> \
   --jobs 6 --progress
 ```
 
-Run it from the project checkout with `source /tmp/wt-env.sh` already done, and redirect stderr to
-a file — the `[score]` and `[progress]` lines are stderr, and they are the whole record.
+Run it from the project checkout and redirect stderr to a file — the `[score]` and `[progress]`
+lines are stderr, and they are the whole record. From a git worktree, export the harness's
+toolchain overrides first (`ASMLIFT_AGBCC` and the rest): a worktree's repo root is not the
+workspace, so without them the sibling checkouts do not resolve and the run measures nothing.
 
 ## The flags are part of the number
 

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -1,0 +1,55 @@
+# The ranked repro
+
+The one invocation both `/match-function` and `/attribute-function` measure a real-project row
+with, and the only place its flags are written down. **Both commands point here; edit this file,
+not a copy inside a prompt.** The last time the same command was described in two prompts they
+drifted, and a round published `557/578` against a `547` baseline — three numbers produced by
+three different commands (PR #79).
+
+## The command
+
+```sh
+cd <project checkout>            # e.g. apps/benchmark/checkouts/klonoa-empire-of-dreams
+npx tsx <repo>/packages/cli/src/main.ts <asm/nonmatchings/…/Fn.s> \
+  --config decomp.yaml \
+  --score-against <build/…/tu.o> \
+  --proto '{"<callee>":{"params":N}}' \
+  --jobs 6 --progress
+```
+
+Run it from the project checkout with `source /tmp/wt-env.sh` already done, and redirect stderr to
+a file — the `[score]` and `[progress]` lines are stderr, and they are the whole record.
+
+## The flags are part of the number
+
+- **`--proto`, whenever a callee's arity matters.** A callee still written in assembly carries no
+  DWARF signature, so asmlift has to guess its arity and guesses wrong. `LoadBGTilemapData`
+  without `--proto '{"thunk_HeapFree":{"params":1}}'` scores **578** where the round's baseline is
+  **547** — a plausible number that is comparable to nothing.
+- **`--jobs 6 --progress`.** The candidate compiles are ~85% of a ranked run and pool cleanly.
+  Two LBG runs launched together measured **36m10s serial against 21m32s at `--jobs 6`** (20608
+  candidates, 0 dropped, identical winner) — but that machine was also running two full benches
+  and both test suites, and a quieter pair measured **31m55s against 11m16s**. The ratio is the
+  machine's, not the code's: re-time on your own log and quote that, never these. The
+  `asmlift: [progress]` lines are what make a later claim about the run checkable from its log.
+- Quote the **candidate and dropped counts** beside every ranked score. A score from a run that
+  dropped candidates is not comparable to one that dropped none.
+
+## Comparing two runs
+
+Compare on the `[score]` lines, filtered with a **fixed** string:
+
+```sh
+diff <(grep -F '[score]' a.err) <(grep -F '[score]' b.err)
+```
+
+`grep '[progress]'` is a bracket **expression** matching any one of `p r o g e s`, so
+`grep -v '[progress]'` deletes almost every line including every `[score]` one, and the diff
+passes having compared nothing. A neutrality check that filters away what it is comparing is
+worse than none.
+
+## Write it down
+
+Whatever you run, paste it verbatim, flags included, into your report. Every later measurement —
+each reviewer's, each remediation's, the PR body's — re-runs _that_ command, not one recomposed
+from memory.

--- a/scripts/check-artifact-provenance.sh
+++ b/scripts/check-artifact-provenance.sh
@@ -33,8 +33,8 @@
 #      rebase onto a main that gained a decompiler change and the artifact commit now sits on top
 #      of it while still holding numbers measured without it. So a branch publishing its own
 #      artifact must have generated it on a tree that already contained the base. Only the paths
-#      that can move a row on their own are a failure here; a base change to the harness is
-#      reported and not failed, because it has been row-neutral before.
+#      that decide a measurement are a failure here; a base change to the harness around them is
+#      reported and not failed — see `measures` below for which is which, and why.
 #
 # usage: scripts/check-artifact-provenance.sh [base-ref…]      (default: origin/main)
 set -eu
@@ -55,10 +55,20 @@ artifact=apps/benchmark/results/results.json
 # (`packages/bench-schema` is deliberately absent: it defines the vocabulary the site RENDERS,
 #  and editing a definition's text moves no row.)
 paths='packages/core/src packages/cli/src packages/toolchains/src apps/benchmark/src apps/benchmark/dataset'
-# the subset that decides a measurement: the decompiler, the compilers it is driven through, and
-# the inputs. The rest is the harness around them — it can move a row and so stays in `paths`,
-# but a BASE change there is reported rather than failed (see verdict 3).
-measures='packages/core/src packages/toolchains/src apps/benchmark/dataset'
+# the subset that decides a measurement: the decompiler, the ranking and scoring it is graded by,
+# the compilers it is driven through, and the inputs. `packages/cli/src` is in this list and not
+# the remainder — `eval/asmlift.ts` imports `decompileRanked` from `@asmlift/cli/rank` and
+# `compile/real.ts` imports `scoreObjects` from `@asmlift/cli/score`, so that package picks the
+# winning candidate and computes the score of every row; #69, a round that moved rows, changed
+# `packages/cli/src/objdiff.ts`. Calling it "the harness around the decompiler" made verdict 3
+# exit 0 on a base commit to the ranker — the exact false pass verdict 3 exists to prevent.
+#
+# The remainder is `apps/benchmark/src`, where a BASE change is reported rather than failed. Not
+# because it is provably row-neutral — it is not — but because of what lands there: in this
+# repo's whole history exactly two commits touched it without also touching one of the paths
+# below, and both came from a meta round whose own gate is a full `bench run` diffed per row
+# against the base. The note is how a reviewer sees one anyway.
+measures='packages/core/src packages/cli/src packages/toolchains/src apps/benchmark/dataset'
 
 [ -f "$artifact" ] || { echo "provenance: no $artifact — nothing to check"; exit 0; }
 
@@ -82,9 +92,13 @@ done
 echo "provenance: base(s) excluded:$bases"
 
 # Does this branch publish an artifact of its own? Compared by blob, not by commit, because that
-# is the only question the stamp's reachability cannot answer after a rebase.
+# is the only question the stamp's reachability cannot answer after a rebase. Hashed from the file
+# ON DISK, not `HEAD:$artifact`, so it is the same bytes the stamp above was read from: an agent
+# who regenerates and runs this before committing would otherwise be told its artifact is the
+# base's — and skip verdicts 2 and 3 on the numbers it is about to publish. In CI the two are the
+# same file.
 own=yes
-head_blob=$(git rev-parse --verify --quiet "HEAD:$artifact" || true)
+head_blob=$(git hash-object "$artifact" 2>/dev/null || true)
 for ref in $bases; do
   base_blob=$(git rev-parse --verify --quiet "$ref:$artifact" || true)
   if [ -n "$head_blob" ] && [ "$head_blob" = "$base_blob" ]; then

--- a/scripts/check-artifact-provenance.sh
+++ b/scripts/check-artifact-provenance.sh
@@ -9,15 +9,32 @@
 # were this, on two branches — reviewer time spent on repo hygiene because nothing mechanical
 # looks.
 #
-# Fires on commits THIS BRANCH adds after the stamp that touch code the artifact measures.
-# Commits the base branch gained meanwhile are not this branch's problem, so every base ref
-# given is excluded — pass the base BRANCH, not only the sha a webhook payload froze: that sha
-# goes stale while the PR is open, while the merge ref CI checks out is rebuilt against the
-# base's moving tip, so excluding only the sha reports someone else's merged round as a commit
-# this branch added. Merge commits are skipped for the same reason: the one GitHub synthesizes
-# for `refs/pull/N/merge` is TREESAME to neither side once both touched these paths, and it is
-# not a change this branch made. A stamp that is not in this repo's history (main squash-merges,
-# so main's own stamp is always unreachable) is UNKNOWN, not a failure.
+# Three verdicts, in the order they are checked:
+#
+#   1. AHEAD-OF-STAMP. Commits THIS BRANCH adds after the stamp that touch code the artifact
+#      measures. Commits the base branch gained meanwhile are not this branch's problem, so every
+#      base ref given is excluded — pass the base BRANCH, not only the sha a webhook payload
+#      froze: that sha goes stale while the PR is open, while the merge ref CI checks out is
+#      rebuilt against the base's moving tip, so excluding only the sha reports someone else's
+#      merged round as a commit this branch added. Merge commits are skipped for the same reason:
+#      the one GitHub synthesizes for `refs/pull/N/merge` is TREESAME to neither side once both
+#      touched these paths, and it is not a change this branch made.
+#
+#   2. UNVERIFIABLE STAMP. A stamp that is not in this repo's history used to be UNKNOWN, full
+#      stop — but that lets a rebase switch the whole check off: rebasing after regenerating
+#      rewrites the commit the artifact names while the artifact keeps naming the old sha, and
+#      after a force-push that sha is not on the remote at all. So the two cases are separated by
+#      the artifact BLOB. Identical to a base's ⇒ the branch published no numbers of its own and
+#      the stamp is the base's business (main squash-merges, so main's own stamp is always
+#      unreachable) ⇒ UNKNOWN. Different from every base's ⇒ this branch published numbers whose
+#      provenance nothing can check ⇒ regenerate after the final rebase.
+#
+#   3. BEHIND THE BASE. The within-branch check is blind to the base moving UNDER the artifact:
+#      rebase onto a main that gained a decompiler change and the artifact commit now sits on top
+#      of it while still holding numbers measured without it. So a branch publishing its own
+#      artifact must have generated it on a tree that already contained the base. Only the paths
+#      that can move a row on their own are a failure here; a base change to the harness is
+#      reported and not failed, because it has been row-neutral before.
 #
 # usage: scripts/check-artifact-provenance.sh [base-ref…]      (default: origin/main)
 set -eu
@@ -38,6 +55,10 @@ artifact=apps/benchmark/results/results.json
 # (`packages/bench-schema` is deliberately absent: it defines the vocabulary the site RENDERS,
 #  and editing a definition's text moves no row.)
 paths='packages/core/src packages/cli/src packages/toolchains/src apps/benchmark/src apps/benchmark/dataset'
+# the subset that decides a measurement: the decompiler, the compilers it is driven through, and
+# the inputs. The rest is the harness around them — it can move a row and so stays in `paths`,
+# but a BASE change there is reported rather than failed (see verdict 3).
+measures='packages/core/src packages/toolchains/src apps/benchmark/dataset'
 
 [ -f "$artifact" ] || { echo "provenance: no $artifact — nothing to check"; exit 0; }
 
@@ -60,9 +81,29 @@ done
 }
 echo "provenance: base(s) excluded:$bases"
 
+# Does this branch publish an artifact of its own? Compared by blob, not by commit, because that
+# is the only question the stamp's reachability cannot answer after a rebase.
+own=yes
+head_blob=$(git rev-parse --verify --quiet "HEAD:$artifact" || true)
+for ref in $bases; do
+  base_blob=$(git rev-parse --verify --quiet "$ref:$artifact" || true)
+  if [ -n "$head_blob" ] && [ "$head_blob" = "$base_blob" ]; then
+    own=no
+  fi
+done
+
 if ! git cat-file -e "$stamp^{commit}" 2>/dev/null || ! git merge-base --is-ancestor "$stamp" HEAD 2>/dev/null; then
-  echo "provenance: artifact stamp $(echo "$stamp" | cut -c1-7) is not an ancestor of HEAD — UNKNOWN, not checked"
-  exit 0
+  if [ "$own" = no ]; then
+    echo "provenance: artifact stamp $(echo "$stamp" | cut -c1-7) is not an ancestor of HEAD, and the artifact"
+    echo "is byte-identical to the base's — this branch publishes no numbers of its own. UNKNOWN, not checked."
+    exit 0
+  fi
+  echo "provenance: FAIL — this branch publishes its own artifact, and the commit it says it was"
+  echo "generated at ($(echo "$stamp" | cut -c1-7)) is not in this history. Regenerating and THEN rebasing"
+  echo "rewrites that commit, which leaves nothing able to check what the numbers measured."
+  echo
+  echo "Regenerate it (pnpm bench run && pnpm bench merge) as the LAST commit on the branch."
+  exit 1
 fi
 
 after=$(git log --no-merges --oneline HEAD --not "$stamp" $bases -- $paths)
@@ -74,6 +115,33 @@ if [ -n "$after" ]; then
   echo
   echo "Regenerate it (pnpm bench run && pnpm bench merge) as the LAST commit on the branch."
   exit 1
+fi
+
+if [ "$own" = yes ]; then
+  # Base commits the stamp does not contain. Both spellings of the base list the same commits, so
+  # dedupe while keeping git's newest-first order.
+  behind=$(for ref in $bases; do
+    git log --no-merges --oneline "$ref" --not "$stamp" -- $measures
+  done | awk 'NF && !seen[$0]++')
+  if [ -n "$behind" ]; then
+    echo "provenance: FAIL — the artifact was generated at $(echo "$stamp" | cut -c1-7), which predates"
+    echo "$(printf '%s\n' "$behind" | wc -l | tr -d ' ') base commit(s) that change what it measures:"
+    printf '%s\n' "$behind" | sed 's/^/  /'
+    echo
+    echo "These numbers were measured without them, so a per-row diff against the base credits their"
+    echo "effect to this branch. Rebase onto the base, then regenerate (pnpm bench run && pnpm bench"
+    echo "merge) as the LAST commit."
+    exit 1
+  fi
+  harness=$(for ref in $bases; do
+    git log --no-merges --oneline "$ref" --not "$stamp" -- $paths
+  done | awk 'NF && !seen[$0]++')
+  if [ -n "$harness" ]; then
+    echo "provenance: note — $(printf '%s\n' "$harness" | wc -l | tr -d ' ') base commit(s) after the stamp touch the harness around the"
+    echo "decompiler, not the decompiler itself. Not a failure; listed because a per-row diff against"
+    echo "the base would attribute anything they moved to this branch:"
+    printf '%s\n' "$harness" | sed 's/^/  /'
+  fi
 fi
 
 echo "provenance: OK — no commit after $(echo "$stamp" | cut -c1-7) touches what the artifact measures"


### PR DESCRIPTION
Three findings from the supervisor's pass survived being checked; two did not. The two rejections
are argued below with the measurements that killed them, because "we looked and it was not there"
is the part a later round otherwise re-discovers.

Everything here is git-only or on a path an unfiltered run never reaches. **Neutrality is proved,
not argued** — see the last section.

---

## 1. A rebase switched the artifact-provenance check off, and the base could move under it

`scripts/check-artifact-provenance.sh` treated an unreachable `meta.asmlift.commit` as UNKNOWN and
exited 0. That is precisely the state a branch reaches by regenerating the artifact and then
rebasing: the rebase rewrites the commit the stamp names. Reproduced in a scratch repo — on a
branch that regenerated and then rebased, the old script prints

```
provenance: artifact stamp 8c441cc is not an ancestor of HEAD — UNKNOWN, not checked
   exit=0
```

and `.github/workflows/ci.yml` runs the script as the whole job, so exit 0 is a green check. The
rebase is not optional; the round briefs ask for one before every PR.

The two cases are now separated by the artifact **blob**, the one thing a rebase cannot rewrite.
Byte-identical to a base's ⇒ the branch published no numbers of its own and the stamp is the base's
business (main squash-merges, so main's own stamp is always unreachable) ⇒ UNKNOWN, unchanged.
Different from every base's ⇒ this branch published numbers nothing can check ⇒ fail, and say to
regenerate after the final rebase.

**The second verdict is the half nothing mechanical looked at.** The within-branch check is blind
to the *base* moving under the artifact, and that is armed on a live branch right now:

| | |
|---|---|
| `origin/match/stack-addr` forks at | `70502e5` |
| its artifact is stamped | `15ad07a7` (own artifact, not main's) |
| main has since gained | `1e60974` (#83) — `frontend/ssa.ts +144`, `rank.ts +80` |

Once that branch rebases and does not regenerate, its artifact commit sits on top of #83 while
holding numbers measured without it, and a per-row diff against main credits #83's row flip to the
branch. So a branch publishing its own artifact must have generated it on a tree that already
contained the base. Only `packages/core/src`, `packages/toolchains/src` and
`apps/benchmark/dataset` fail here; a base change to the harness around them is *reported and not
failed*, because #82 showed one can be row-neutral.

Eight scenarios exercised in a scratch git repo — clean; within-branch drift (verdict unchanged);
base-advance; rebase-then-regenerate (passes); regenerate-then-rebase (was exit 0, now exit 1);
inherited artifact; harness-only base advance (note, exit 0); mixed (fails on the decompiler commit
only).

> **Heads-up for the live tracks.** Both `match/stack-addr` and `match/gameupdate` should expect
> this check to demand `rebase → gates → regenerate → push` in that order. Regenerating before the
> final rebase now fails instead of passing silently.

## 2. A filter that selects no row was a green tick, and it emptied the tier file

Measured in this worktree, before the fix:

```
$ pnpm bench run --tier real --only NoSuchFunctionXYZ
✓ real: 0 results in 1.3s → results/real.json
EXIT=0
$ ls -la apps/benchmark/results/real.json      # was 1872803 bytes, 240 rows
-rw-r--r--  1 macabeus  wheel  183 …            # now 0 rows
```

`stitch`'s existing guard only covers "no part file at all". A filter selecting nothing still has
every shard write its own empty part, so the write happens with `parts > 0`. That empty tier file
is the input to `bench merge`, which has no coverage guard of its own — it would publish a 594-row
`results.json` into both web copies without a word. `match-function.md` Phase 0 and Phase 3 and
`attribute-function.md` Phase 0 all instruct agents to run exactly this shape, and #81's fix for
the same class was a prompt rule asking for a manual `grep`.

After:

```
– real: 0 results in 0.7s — no row selected, results/real.json left unchanged
Error: no row matched --only NoSuchFunctionXYZ in tier(s) real — nothing was measured, and
results/*.json were left as they were. Check the symbol with `grep -rn "sym: '<name>'" apps/benchmark/dataset`.
```

The verdict is taken over the whole run, never per tier: `--toolchain` only selects in synthetic
and `--project` only in real, so `--only <a real symbol> --tier both` legitimately selects nothing
in synthetic. Verified end to end — `--only HuMemUsedMemorySizeGet --tier both` prints
`– synthetic: 0 results … left unchanged` / `✓ real: 1 results` and exits 0. `tierIsFiltered` is
exported and unit-tested; it is the whole rule.

## 3. One ranked repro, shared by both round commands

#82 gave `match-function.md` the `--jobs 6 --progress` paragraph. `attribute-function.md` still
said only "run the CLI … with `--config decomp.yaml --score-against <target.o>`". Attribution
rounds do run the heavy ranked LBG: scanning the 39 agent transcripts of the last seven workflows
for `Bash` calls naming `LoadBGTilemapData.s` with `--score-against` gives **17 launches by 13
agents**, from `/tmp/wt-attr2`, `/tmp/wt-attr3` and `/tmp/wt-attr4` among others — and **only 3
carry `--jobs`**. This is the second instance of the drift; PR #79 records the first, where
`--proto` lived only in the other file and a round published 557/578 against a 547 baseline.

So the invocation gets one home — `docs/ranked-repro.md` — and both prompts point at it by path and
say to correct it there. `match-function.md` **loses** the 16-line copy it was carrying (225 → 216
lines); the prompts do not grow.

Phase 4's probe in `attribute-function.md` is deliberately left alone, against the finding's
proposal: a ~20-line minimal shape enumerates few candidates and needs neither the pool nor a
`--proto`, so pointing it at the ranked command would be noise.

---

## Rejected, with the evidence

**A machine-wide `--jobs` budget (`scripts/jobs-budget.sh`).** The load numbers check out — 10
cores, and `uptime` sampled during this work showed 1/5/15-minute averages of 4.52 / 6.50 / 16.76.
But the proposal replaces a constant nobody has shown to be wrong with a value computed at launch
and stale seconds later, and its plausible failure mode is worse than the status quo: #82's own
pair shows `--jobs 6` still delivering 1.68× on the *loaded* machine, and a budget that clamps to 1
or 2 under a transient spike returns that run to the 36-minute serial figure. Nothing has measured
that fewer jobs under load is faster than six. Building a knob whose benefit I cannot measure is
exactly the thing the round rules forbid quoting.

**A prompt rule against blocking waits.** The measurement replicates: across the same 39
transcripts, 4581 Bash calls and 628.8 minutes of wall-clock, calls containing a `sleep N` or an
`until … do` loop account for **240.0 min over 166 calls (38.2%)**, the largest bucket. But 212 of
those 240 minutes are in 35 waits longer than two minutes, and reading them shows what they are
waiting on: a ~20-minute ranked run, a full bench, `test:matching`. Sleeping while your own job runs
costs the round nothing unless other work existed, and nothing in the transcripts establishes that
it did. A "do the next piece of work instead" clause is the kind of exhortation agents skim, and
the round rules are explicit that a prompt which grows without bound is itself a defect. Two
mechanical sub-observations are worth recording without a prompt change: one wait was blind
(`sleep 560` with no condition), and one used `until ! ps -p 8066` — the same family as the
`pgrep -f` self-match trap the harness memory already documents.

## Proposed, not implemented (out of scope here)

- **Stamp the measured *content*, not a commit sha.** Everything above works around the fact that
  `meta.asmlift.commit` is a sha, which a rebase invalidates and a squash makes unreachable. If
  `bench merge` also stamped the tree hash of each measured path (`git rev-parse HEAD:packages/core/src`,
  …), the check would be a content comparison: exact, rebase-proof, squash-proof, and it would
  delete most of the script including every UNKNOWN branch. It needs one optional field on
  `BenchMeta`, and `packages/bench-schema/**` is out of scope for this PR.
- **A coverage guard in `bench merge`.** Merge will happily publish a results.json with a whole
  tier missing. It has the previous `results.json` right there to compare row counts against.

## Neutrality proof

Full run on this branch: **834 rows (594 synthetic + 240 real), 0 SKIPs**, `EXIT=0`, 3m34s wall
(20:36:50 → 20:40:24 UTC; `uptime` at launch showed load 7.23, with another worktree's `tsx` probe
running). Then `pnpm bench:merge`, then a per-row comparison against
`git show origin/main:apps/benchmark/results/results.json` over
`asmlift.{outcome,score,candidateLabel,source}` and `m2c.{outcome,score,source}`:

```
base   origin/main: 834 rows, stamp 8f295590
branch HEAD      : 834 rows, stamp 1e609746

rows compared: 834
gated-field differences: 0
other differing fields (field: row count):

VERDICT: NEUTRAL
```

The "other differing fields" list is **empty**: not one field of one row object differs, so none of
the permitted exceptions (timings, `droppedCandidates` ordering) was even needed. The only
differences are in `meta` — `generatedAt`, `asmlift.commit` (the provenance stamp), and
`asmlift.dirty`, true because the proof was run from a working tree carrying these changes
uncommitted. The repo's own gate agrees:

```
$ pnpm bench diff --base origin/main
diff vs origin/main: 0 field change(s), 0 added, 0 removed (834 base rows, 834 fresh rows)
```

The regenerated artifacts are **not committed** — the numbers on main are still correct for the
code that produced them, and committing a 9.5 MB no-op diff would collide with the two live
branches that own those files.

Other gates: `pnpm typecheck` clean; `npx vitest run --maxWorkers=3` **1577 passed (129 files)**;
`npx eslint apps packages` 0 errors; `pnpm format`; `pnpm test:matching` **287 passed (33 files)**.

Branch is `meta/opt-iter2`, not `meta/opt-2`: that name is already PR #81's merged head and
pushing over it would have rewritten it.



---

## Reviewer's pass (agent 3)

Scope confirmed clean: the diff touches `.claude/commands/`, `docs/`, `scripts/`,
`apps/benchmark/src/{cli.ts,run/orchestrate.ts}` and `apps/benchmark/test/` — nothing under
`packages/core/**`, `apps/benchmark/dataset/**`, `packages/bench-schema/**` or
`cases/features.ts`, so neither live capability branch is touched.

Three of the four findings held on re-examination. Two more did not, and are fixed on the branch.

**Blocking, fixed — `packages/cli/src` was classified as "the harness around the decompiler".**
Verdict 3's `measures` list omitted it, so a base commit to the ranker or the scorer produced a
green tick. Reproduced in a scratch repo against the branch as pushed:

```
--- S5 base gained packages/cli/src (rank/score) under the stamp
   exit=0
   provenance: note — 1 base commit(s) after the stamp touch the harness around the
   decompiler, not the decompiler itself. Not a failure; …
```

That package is not the harness: `apps/benchmark/src/eval/asmlift.ts` imports `decompileRanked`
from `@asmlift/cli/rank` and `compile/real.ts` imports `scoreObjects` from `@asmlift/cli/score`,
so it picks the winning candidate and computes the score of every row — and #69, a round that
moved rows, changed `packages/cli/src/objdiff.ts`. Moved into `measures`; S5 now exits 1. The
remaining note tier is `apps/benchmark/src` alone, and its comment now gives the actual reason:
in this repo's whole history exactly two commits touched it without also touching a measured
path, and both came from a meta round whose own gate is a full run diffed per row against the
base.

**Blocking, fixed — the empty-filter guard was on one of the two run paths.**
`--serial` bypasses `orchestrate` entirely and writes `<tier>.json` directly. The literal shape
`attribute-function.md:127` instructs, with a typo'd symbol, measured on the branch as pushed:

```
$ pnpm bench run --tier synthetic --only NoSuchFunctionXYZ --toolchain agbcc --serial
Wrote 0 synthetic results → …/results/synthetic.json
$ echo $?
0
$ pnpm bench:merge
Merged 240 results (0 synthetic + 240 real) → results/results.json
Published → web/src/pages/benchmark/data/results.json + web/src/data/summary.json
```

594 rows gone and both web copies republished, silently. The verdict now lives in
`emptySelectionError`, shared by both paths; the serial loop takes it, and a shard CHILD is
exempt because it must always write its part file (a filter narrower than the shard count
legitimately empties most shards). After: exit 1, `synthetic.json` still 594 rows. Verified the
child is still exempt — `--serial --shard 3/8 --only hipress` writes a 0-row `synthetic.part3.json`
and exits 0.

**Fixed — the guard's own message could state something false.** `--project <typo>` with the
default `--tier both` leaves `real.json` alone but runs synthetic WHOLE and rewrites it, because
`--project` does not filter synthetic at all; "results/*.json were left as they were" was a claim
about a write that had happened. The message now names only the tier files actually left alone,
with a unit test on that.

**Fixed — the check read the stamp and the artifact identity from different bytes.** `own` came
from `HEAD:results.json` while `stamp` came from the file on disk, so an agent running the script
right after `bench run && bench merge` and before committing — which both prompts now tell it to
do — was told its artifact was the base's and skipped verdicts 2 and 3 on the numbers it was
about to publish. Now hashed from the same file. Measured both ways on one scratch scenario
(local regen, uncommitted, base gained a core commit): before `exit=0 … OK`, after `exit=1 …
predates 1 base commit(s) that change what it measures`.

**Fixed — a machine-local path in a published doc.** `docs/ranked-repro.md` was the only file in
`docs/` or `README.md` naming a `/tmp/…` path; it now states the requirement (export the
harness's toolchain overrides in a worktree) instead of one machine's file.

**No false alarms.** Eight scratch scenarios re-run against the fixed script: clean regen-last
(0), branch commit after the stamp (1), regenerate-then-rebase (1), base gained core (1), base
gained cli (1), inherited artifact with the base moved (0), base gained harness only (0 + note),
and the prescribed rebase→regenerate order (0). The bench guards: a filter that selects rows does
not fire, and `--only <a real symbol> --tier both` still prints
`– synthetic: 0 results … left unchanged` / `✓ real: 1 results` and exits 0.

**Independent neutrality proof**, run on the branch WITH these fixes, per row over
`asmlift.{outcome,score,candidateLabel,source}` and `m2c.{outcome,score,source}`:

```
base  origin/main: 834 rows, stamp 8f295590 dirty=false
fresh HEAD       : 834 rows, stamp b13a8054 dirty=true (fixes uncommitted at run time)

rows compared: 834
gated-field differences: 0   missing: 0   added: 0
other differing fields (field: row count):
VERDICT: NEUTRAL
```

Not one field of one row object differs; the only differences in the whole file are
`meta.generatedAt` and `meta.asmlift.commit`. `pnpm bench diff --base origin/main` agrees:
`0 field change(s), 0 added, 0 removed (834 base rows, 834 fresh rows)`. Both runs 834 rows
(594 synthetic + 240 real) with **0 SKIPs**. Regenerated artifacts deliberately NOT committed.

Gates re-run by the reviewer: `pnpm typecheck` clean, `npx eslint apps packages` 0 errors (61
pre-existing warnings, none in a touched file), `npx prettier --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
