### PR TITLE
Meta-optimisation, iteration 3: one queue for both tier fans, the ranked run's counts as a line, and a PR waiter

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -157,7 +157,7 @@ attribution line for every decline naming its first blocker. Constraints learned
   An attribution that has silently gone stale sends the next session down the wrong lever.
 - Report: baseline, the named gap classes with their verified causes, the row matrix, and what
   a future `/match-function` should build first. Push the branch and open the PR.
-- Then `scripts/pr-wait.sh <pr>` — it blocks on the real CI event and exits with the ANSWER (0 merged · 1 a check failed · 3 green and ready to merge). Never ask a human whether CI is green or whether the PR merged; that question was asked six times in one session and the script answers all six.
+- Then `scripts/pr-wait.sh <pr>` — it polls the PR's real state under a deadline and exits with the ANSWER (0 merged · 1 a check failed · 2 still pending, nothing decided · 3 green and ready to merge). Never ask a human whether CI is green or whether the PR merged; that question was asked six times in one session and the script answers all six.
 
 ---
 

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -157,6 +157,7 @@ attribution line for every decline naming its first blocker. Constraints learned
   An attribution that has silently gone stale sends the next session down the wrong lever.
 - Report: baseline, the named gap classes with their verified causes, the row matrix, and what
   a future `/match-function` should build first. Push the branch and open the PR.
+- Then `scripts/pr-wait.sh <pr>` — it blocks on the real CI event and exits with the ANSWER (0 merged · 1 a check failed · 3 green and ready to merge). Never ask a human whether CI is green or whether the PR merged; that question was asked six times in one session and the script answers all six.
 
 ---
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -193,7 +193,7 @@ this phase is the only pass they get.
   `asmlift-adversarial-validation.md`) with the round's outcome and any gate that turned out to be
   load-bearing.
 - Push the branch (this project's convention is commit + push on a finished goal).
-- Then `scripts/pr-wait.sh <pr>` — it blocks on the real CI event and exits with the ANSWER (0 merged · 1 a check failed · 3 green and ready to merge). Never ask a human whether CI is green or whether the PR merged; that question was asked six times in one session and the script answers all six.
+- Then `scripts/pr-wait.sh <pr>` — it polls the PR's real state under a deadline and exits with the ANSWER (0 merged · 1 a check failed · 2 still pending, nothing decided · 3 green and ready to merge). Never ask a human whether CI is green or whether the PR merged; that question was asked six times in one session and the script answers all six.
 
 ---
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -193,6 +193,7 @@ this phase is the only pass they get.
   `asmlift-adversarial-validation.md`) with the round's outcome and any gate that turned out to be
   load-bearing.
 - Push the branch (this project's convention is commit + push on a finished goal).
+- Then `scripts/pr-wait.sh <pr>` — it blocks on the real CI event and exits with the ANSWER (0 merged · 1 a check failed · 3 green and ready to merge). Never ask a human whether CI is green or whether the PR merged; that question was asked six times in one session and the script answers all six.
 
 ---
 

--- a/apps/benchmark/src/run/orchestrate.ts
+++ b/apps/benchmark/src/run/orchestrate.ts
@@ -134,14 +134,42 @@ function stitch(tier: Tier, n: number, filtered: boolean): number {
   return results.length;
 }
 
+/** Tiers are enqueued in this order (any tier not named keeps its `--tier` order, after these).
+ *  Measured over five full runs: the real tier's heaviest shard is 2-3x the synthetic tier's
+ *  (147/165/215/161/194s against 46/98/113/96/64s). With `tiers × jobs` tasks over `jobs` slots a
+ *  task queued late starts late, so the expensive tier is queued first — starting the longest
+ *  task last is exactly the tail the shared queue exists to remove. */
+const COST_ORDER: readonly Tier[] = ['real', 'synthetic'];
+
+/** Every tier's shard tasks, in the order the slots take them. Exported for the test: this
+ *  ordering is the whole scheduling decision, and it must stay a permutation of `tiers × jobs`. */
+export function shardQueue(opts: Pick<OrchestrateOptions, 'jobs' | 'tiers'>): { tier: Tier; shard: number }[] {
+  const rank = (t: Tier): number => (COST_ORDER.includes(t) ? COST_ORDER.indexOf(t) : COST_ORDER.length);
+  return opts.tiers
+    .map((tier, i) => ({ tier, i }))
+    .sort((a, b) => rank(a.tier) - rank(b.tier) || a.i - b.i)
+    .flatMap(({ tier }) => Array.from({ length: opts.jobs }, (_, shard) => ({ tier, shard })));
+}
+
 export async function orchestrate(opts: OrchestrateOptions): Promise<void> {
   mkdirSync(RESULTS_DIR, { recursive: true });
-  let failedShards = 0;
-  // Rows selected across every tier a filter could have selected in. Stays null on an unfiltered
-  // run, which is the only kind that reaches a branch — so this verdict cannot move a number.
-  let selected: number | null = null;
-  const untouched: Tier[] = [];
-  for (const tier of opts.tiers) {
+
+  // ONE queue across ALL tiers, drained by exactly `opts.jobs` slots. Fanning the tiers one after
+  // the other (a `Promise.all` per tier) made every run pay both tiers' TAILS: the real fan could
+  // not start until the last synthetic shard had exited, and the real fan then ended with one
+  // shard running alone for 46-59s (measured across five full runs) while seven slots idled — the
+  // synthetic work that could have filled them having already drained. Overlapping them is 15-27%
+  // off the run phase on those same five runs, and cannot be WORSE than the split fan: with
+  // `jobs` tasks per tier over `jobs` slots each slot runs one shard per tier, so the makespan is
+  // max_i(that slot's shards summed) ≤ the per-tier maxima summed, which is exactly what the
+  // split fan always paid.
+  //
+  // Concurrency is still capped at `opts.jobs`, so the Docker container pool and the machine see
+  // the load they always saw, and the same shard children run the same `idx % jobs` slices over
+  // the same rows in the same order — only scheduled to overlap. The canonical artifact cannot
+  // notice: merge.ts already sorts rows by id precisely because the shard count, and so the
+  // per-tier row order, differs by machine.
+  const extraFor = (tier: Tier): string[] => {
     const extra: string[] = [];
     if (opts.only) {
       extra.push('--only', opts.only);
@@ -152,20 +180,52 @@ export async function orchestrate(opts: OrchestrateOptions): Promise<void> {
     if (tier === 'real' && opts.project) {
       extra.push('--project', opts.project);
     }
-    const t0 = Date.now();
-    console.log(`\n▶ ${tier}: fanning across ${opts.jobs} shards…`);
-    const outcomes = await Promise.all(
-      Array.from({ length: opts.jobs }, (_, i) => runShard(tier, `${i}/${opts.jobs}`, extra)),
-    );
-    const failed = outcomes.filter((o) => o.code !== 0).length;
+    return extra;
+  };
+  const queue = shardQueue(opts);
+  const outcomes = new Map<Tier, ShardOutcome[]>(opts.tiers.map((t) => [t, []]));
+  // First child spawned → last child exited, per tier: with the tiers overlapping, a clock read
+  // once at the end of the run is no longer that tier's own elapsed time.
+  const span = new Map<Tier, { t0: number; t1: number }>();
+  const runStart = Date.now();
+  let next = 0;
+  // One slot: take the next shard task, run it to completion, repeat. `next++` needs no lock —
+  // the read and the increment are one synchronous step on the one event loop.
+  const slot = async (): Promise<void> => {
+    for (;;) {
+      const task = queue[next++];
+      if (!task) {
+        return;
+      }
+      if (!span.has(task.tier)) {
+        span.set(task.tier, { t0: Date.now(), t1: 0 });
+        console.log(`\n▶ ${task.tier}: fanning across ${opts.jobs} shards…`);
+      }
+      outcomes.get(task.tier)!.push(await runShard(task.tier, `${task.shard}/${opts.jobs}`, extraFor(task.tier)));
+      span.get(task.tier)!.t1 = Date.now();
+    }
+  };
+  await Promise.all(Array.from({ length: opts.jobs }, () => slot()));
+
+  let failedShards = 0;
+  // Rows selected across every tier a filter could have selected in. Stays null on an unfiltered
+  // run, which is the only kind that reaches a branch — so this verdict cannot move a number.
+  let selected: number | null = null;
+  const untouched: Tier[] = [];
+  // Stitched and reported in the CALLER's tier order, so the summary lines read as they always
+  // have however the queue interleaved the children.
+  for (const tier of opts.tiers) {
+    const mine = outcomes.get(tier)!;
+    const failed = mine.filter((o) => o.code !== 0).length;
     failedShards += failed;
-    const skips = outcomes.reduce((sum, o) => sum + o.skips, 0);
+    const skips = mine.reduce((sum, o) => sum + o.skips, 0);
     const filtered = tierIsFiltered(tier, opts);
     const n = stitch(tier, opts.jobs, filtered);
     if (filtered) {
       selected = (selected ?? 0) + n;
     }
-    const secs = ((Date.now() - t0) / 1000).toFixed(1);
+    const s = span.get(tier);
+    const secs = (((s?.t1 ?? 0) - (s?.t0 ?? 0)) / 1000).toFixed(1);
     // A skip total belongs on the tier line, not only in the scrollback: an absent toolchain
     // costs whole projects (marioparty3's 40 rows) and `bench regression` reads them as MISSING.
     const skipNote = skips ? ` — ⚠ ${skips} row(s) SKIPPED, toolchain unavailable` : '';
@@ -186,5 +246,5 @@ export async function orchestrate(opts: OrchestrateOptions): Promise<void> {
   if (selected === 0) {
     throw emptySelectionError(opts, untouched);
   }
-  console.log(`\nDone. Next: pnpm bench:merge`);
+  console.log(`\nDone in ${((Date.now() - runStart) / 1000).toFixed(1)}s. Next: pnpm bench:merge`);
 }

--- a/apps/benchmark/test/orchestrate-filter.test.ts
+++ b/apps/benchmark/test/orchestrate-filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { emptySelectionError, tierIsFiltered } from '../src/run/orchestrate';
+import { emptySelectionError, shardQueue, tierIsFiltered } from '../src/run/orchestrate';
 
 // A filter that selects no row used to print `✓ real: 0 results` and exit 0, having replaced a
 // good 240-row `real.json` with `results: []` — the file `bench merge` reads next. The verdict is
@@ -42,5 +42,45 @@ describe('emptySelectionError', () => {
     const m = emptySelectionError({ only: 'Nope', toolchain: 'agbcc' }, ['synthetic']).message;
     expect(m).toContain('--only Nope');
     expect(m).toContain('--toolchain agbcc');
+  });
+});
+
+// The two tier fans used to be two sequential `Promise.all`s, so every run paid both tiers'
+// tails: the real fan could not start until the last synthetic shard exited, and then ran its own
+// heaviest shard alone. One queue over `jobs` slots removes that — but only if the queue is still
+// exactly the same set of shard tasks, since a shard's slice (`idx % jobs`) is what decides which
+// rows it measures.
+describe('shardQueue', () => {
+  it('is a permutation of every tier × every shard — no row gained, none lost', () => {
+    const q = shardQueue({ jobs: 8, tiers: ['synthetic', 'real'] });
+    expect(q).toHaveLength(16);
+    expect(new Set(q.map((t) => `${t.tier}/${t.shard}`)).size).toBe(16);
+    for (const tier of ['synthetic', 'real'] as const) {
+      expect(
+        q
+          .filter((t) => t.tier === tier)
+          .map((t) => t.shard)
+          .sort((a, b) => a - b),
+      ).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    }
+  });
+
+  it('queues the expensive tier first whichever order --tier gave it', () => {
+    for (const tiers of [['synthetic', 'real'] as const, ['real', 'synthetic'] as const]) {
+      expect(shardQueue({ jobs: 2, tiers: [...tiers] })).toEqual([
+        { tier: 'real', shard: 0 },
+        { tier: 'real', shard: 1 },
+        { tier: 'synthetic', shard: 0 },
+        { tier: 'synthetic', shard: 1 },
+      ]);
+    }
+  });
+
+  it('leaves a single-tier run exactly as it was', () => {
+    expect(shardQueue({ jobs: 3, tiers: ['synthetic'] })).toEqual([
+      { tier: 'synthetic', shard: 0 },
+      { tier: 'synthetic', shard: 1 },
+      { tier: 'synthetic', shard: 2 },
+    ]);
   });
 });

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -34,8 +34,21 @@ workspace, so without them the sibling checkouts do not resolve and the run meas
   and both test suites, and a quieter pair measured **31m55s against 11m16s**. The ratio is the
   machine's, not the code's: re-time on your own log and quote that, never these. The
   `asmlift: [progress]` lines are what make a later claim about the run checkable from its log.
-- Quote the **candidate and dropped counts** beside every ranked score. A score from a run that
-  dropped candidates is not comparable to one that dropped none.
+- **`--proto`'s absence is now in the log.** Every run ends with an `asmlift: [proto]` line
+  naming the callees whose arity it had to guess (nothing declared them: no `--proto` entry, no
+  signature in `tools.asmlift.elf`). On the canonical LBG command that line is absent; without
+  `--proto` it reads `1 callee(s) have no declared arity … thunk_HeapFree`, in the same stderr you
+  are already pasting. Check the tail of your log before you quote a score.
+- Quote the counts by pasting the **`asmlift: [ranked]` line**, the last thing every ranked run
+  writes:
+
+  ```
+  asmlift: [ranked] 20608 candidate(s) scored, 0 dropped, best <label>: 531
+  ```
+
+  A score from a run that dropped candidates is not comparable to one that dropped none — and
+  "0 dropped" is now something the run SAYS. It used to be spelled as an absent line, so a clean
+  run, a truncated log and a killed run left identical evidence.
 
 ## Comparing two runs
 

--- a/packages/cli/src/callees.ts
+++ b/packages/cli/src/callees.ts
@@ -1,0 +1,71 @@
+// asmlift — which callees this run has NO declared arity for.
+//
+// A callee still written in assembly carries no signature anywhere, so the frontend falls back to
+// counting contiguous argument registers — and that guess is silent. `LoadBGTilemapData` scored
+// 578 without `--proto '{"thunk_HeapFree":{"params":1}}'` against a 547 baseline: a plausible
+// number, comparable to nothing, and indistinguishable in the log from a correct one. Over one
+// working session 24 of the 79 ranked runs of that function were launched without the flag.
+//
+// So the CLI says which names it had to guess for. Purely textual: the asm the run was given, the
+// `--proto` table it parsed, and the project ELF's callee signatures — no pipeline stage involved,
+// and nothing here can change what is emitted.
+import { type Prototypes, protoArity } from '@asmlift/core/proto';
+import { type SymbolMap, symbolsByName } from '@asmlift/core/symbols';
+
+/** A label DEFINED in this asm — `foo:` at the start of a line. */
+const LABEL_DEF = /^\s*([A-Za-z_.$][\w.$]*)\s*:/;
+/** The prefixes that sit in front of a mnemonic in the two dump formats this CLI also accepts:
+ *  a pret-style `/* addr bytes *​/` block comment, and objdump's `  8004b60:\tf7ff fffe \t`. */
+const PREFIX = /\/\*[\s\S]*?\*\//g;
+const OBJDUMP_PREFIX = /^\s*[0-9a-fA-F]+:\s+(?:[0-9a-fA-F]{2,8} )*\s*/;
+/** A call and its target. Every backend's call mnemonic, and both operand spellings: a bare
+ *  symbol (`bl foo`, hand-written and compiler `.s`) and objdump's `8004b50 <foo>`. */
+const CALL = /^\s*(?:bl|blx|jal|bctrl|bctrlx)\s+(?:[^<]*<([^>+]+)>|([A-Za-z_.$][\w.$]*))\s*(?:@|#|;|\/\/|$)/;
+
+/** The names this asm CALLS, in first-appearance order.
+ *
+ *  A `bl` whose target is a label defined in the same asm is NOT a call: agbcc emits `bl` as an
+ *  intra-function long branch (one klonoa function is 28 KB of it), and treating those targets as
+ *  callees would bury the real ones. The function's own name is dropped for the same reason —
+ *  a recursive call needs no external arity. */
+export function calleeNames(asm: string, self?: string): string[] {
+  const defined = new Set<string>();
+  for (const line of asm.split('\n')) {
+    const m = LABEL_DEF.exec(line);
+    if (m) {
+      defined.add(m[1]);
+    }
+  }
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const line of asm.split('\n')) {
+    const m = CALL.exec(line.replace(PREFIX, ' ').replace(OBJDUMP_PREFIX, ' '));
+    const target = m?.[1] ?? m?.[2];
+    if (!target || defined.has(target) || target === self || seen.has(target)) {
+      continue;
+    }
+    seen.add(target);
+    out.push(target);
+  }
+  return out;
+}
+
+/** Of those callees, the ones whose arity this run had to GUESS: no `--proto` entry with a
+ *  readable `params`, and no signature in the project's own DWARF either. `protoArity` is the
+ *  same reader the frontend uses, so a mistyped `params: "2"` counts as guessed here exactly as
+ *  it does there. */
+export function guessedArityCallees(asm: string, self: string, prototypes?: Prototypes, symbols?: SymbolMap): string[] {
+  const declared = symbols ? symbolsByName(symbols) : undefined;
+  return calleeNames(asm, self).filter(
+    (n) => protoArity(prototypes?.[n]) === undefined && declared?.get(n)?.signature === undefined,
+  );
+}
+
+/** The one stderr line, or '' when every callee's arity was declared. */
+export function guessedArityNote(asm: string, self: string, prototypes?: Prototypes, symbols?: SymbolMap): string {
+  const guessed = guessedArityCallees(asm, self, prototypes, symbols);
+  return guessed.length === 0
+    ? ''
+    : `asmlift: [proto] ${guessed.length} callee(s) have no declared arity, guessed from the argument registers: ` +
+        `${guessed.join(', ')} — pass --proto '{"${guessed[0]}":{"params":N}}' if a guess is wrong\n`;
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -71,7 +71,7 @@ const IDENT = /^[A-Za-z_$][A-Za-z0-9_$.]*$/;
 const USAGE = `usage: asmlift <file.s|file.asm|file.o|-> [--target <${Object.keys(TARGETS).join('|')}>]
                 [--name <symbol>] [--backend <c|pascal>] [--strict]
                 [--config <decomp.yaml>] [--score-against <target.o>]
-                [--asm-data <dump.txt>] [--proto <proto.json>]
+                [--asm-data <dump.txt>] [--proto <json|proto.json>]
                 [--jobs <n>] [--progress]
 
 Decompiles a function to source on stdout.
@@ -87,7 +87,8 @@ Gaps are annotated in-source as ASMLIFT_ERROR markers, diagnostics on stderr.
                    (implies --strict)
   --asm-data       for text input: objdump -s -r -t dump of the source object
                    (jump tables, anonymous constants)
-  --proto          callee prototypes JSON, e.g. {"sym":{"params":2|["u8","s32"]}}
+  --proto          callee prototypes, inline JSON or a path to it:
+                   {"sym":{"params":2|["u8","s32"]}}
   --jobs           with --score-against: compile n candidates at a time (default 1)
   --progress       with --score-against: stream a liveness line to stderr while
                    scoring; the [score] table it prints at the end is unchanged
@@ -261,14 +262,22 @@ export async function runCli(
   let prototypes: Prototypes | undefined;
   const protoFlag = flags.get('proto') as string | undefined;
   if (protoFlag !== undefined) {
+    // A table INLINE (`--proto '{"sym":{"params":1}}'`) or the path to one. Inline is the form
+    // docs/ranked-repro.md's canonical command uses, and the form the `[proto]` note below prints
+    // as its own remedy — but it used to be resolved as a path, so following either exited 66 on
+    // a missing file literally named `{"sym":{"params":1}}`. Three different scratch proto.json
+    // files got invented around that, carrying two different tables for the same "canonical" run.
+    const inline = protoFlag.trimStart().startsWith('{');
     let parsed: unknown;
     try {
-      parsed = JSON.parse(readFileSync(resolve(protoFlag), 'utf8'));
+      parsed = JSON.parse(inline ? protoFlag : readFileSync(resolve(protoFlag), 'utf8'));
     } catch (e) {
       return {
         code: 66,
         stdout: '',
-        stderr: `asmlift: cannot read --proto file: ${e instanceof Error ? e.message : e}\n`,
+        stderr: `asmlift: cannot ${inline ? 'parse --proto JSON' : 'read --proto file'}: ${
+          e instanceof Error ? e.message : e
+        }\n`,
       };
     }
     // Every entry, not just the envelope — an unreadable `params` decompiles at a guessed arity

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -30,6 +30,7 @@ import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { guessedArityNote } from './callees';
 import { type CommandCompilers, compilersFromCommand } from './compile-command';
 import { type AsmliftToolConfig, loadDecompConfig, resolveTarget } from './config';
 import { ObjectInputUnsupportedError, asmDataForObject, disasmObject, isElfObject } from './objfile';
@@ -315,6 +316,10 @@ export async function runCli(
     symbols = asIfUndecompiled(symbols, name);
   }
 
+  // Which callees' arity this run had to guess — computed AFTER `asIfUndecompiled`, so the
+  // target's own withheld signature cannot make the note claim a fact the run did not use.
+  const protoNote = guessedArityNote(asm, name, prototypes, symbols);
+
   // --score-against: compile the output (and every ranked candidate) with the project's own
   // compiler command (decomp.yaml tools.asmlift.compiler — REQUIRED) and objdiff-score
   // against the given object. Inherently strict: candidates come from the strict tower, so a
@@ -394,10 +399,18 @@ export async function runCli(
         ? `asmlift: [dropped] ${ranked.dropped.length} candidate(s) failed to score; first: ` +
           `${ranked.dropped[0].label}: ${ranked.dropped[0].error}\n`
         : '';
+      // The two counts docs/ranked-repro.md requires beside every ranked score, as ONE line that
+      // is always present. They used to be recoverable only as the line count of a 2 MB stderr
+      // stream, and "0 dropped" was asserted by the ABSENCE of the `[dropped]` line above — so a
+      // clean run, a truncated log and a killed run left identical evidence for the claim this
+      // loop's every published score rests on.
+      const summary =
+        `asmlift: [ranked] ${ranked.candidates.length} candidate(s) scored, ${ranked.dropped.length} dropped, ` +
+        `best ${ranked.best.label}: ${ranked.best.score.score}${ranked.best.score.match ? ' (match)' : ''}\n`;
       return {
         code: ranked.best.score.match ? 0 : 1,
         stdout: ranked.best.source,
-        stderr: targetTrace + warn + table + drops,
+        stderr: targetTrace + warn + table + drops + summary + protoNote,
       };
     } catch (e) {
       const kind = isDecline(e) ? 'declined' : 'internal error';
@@ -412,7 +425,8 @@ export async function runCli(
   const onGap: OnGap = flags.has('strict') ? 'strict' : 'annotate';
   try {
     const result = decompile(name, asm, target, { backend, onGap, asmData, prototypes, symbols });
-    const stderr = targetTrace + warn + result.diagnostics.map((d) => `asmlift: [${d.stage}] ${d.reason}\n`).join('');
+    const stderr =
+      targetTrace + warn + result.diagnostics.map((d) => `asmlift: [${d.stage}] ${d.reason}\n`).join('') + protoNote;
     return { code: result.diagnostics.length === 0 ? 0 : 1, stdout: result.source, stderr };
   } catch (e) {
     const kind = isDecline(e) ? 'declined' : 'internal error';

--- a/packages/cli/test/offline/callees.test.ts
+++ b/packages/cli/test/offline/callees.test.ts
@@ -1,0 +1,101 @@
+import type { SymbolMap } from '@asmlift/core/symbols';
+import { describe, expect, it } from 'vitest';
+
+import { calleeNames, guessedArityCallees, guessedArityNote } from '../../src/callees';
+
+// `LoadBGTilemapData` scored 578 without `--proto '{"thunk_HeapFree":{"params":1}}'` against a
+// 547 baseline, and 24 of one session's 79 ranked runs of it were launched without the flag. The
+// note exists so the guess is in the log instead of in a doc the runner has to remember.
+
+const LBG = `
+	thumb_func_start LoadBGTilemapData
+LoadBGTilemapData: @ 0804B4B0
+	push {r4, r5, r6, r7, lr}
+	bl DecompressAlloc
+	b _0804B604
+_0804B604:
+	bl thunk_HeapFree
+	bl _0804B604
+	pop {r0}
+`;
+
+describe('calleeNames', () => {
+  it('takes the bl targets and drops the ones that are labels in the same asm', () => {
+    // agbcc emits `bl` as an intra-function LONG BRANCH — one klonoa function is 28 KB of them,
+    // so a bl target is not evidence of a callee unless nothing here defines it.
+    expect(calleeNames(LBG, 'LoadBGTilemapData')).toEqual(['DecompressAlloc', 'thunk_HeapFree']);
+  });
+
+  it('drops the function itself, and reads objdump operands as well as bare symbols', () => {
+    const mips = `
+glabel func_80012340
+/* 0000 */  jal   func_80012340
+/* 0004 */  jal   osRecvMesg
+    `;
+    expect(calleeNames(mips, 'func_80012340')).toEqual(['osRecvMesg']);
+    expect(calleeNames('  bl 8004b60 <thunk_HeapFree>\n', 'Fn')).toEqual(['thunk_HeapFree']);
+    // `<name+0x12>` is an interior address, not a call to `name`
+    expect(calleeNames('  bl 8004b60 <thunk_HeapFree+0x12>\n', 'Fn')).toEqual([]);
+  });
+
+  it('ignores a register-indirect call and a mnemonic inside a comment', () => {
+    expect(calleeNames('  jalr $t9\n  @ bl NotACall\n  # jal NotACall\n', 'Fn')).toEqual([]);
+  });
+});
+
+describe('guessedArityCallees', () => {
+  it('is every callee when nothing declares one', () => {
+    expect(guessedArityCallees(LBG, 'LoadBGTilemapData')).toEqual(['DecompressAlloc', 'thunk_HeapFree']);
+  });
+
+  it('counts a --proto entry, in both the count and the typed-list form', () => {
+    expect(
+      guessedArityCallees(LBG, 'LoadBGTilemapData', {
+        thunk_HeapFree: { params: 1 },
+        DecompressAlloc: { params: ['void *', 'u32'] },
+      }),
+    ).toEqual([]);
+  });
+
+  it('does NOT count a params the frontend cannot read — the same reader decides both', () => {
+    // `params: "1"` decompiles at a GUESSED arity (protoArity returns undefined), so a note that
+    // called it declared would be the exact false reassurance this line exists to prevent.
+    expect(guessedArityCallees(LBG, 'LoadBGTilemapData', { thunk_HeapFree: { params: '1' } as never })).toEqual([
+      'DecompressAlloc',
+      'thunk_HeapFree',
+    ]);
+  });
+
+  it('counts a signature the project ELF declares', () => {
+    const symbols: SymbolMap = new Map([
+      [
+        0x08000100,
+        [
+          {
+            name: 'DecompressAlloc',
+            addr: 0x08000100,
+            kind: 'code' as const,
+            signature: { returns: null, params: [] },
+          },
+        ],
+      ],
+    ]);
+    expect(guessedArityCallees(LBG, 'LoadBGTilemapData', undefined, symbols)).toEqual(['thunk_HeapFree']);
+  });
+});
+
+describe('guessedArityNote', () => {
+  it('is empty when every arity is declared — a clean run says nothing', () => {
+    expect(
+      guessedArityNote(LBG, 'LoadBGTilemapData', { DecompressAlloc: { params: 2 }, thunk_HeapFree: { params: 1 } }),
+    ).toBe('');
+  });
+
+  it('names the callees and shows the flag that fixes it', () => {
+    const note = guessedArityNote(LBG, 'LoadBGTilemapData', { DecompressAlloc: { params: 2 } });
+    expect(note).toContain('asmlift: [proto] 1 callee(s)');
+    expect(note).toContain('thunk_HeapFree');
+    expect(note).toContain('--proto');
+    expect(note.endsWith('\n')).toBe(true);
+  });
+});

--- a/packages/cli/test/offline/cli.test.ts
+++ b/packages/cli/test/offline/cli.test.ts
@@ -126,6 +126,33 @@ test('--proto: unreadable file and non-object JSON stay distinguishable (66 vs 6
   expect(scalar.stderr).toContain('must be an object mapping a symbol name to its prototype');
 });
 
+// docs/ranked-repro.md's canonical command passes the table INLINE, and so does the `[proto]`
+// note's own printed remedy — but the flag used to resolve every value as a path, so following
+// either exited 66 on a missing file literally named `{"thunk_HeapFree":{"params":1}}`. Three
+// separate scratch proto.json files got invented around that, carrying two different tables for
+// what the doc calls one canonical run.
+test('--proto: an inline table is read as JSON, and means exactly what the file means', async () => {
+  const table = { callee: { params: 1 } };
+  const inline = await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', JSON.stringify(table));
+  expect(inline.code).toBe(0);
+  expect(inline.stderr).toBe('');
+  const viaFile = await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', protoFile(table));
+  expect(inline.stdout).toBe(viaFile.stdout);
+  // leading whitespace is still inline, not a path
+  expect((await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', ' {"callee":{"params":1}}')).code).toBe(0);
+});
+
+test('--proto: a malformed inline table says JSON, a missing path says file — both 66', async () => {
+  const bad = await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', '{"callee":');
+  expect(bad.code).toBe(66);
+  expect(bad.stderr).toContain('cannot parse --proto JSON');
+  const missing = await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', join(tmpdir(), 'nope-asmlift.json'));
+  expect(missing.code).toBe(66);
+  expect(missing.stderr).toContain('cannot read --proto file');
+  // an inline table that parses but is unusable is still the entry-level refusal, not 66
+  expect((await run('agbcc-clamp0.s', '--target', 'agbcc', '--proto', '{"callee":{"params":"1"}}')).code).toBe(64);
+});
+
 test('--jobs/--progress belong to the ranked path and are refused elsewhere, not ignored', async () => {
   for (const flag of [['--jobs', '4'], ['--progress']]) {
     const r = await run('agbcc-clamp0.s', '--target', 'agbcc', ...flag);

--- a/scripts/pr-wait.sh
+++ b/scripts/pr-wait.sh
@@ -8,7 +8,7 @@
 #
 #   scripts/pr-wait.sh 82                  # wait for checks, then report what is missing
 #   scripts/pr-wait.sh 82 --until-merged   # …and keep waiting until it is merged or closed
-#   scripts/pr-wait.sh 82 --timeout 900    # give up after 15 minutes (default 3600s)
+#   scripts/pr-wait.sh 82 --timeout 900    # give up after 15 min (default 3600s) — the WHOLE run
 #
 # Exit codes — each one is an ANSWER, so a caller never has to ask a human:
 #   0  merged
@@ -18,9 +18,11 @@
 #   4  closed without merging
 #   64 usage / no such PR
 #
-# Waits on EVENTS, never on a process pattern: `gh pr checks --watch` long-polls GitHub, and the
-# merge phase polls the PR itself. A `pgrep -f` wait whose pattern matches the waiting shell
-# deadlocks forever, and cost this project eight hours once.
+# Waits on the PR's REAL state, never on a process pattern: both phases ask GitHub what the PR is
+# doing. A `pgrep -f` wait whose pattern matches the waiting shell deadlocks forever, and cost this
+# project eight hours once. Every wait here is bounded by --timeout, for the same reason: a queued
+# workflow with no free runner is otherwise indistinguishable from a hang, and re-enters exactly
+# the deadlock this script replaces.
 set -eu
 
 usage() {
@@ -67,6 +69,16 @@ say() { echo "pr-wait #$PR: $*"; }
 # One JSON read of the PR's own state. Kept in one place so every phase reads the same fields.
 state() { gh pr view "$PR" --json state,mergeStateStatus --jq '.state + " " + .mergeStateStatus'; }
 
+# The same read, but a transient API error is NOT an answer. Under `set -e` a bare `S=$(state)`
+# exits the script with gh's own status — which is 1, this script's code for A CHECK FAILED — so a
+# single network blip sent the caller hunting a red build that does not exist. UNKNOWN matches
+# neither MERGED nor CLOSED, so the poll just keeps waiting and the deadline decides.
+state_or_unknown() { state 2>/dev/null || echo "UNKNOWN transient-api-error"; }
+
+# One deadline for the whole run, so no phase can outlive --timeout.
+DEADLINE=$(($(date +%s) + TIMEOUT))
+expired() { [ "$(date +%s)" -ge "$DEADLINE" ]; }
+
 if ! S=$(state 2>&1); then
   echo "pr-wait: cannot read PR #$PR: $S" >&2
   exit 64
@@ -85,17 +97,32 @@ case "$S" in
     ;;
 esac
 
-# Phase 1 — the checks. `--watch` blocks on GitHub's side; `--fail-fast` returns the moment one
-# check fails, so a red build is not waited out to the end.
+# Phase 1 — the checks, polled on our own clock rather than inside `gh … --watch`. `--watch` has
+# no timeout of its own (its --interval is just how often it re-asks), so a queued or stuck job
+# blocks it forever; this loop asks the same question at the same rate and can stop. gh's exit
+# codes ARE the three answers: 0 all complete and passing, 8 still pending, anything else a
+# failure.
 say "watching checks…"
 CHECKS=0
-gh pr checks "$PR" --watch --fail-fast --interval "$INTERVAL" || CHECKS=$?
-if [ "$CHECKS" -ne 0 ]; then
-  # 8 is gh's "checks pending" (nothing to watch yet, e.g. no workflow has been queued)
-  if [ "$CHECKS" -eq 8 ]; then
-    say "no check has reported yet — re-run once CI has started"
+PENDING=0
+while :; do
+  CHECKS=0
+  gh pr checks "$PR" >/dev/null 2>&1 || CHECKS=$?
+  [ "$CHECKS" -eq 8 ] || break
+  # 8 also covers "no workflow has reported yet", which is what a PR opened seconds ago looks
+  # like — the single most likely first call. Waiting it out is the answer the caller asked for.
+  if [ "$PENDING" -eq 0 ]; then
+    say "checks pending…"
+  fi
+  PENDING=$((PENDING + 1))
+  if expired; then
+    say "checks still pending after ${TIMEOUT}s — giving up, nothing decided"
     exit 2
   fi
+  sleep "$INTERVAL"
+done
+gh pr checks "$PR" || true # the table itself, for the caller's log
+if [ "$CHECKS" -ne 0 ]; then
   say "a check FAILED — fix it before asking anyone about merging"
   exit 1
 fi
@@ -104,14 +131,13 @@ say "checks are green"
 # Phase 2 — the merge. Without --until-merged, green checks is the answer: report the merge state
 # and stop, so the caller can act instead of blocking on a human to press a button.
 if [ "$UNTIL_MERGED" -eq 0 ]; then
-  say "$(state) — checks green, PR open: nothing is missing, it is ready to merge"
+  say "$(state_or_unknown) — checks green, PR open: nothing is missing, it is ready to merge"
   exit 3
 fi
 
-START=$(date +%s)
 LAST=""
 while :; do
-  S=$(state)
+  S=$(state_or_unknown)
   [ "$S" = "$LAST" ] || say "$S"
   LAST="$S"
   case "$S" in
@@ -124,8 +150,7 @@ while :; do
       exit 4
       ;;
   esac
-  NOW=$(date +%s)
-  if [ $((NOW - START)) -ge "$TIMEOUT" ]; then
+  if expired; then
     say "still $S after ${TIMEOUT}s — giving up, nothing decided"
     exit 2
   fi

--- a/scripts/pr-wait.sh
+++ b/scripts/pr-wait.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# Block until a pull request's CI has an answer, and say what the PR is waiting on.
+#
+# Over one 18-hour working session, 13 of the 29 human turns were "is it stuck / the CI is green /
+# the PR is already merged" — six of them about PR state the loop had no mechanical way to learn,
+# and one an explicit complaint about waiting on a PR that had already merged. The prompts end at
+# "push the branch and open the PR"; this is the line after that.
+#
+#   scripts/pr-wait.sh 82                  # wait for checks, then report what is missing
+#   scripts/pr-wait.sh 82 --until-merged   # …and keep waiting until it is merged or closed
+#   scripts/pr-wait.sh 82 --timeout 900    # give up after 15 minutes (default 3600s)
+#
+# Exit codes — each one is an ANSWER, so a caller never has to ask a human:
+#   0  merged
+#   1  a check failed (the failing checks are printed)
+#   2  timed out — still pending, nothing decided
+#   3  checks are green and the PR is still open: nothing is missing, it is ready to merge
+#   4  closed without merging
+#   64 usage / no such PR
+#
+# Waits on EVENTS, never on a process pattern: `gh pr checks --watch` long-polls GitHub, and the
+# merge phase polls the PR itself. A `pgrep -f` wait whose pattern matches the waiting shell
+# deadlocks forever, and cost this project eight hours once.
+set -eu
+
+usage() {
+  echo "usage: scripts/pr-wait.sh <pr-number> [--until-merged] [--timeout <seconds>] [--interval <seconds>]" >&2
+  exit 64
+}
+
+PR=""
+UNTIL_MERGED=0
+TIMEOUT=3600
+INTERVAL=15
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --until-merged) UNTIL_MERGED=1 ;;
+    --timeout)
+      shift
+      [ $# -gt 0 ] || usage
+      TIMEOUT="$1"
+      ;;
+    --interval)
+      shift
+      [ $# -gt 0 ] || usage
+      INTERVAL="$1"
+      ;;
+    -h | --help) usage ;;
+    -*) usage ;;
+    *)
+      [ -z "$PR" ] || usage
+      PR="$1"
+      ;;
+  esac
+  shift
+done
+case "$PR" in
+  '' | *[!0-9]*) usage ;;
+esac
+command -v gh >/dev/null 2>&1 || {
+  echo "pr-wait: gh is not installed — this needs the GitHub CLI" >&2
+  exit 64
+}
+
+say() { echo "pr-wait #$PR: $*"; }
+
+# One JSON read of the PR's own state. Kept in one place so every phase reads the same fields.
+state() { gh pr view "$PR" --json state,mergeStateStatus --jq '.state + " " + .mergeStateStatus'; }
+
+if ! S=$(state 2>&1); then
+  echo "pr-wait: cannot read PR #$PR: $S" >&2
+  exit 64
+fi
+say "$S"
+
+# Already decided before anything blocks — the exact case the human kept having to point out.
+case "$S" in
+  MERGED*)
+    say "already merged; nothing to wait for"
+    exit 0
+    ;;
+  CLOSED*)
+    say "closed without merging"
+    exit 4
+    ;;
+esac
+
+# Phase 1 — the checks. `--watch` blocks on GitHub's side; `--fail-fast` returns the moment one
+# check fails, so a red build is not waited out to the end.
+say "watching checks…"
+CHECKS=0
+gh pr checks "$PR" --watch --fail-fast --interval "$INTERVAL" || CHECKS=$?
+if [ "$CHECKS" -ne 0 ]; then
+  # 8 is gh's "checks pending" (nothing to watch yet, e.g. no workflow has been queued)
+  if [ "$CHECKS" -eq 8 ]; then
+    say "no check has reported yet — re-run once CI has started"
+    exit 2
+  fi
+  say "a check FAILED — fix it before asking anyone about merging"
+  exit 1
+fi
+say "checks are green"
+
+# Phase 2 — the merge. Without --until-merged, green checks is the answer: report the merge state
+# and stop, so the caller can act instead of blocking on a human to press a button.
+if [ "$UNTIL_MERGED" -eq 0 ]; then
+  say "$(state) — checks green, PR open: nothing is missing, it is ready to merge"
+  exit 3
+fi
+
+START=$(date +%s)
+LAST=""
+while :; do
+  S=$(state)
+  [ "$S" = "$LAST" ] || say "$S"
+  LAST="$S"
+  case "$S" in
+    MERGED*)
+      say "merged"
+      exit 0
+      ;;
+    CLOSED*)
+      say "closed without merging"
+      exit 4
+      ;;
+  esac
+  NOW=$(date +%s)
+  if [ $((NOW - START)) -ge "$TIMEOUT" ]; then
+    say "still $S after ${TIMEOUT}s — giving up, nothing decided"
+    exit 2
+  fi
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
Iteration 3 of the meta-optimisation loop. Four findings arrived; **three survived** and are in the
diff, one survived in half. Every number below came from a command in this session.

---

## Proof of output neutrality — the hard invariant

Full `pnpm bench run` on this branch (rebased onto `f60cb42`, which merged mid-session), then the
gate `#82` built for exactly this:

```
$ pnpm bench run          # 834 rows, 0 SKIPs
✓ synthetic: 594 results in 151.4s → results/synthetic.json
✓ real: 240 results in 202.2s → results/real.json
Done in 202.5s.

$ pnpm bench merge && pnpm bench diff --base origin/main
diff vs origin/main: 0 field change(s), 0 added, 0 removed (834 base rows, 834 fresh rows)
```

`bench diff` compares exactly the mandated six fields — `asmlift.{outcome,score,candidateLabel,
source}` and `m2c.{outcome,score,source}` — for every row. I then went further and compared **every
key of every row**, not just the six:

```
row fields that differ at all (any field, not just the six):
  (none)
```

**Nothing differed except `meta`**: `asmlift.commit` `8ecdecd4…` → `8e3054ee…` and `generatedAt`
`2026-08-22T21:42:27Z` → `2026-08-22T22:20:57Z`. Not timings, not `droppedCandidates` ordering —
those were identical too. The regenerated artifacts are **not** committed, so this PR is source-only.

`bench fidelity` spot-checked on the two shapes whose verdict reads CLI stderr — a `declined` row
(`af:add_calc_a:ido7.1`) and a `noncompile` row (`kleod:SetupBG3WindowOverlay:agbcc`). Both report
`1 ok, 1 warn, 0 fail`; I then disabled this PR's CLI change in place and re-ran both, getting
**byte-identical warnings**, so the two warns are pre-existing on `origin/main` and not caused here.

`pnpm typecheck` clean · `npx vitest run` 1606 passed / 130 files · `npx eslint apps packages`
0 errors (61 pre-existing warnings, none in the changed files) · `pnpm format` run.

---

## 1. The two tier fans were serialized — one queue instead (`apps/benchmark/src/run/orchestrate.ts`)

`orchestrate()` ran a `Promise.all` **per tier**, so the real fan could not start until the last
synthetic shard had exited, and the real fan then ended with a single shard running alone while
seven slots idled.

Counted from the per-row seconds the runner already prints, per shard, over five independent full
runs on five trees under five different loads:

| log | synth shards (s), max | real shards (s), max | solo tail |
|---|---|---|---|
| full-run | 46 | 147 | 48 s |
| attr2 | 98 | 165 | 47 s |
| attr3 | 113 | 215 | 46 s |
| attr4 | 96 | 161 | 46 s |
| gu-bench | 64 | 194 | 59 s |

The real tier's heaviest shard is 2–3× the synthetic tier's, so it is the tier that must start
first. Replaced with **one queue of `tiers × jobs` shard tasks drained by exactly `jobs` slots**,
expensive tier queued first. Simulated on those same five runs: 205→156, 273→198, 341→246, 268→191,
278→210 s — **15–27%, 26.7% overall**.

Measured on this PR's own neutrality run, from work rather than a before/after wall-clock pair: the
split fan must pay at least `max(synth shard) + max(real shard)` = 86.6 + 199.5 = **286.1 s** of
shard-busy time; the merged queue's measured wall was **202.5 s** — **83.6 s, 29.2%**. (The two
tier lines still print 151.4 s and 202.2 s, summing to 353.6 s, because they now overlap.)

Why it cannot regress: with `jobs` tasks per tier over `jobs` slots, each slot runs one shard per
tier, so the makespan is `max_i(that slot's shards summed) ≤ (the per-tier maxima summed)` — which
is exactly what the split fan always paid. Concurrency is still capped at `opts.jobs`, so the Docker
pool and the box see the load they always saw, and every shard runs the same `idx % jobs` slice over
the same rows. `merge.ts:47` already sorts rows by id precisely so the shard count cannot reach the
artifact — and the 0-field diff above confirms it.

`shardQueue` is exported and tested: it must stay a permutation of `tiers × jobs`, must put the
expensive tier first whichever order `--tier` gave it, and must leave a single-tier run untouched.

### Corrections to the finding as filed
- The finding's solo tails (**87–103 s**) are not reproducible. Its per-shard sums undercount: for
  `full-run.log` it reports real shards `[33,13,145,57,32,17,15,20]` summing to 332 row-seconds
  where the log's 240 real rows sum to **490**. The real tails are **46–59 s**.
- **"1.8–2.3× its own parallel floor" is not a claim about this defect.** That floor
  (`max(heaviest row, total/8)`) requires splitting a single row across slots, which no scheduler
  can do. The honest recoverable figure is 15–27%, and the heaviest row
  (`kleod:UpdateCameraScroll:agbcc`, 115–162 s) is a floor no change in this PR crosses.
- **The proposed second half is rejected, measured.** "Persist row times and order `casesFor` cost-
  descending" is not LPT — `idx % 8` over a sorted list is a fixed stride that clumps the heavy rows.
  Simulated on the same five logs it is **worse in four of five**: 147→146, 166→186, 215→233,
  161→179, 194→201 s. Not built.
- `pnpm bench run` invocation count: I count **114** unfiltered starts in the main transcript, not
  138 (139 more carried a `--tier/--only/--project/--toolchain` filter). Still the loop's most-run
  command by a wide margin.

## 2. The ranked run now states its own counts (`packages/cli/src/main.ts`)

`docs/ranked-repro.md` requires: *"Quote the candidate and dropped counts beside every ranked
score."* The CLI emitted neither as a fact. The candidate count existed only as the line count of a
2 MB stderr stream, and **the good case — zero dropped — was spelled as an absent line**, so a clean
run, a truncated log and a killed run left identical evidence for the claim every published ranked
number in this loop rests on. Verified in `main.ts` on `origin/main`: `drops` is `''` when
`ranked.dropped.length === 0`.

One additive line, last thing every ranked run writes. Real run,
`kleod:StreamCmd_ToggleLayerFlag:agbcc`:

```
asmlift: [ranked] 14 candidate(s) scored, 0 dropped, best unsigned: 12
```

`grep -cF '[score]'` on the same log is `14` — the counts agree. The per-candidate `[score]` table
and the `[dropped]` detail line are untouched, so `diff <(grep -F '[score]' a.err) …` still works.
`docs/ranked-repro.md` updated so "quote the counts" means "paste this line".

## 3. A guessed callee arity is now in the log (`packages/cli/src/callees.ts`, new)

Confirmed the finding's count exactly against the main transcript: **177 `--score-against`
invocations, 79 naming `LoadBGTilemapData`, 24 of those 79 with no `--proto` in any form** (95 of
all 177). I also checked the escape hatch — `decomp.yaml` carries no prototypes for the bench
klonoa checkout, and `AsmliftToolConfig` has no `prototypes` field at all, so `--proto` is the only
channel and all 24 really did guess. This is ledger trap #5 and it caused PR #79 (a round published
`557/578` against a `547` baseline).

`calleeNames` takes the call targets out of the input asm and drops the ones that are labels defined
in the same file — agbcc emits `bl` as an intra-function long branch, so a `bl` target is not
evidence of a callee. `guessedArityCallees` then keeps only those that nothing declares: no
`--proto` entry the frontend can actually read (it calls `protoArity`, so a mistyped `params: "2"`
counts as guessed exactly as it does in the pipeline) and no `signature` in `tools.asmlift.elf`.

On the real LBG input, with the project ELF loaded:

```
$ npx tsx packages/cli/src/main.ts asm/nonmatchings/gfx/LoadBGTilemapData.s --config decomp.yaml
asmlift: [proto] 1 callee(s) have no declared arity, guessed from the argument registers:
  thunk_HeapFree — pass --proto '{"thunk_HeapFree":{"params":N}}' if a guess is wrong
```

It names `thunk_HeapFree` and **not** `DecompressAlloc`, whose signature the project ELF carries —
and with `--proto` supplied it is silent. Purely textual, purely in the CLI; the benchmark imports
`decompileRanked` directly and never goes through `main.ts`.

## 4. `scripts/pr-wait.sh` — half of the finding

Verified: **29 human turns** from the workflow's start to its last event, of which **13 are liveness
or PR-state pokes** (45%), six about PR/CI state — including *"The PR is already merged. You should
pay more attention to not be blocked by waiting unnecessarily again"* and *"What's missing for
`meta-optimizer-loop-v2` to merge it?"* asked twice. `scripts/` had no waiter of any kind.

`scripts/pr-wait.sh <n>` blocks on `gh pr checks --watch` — a real event, never a `pgrep -f` pattern
that can match the waiting shell (ledger trap #4, which cost eight hours once) — and exits with the
**answer**: `0` merged · `1` a check failed · `2` timed out · `3` green and open, nothing missing ·
`4` closed unmerged · `64` usage. An already-merged PR short-circuits before anything blocks, which
is the exact case the human kept having to point out.

Verified live against the two real states:

```
$ ./scripts/pr-wait.sh 84
pr-wait #84: MERGED UNKNOWN
pr-wait #84: already merged; nothing to wait for      → exit 0

$ ./scripts/pr-wait.sh 85 --timeout 60
pr-wait #85: OPEN UNSTABLE
pr-wait #85: watching checks…                          (blocked ~75s on real CI)
pr-wait #85: checks are green
pr-wait #85: OPEN CLEAN — checks green, PR open: nothing is missing, it is ready to merge  → exit 3
```

**`docs/waiting.md` was NOT written.** A second doc restating two rules is churn an agent skims
past; the script's own header carries them, and one line at the tail of each round prompt points at
it. Prompt growth this iteration: **two lines total**.

---

## Proposals — out of scope here, not implemented

- **`kleod:UpdateCameraScroll:agbcc` is the real floor.** 115/120/162/116/157 s across five runs —
  20–33% of ALL real-tier row-seconds in one row, and `outcome: noncompile` with 0 dropped
  candidates. No scheduler crosses it. `packages/cli/src/rank.ts:97` records a deliberate decision
  that the benchmark keeps the serial `decompileRanked` ("a published measurement must not depend on
  a scheduler"), so going below ~157 s means either revisiting that for the straggler or
  understanding why one noncompile row costs two minutes. Worth one attribution round.
- **`onLeverError` is still wired nowhere** in the CLI or the benchmark (known-open in the ledger); a
  lever that always throws is invisible in both.
- **The machine-wide job budget** remains unaddressed: every track passes a flat `--jobs` on a
  10-core box running 4–6 workflows. This PR does not make it worse — concurrency stays capped at
  `opts.jobs` — but it does not help either.
- **A `[proto]`-equivalent for the benchmark.** The harness bypasses `main.ts`, so a bench row whose
  callee arity is guessed still says nothing. That needs a core or `apps/benchmark/src/eval` seam.

---

## Review (agent 3), iteration 1 — audited, three fixes applied, merged

**Scope**: the diff touches nothing owned by a live track — no `packages/core/**`, no
`apps/benchmark/dataset/**`, no `bench-schema`, no `cases/features.ts`. Confirmed by
`git diff --name-status origin/main..HEAD`.

**Output neutrality, re-proven independently — twice.** Two full `pnpm bench run --jobs 8` +
`bench merge` on this branch (once at `8e3054e`, once at the final tree), each diffed per row
against `origin/main`'s committed `results.json`. **834 rows both sides, 0 differences** in
`asmlift.{outcome,score,candidateLabel,source}` and `m2c.{outcome,score,source}`. The check was
widened past the brief to compare **every** field of every row and of `meta`: across the whole
9.5 MB artifact exactly two values differ — `meta.generatedAt` and `meta.asmlift.commit`. Not even
`droppedCandidates` ordering moved. 0 rows SKIPPED. The two published copies
(`apps/web/src/pages/benchmark/data/results.json`, `apps/web/src/data/summary.json`) were
field-diffed too: same two stamps, nothing else. No artifact is committed here.

**F1 (one queue) — sound, and replicated.** Re-derived from my own run's work counts rather than a
wall-clock pair: the split fan must pay at least `max(real shard) + max(synth shard)` =
189.0 + 65.7 = **254.7 s**; the merged queue's measured wall was **192.0 s** — **62.7 s, 24.6 %**.
(The PR's own run measured 83.6 s / 29.2 %; both are the same method, on differently loaded runs.)
The no-regression argument holds: with `jobs` tasks per tier over `jobs` slots each slot takes
exactly one shard per tier, so the makespan is bounded by the per-tier maxima summed. Concurrency
stays capped at `opts.jobs`; the Docker pool is keyed by `(image, toolchain dir)` so interleaving
the tiers creates no new container and no new mount; cache writes are already tmp-then-rename with
the pid in the name. `tiers` is only ever `['synthetic','real']` or a single tier, so `shardQueue`
cannot see a duplicate. Nothing in the repo parses the run log's lines.

**F2 (`[ranked]`) — sound, verified on a real ranked run.** `asmlift: [ranked] 2 candidate(s)
scored, 0 dropped, best signed: 1`, and `grep -cF '[score]'` on the same stderr is 2.

**F3 (`[proto]`) — sound, verified both directions on the real LBG input**, and it exposed a
defect *behind* it, now fixed (below).

**F4 (`pr-wait.sh`) — sound in shape, three defects found by running it. All fixed here.**

### Fixes applied by the review

1. **`--timeout` bounded nothing that could actually hang.** It governed only the `--until-merged`
   poll; `gh pr checks --watch` has no timeout of its own. Measured against a watch that never
   returns, `--timeout 3` blocked the full **60 s**. A queued workflow with no free runner is
   indistinguishable from a hang, so the script whose purpose is "never block forever" could block
   forever. Phase 1 now polls on its own clock (`--watch`'s `--interval` is just how often it
   re-asks, so this is the same question at the same rate), under one deadline for the whole run.
   Note `--fail-fast` outside watch mode exits **1 even when every check passes** — keeping it in
   the non-watch call would have reported "a check FAILED" on every green PR.
2. **A transient `gh` error was reported as a red build.** Under `set -eu` a failed `gh pr view` in
   the merge poll exited with gh's own status — **1**, this script's code for A CHECK FAILED.
   Reproduced with a stubbed `gh`; now reads `UNKNOWN` and lets the deadline decide (exit 2).
3. **`--proto` accepted a path only**, while `docs/ranked-repro.md`'s canonical command *and the
   `[proto]` note's own printed remedy* both pass the table inline — so following either exited
   **66** on a missing file literally named `{"thunk_HeapFree":{"params":1}}`. Three separate
   scratch `proto.json` files exist on this box from agents working around it, and they carry
   **two different tables** for what the doc calls one canonical run — the exact drift
   `docs/ranked-repro.md` was written to end. Inline JSON is now read as JSON; a path still works
   and produces byte-identical output; 66-vs-64 stays distinguishable. Verified end to end: the
   note prints a remedy, the remedy runs, the note goes silent.

The round-prompt line now also names exit 2, which the wait can newly reach.

### Gates re-run by the review

`typecheck` ✓ · `eslint apps packages` 0 errors ✓ · `format:check` ✓ · `test:offline` 1311 passed
(2 added here) ✓ · `vitest run apps/benchmark/test` 220 passed ✓. The empty-selection guard was
exercised through the merged queue in both directions: `--only ThisRowDoesNotExist` still fails
loud and leaves both canonical files untouched, `--only DivideQ4` still passes and reports the
other tier as left unchanged. `pr-wait.sh` was re-tested on four stubbed scenarios (never-reporting
checks, transient API error, CI-not-started-then-green, red check) and live on a merged PR (0) and
a green open PR (3).

### One measurement for the next round

The straggler is now essentially the whole critical path. In my run
`kleod:UpdateCameraScroll:agbcc` cost **155.4 s** — 22.6 % of all 689.1 s of real-tier row-seconds —
and its shard was the last to finish. Wall was 192.0 s, i.e. only **36.6 s above that single row**.
Rows are atomic, so no scheduler can go below it: further scheduling work on this harness is capped
at ~19 % and then hits a hard wall at one row. The proposed attribution round on that row is the
only remaining lever, and it is worth more than it looked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

