### PR TITLE
Meta-optimisation, iteration 2: a neutrality proof that must have run, a lint gate that can go green, and a waiter that stops inventing red builds

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -137,7 +137,7 @@ attribution line for every decline naming its first blocker. Constraints learned
    already committed its own artifact compares it against itself, which is vacuous the other way.
 2. Expect the two tag-vocabulary tests to fail BETWEEN adding the tag and merging the artifacts;
    they must pass after. `npx vitest run`, `pnpm test:matching`, `pnpm typecheck`,
-   `npx eslint apps packages` (not `pnpm lint`), `pnpm format` check.
+   `pnpm lint`, `pnpm format` check.
 3. Artifacts (`apps/benchmark/results/results.json`, both web copies) regenerated at the source
    commit's HEAD (`meta.asmlift.dirty` must be false) and committed separately — **after** your
    final rebase, as the last commit. A rebase rewrites the commit the artifact's stamp names, and
@@ -145,7 +145,9 @@ attribution line for every decline naming its first blocker. Constraints learned
    `scripts/check-artifact-provenance.sh` fails both; run it before opening the PR.
 4. Zero-flip over the previously committed rows blocks the branch, same as `/match-function`.
    `pnpm bench diff --base origin/main` is that check by row and field, and its output is the
-   report's list of what moved.
+   report's list of what moved. It exits **2**, "nothing was compared", if `results.json` still
+   carries the base's `generatedAt` — the artifact is committed, so a gate run before `run`+`merge`
+   compares the base with itself and prints a green line in a second.
 
 ## Phase 8 — Write it down and report
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -90,7 +90,9 @@ Before declaring the branch done: `pnpm bench run` (all tiers), `pnpm bench:merg
 `pnpm bench regression --base origin/main` and `pnpm bench diff --base origin/main`. **Any lost
 match blocks the branch.** Pass the base ref: both gates read the COMMITTED artifact, so on a
 branch that has already committed its own they compare it against itself and pass vacuously.
-`regression` answers "did a match break"; `diff` names every row and field that moved
+Keep the order too: `diff` exits **2**, "nothing was compared", if `results.json` still carries the
+base's `generatedAt` — run before `run`+`merge` it compares the base with itself in a second and
+prints a green line. `regression` answers "did a match break"; `diff` names every row and field that moved
 (`asmlift.{outcome,score,candidateLabel,source}`, `m2c.{outcome,score,source}`) — that list is the
 PR body's inventory of what the round did, and for a commit claiming to move nothing it is the
 gate. If a match is lost, either tighten the gate on your lever or drop the lever — do not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
       # The benchmark harness's own toolchain-free tests (normalizer/heuristic/policy pins):
       # no Docker, no compilers — everything heavy is lazily invoked, never at import.
       - run: pnpm exec vitest run apps/benchmark/test
+      # scripts/pr-wait.sh's exit contract, replayed against a stubbed gh: no network, ~1s. The
+      # loop reads those codes instead of asking a human whether CI is green, so a code that
+      # quietly changes meaning is worse than no script at all.
+      - run: sh scripts/pr-wait-selftest.sh
 
   # Is the committed benchmark artifact older than the code it measures? Git-only and sub-second,
   # so it needs neither pnpm nor a toolchain — but it does need real history, hence its own

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       # The benchmark harness's own toolchain-free tests (normalizer/heuristic/policy pins):
       # no Docker, no compilers — everything heavy is lazily invoked, never at import.
       - run: pnpm exec vitest run apps/benchmark/test
-      # scripts/pr-wait.sh's exit contract, replayed against a stubbed gh: no network, ~1s. The
+      # scripts/pr-wait.sh's exit contract, replayed against a stubbed gh: no network, ~8s. The
       # loop reads those codes instead of asking a human whether CI is green, so a code that
       # quietly changes meaning is worse than no script at all.
       - run: sh scripts/pr-wait-selftest.sh

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -114,6 +114,9 @@ pnpm bench:smoke                      # one trivial fn through every available t
 pnpm bench verify apps/benchmark/dataset/real/<p>.json   # compile-check loop for manifests
 pnpm bench regression --base origin/main   # gate: exit 1 on any lost match or vanished row
 pnpm bench diff --base origin/main         # gate: exit 1 if ANY compared field moved, row by row
+                                           #   exit 2 if results.json was never regenerated: it is
+                                           #   committed, so an unrun gate compares the base with
+                                           #   ITSELF and prints a green line having measured nothing
 cd apps/web && pnpm run build         # the site (the Benchmark view renders results.json)
 ```
 

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -17,6 +17,7 @@
 //   pnpm bench stale-check [--base ref]  # committed vs fresh results (measurement-level)
 //   pnpm bench regression [--base ref]   # committed vs fresh MATCH gate: exit 1 on any lost match
 //   pnpm bench diff [--base ref]         # committed vs fresh per-ROW, per-FIELD: exit 1 on any move
+//                                        #   exit 2 = nothing compared (no run behind it)
 //   pnpm bench smoke                     # one trivial fn through every available toolchain
 //   pnpm bench verify <manifest.json>    # compile-check loop for authoring real manifests
 //   pnpm bench vendor [--project p]      # freeze the real tier's preprocessed TUs (needs checkouts)

--- a/apps/benchmark/src/report/committed.ts
+++ b/apps/benchmark/src/report/committed.ts
@@ -10,6 +10,36 @@ import { REPO_ROOT } from '../config';
 
 export const RESULTS_PATH = 'apps/benchmark/results/results.json';
 
+/** `git …` in the repo, or `undefined` when git declines to answer. Used only for the provenance
+ *  LINE a gate prints about itself, so a question git cannot answer must degrade to "not shown",
+ *  never to a thrown gate. */
+function git(...args: string[]): string | undefined {
+  try {
+    return execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/** The sha `ref` names in THIS checkout, abbreviated. A gate that reports its base by NAME has
+ *  reported nothing checkable: `origin/main` is a different commit on every machine and after
+ *  every fetch. */
+export const shortSha = (ref: string): string | undefined => git('rev-parse', '--short', `${ref}^{commit}`);
+
+/** Does HEAD contain `ref`? `undefined` when git cannot say. A branch compared against a base it
+ *  has not merged in is credited with everything the base gained meanwhile. */
+export function headContains(ref: string): boolean | undefined {
+  if (git('rev-parse', '--verify', `${ref}^{commit}`) === undefined) {
+    return undefined;
+  }
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', ref, 'HEAD'], { cwd: REPO_ROOT, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** The artifact as of `ref` (a commit, tag or branch — `HEAD` by default). */
 export function readCommitted(ref = 'HEAD'): BenchOutput {
   let raw: string;

--- a/apps/benchmark/src/report/diff.ts
+++ b/apps/benchmark/src/report/diff.ts
@@ -14,7 +14,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { RESULTS_DIR } from '../config';
-import { byId, readCommitted, scrub } from './committed';
+import { RESULTS_PATH, byId, headContains, readCommitted, scrub, shortSha } from './committed';
 
 /** The fields a published claim is made of. `source` is in the list because a change that moves
  *  no score can still rewrite what the report shows, and `candidateLabel` because the ranked
@@ -87,13 +87,58 @@ export function compareMeasurements(base: BenchOutput, fresh: BenchOutput): Diff
   };
 }
 
+/** Is the artifact on disk still the base's own committed file, with no run behind it?
+ *
+ *  This gate reads whatever bytes happen to sit at `apps/benchmark/results/results.json` — and
+ *  that file is COMMITTED, so on a source-only branch with a clean tree it already IS the base's.
+ *  Running the gate then compares the base against ITSELF and prints `0 field change(s)` in about
+ *  a second, which is indistinguishable from the ~200s run it is supposed to summarise. That green
+ *  line is what a PR body publishes as its neutrality proof, so the cheapest way to produce it
+ *  must not be the one that measures nothing. (`committed.ts` guards the same vacuity on the BASE
+ *  side — `HEAD` comparing a branch against itself; this is the FRESH side of it.)
+ *
+ *  `meta.generatedAt` decides, because `bench merge` re-mints it from `new Date()` on every run
+ *  (`run/runner.ts` benchMeta). Equal stamps therefore mean no merge has run since the base's
+ *  artifact was committed — there are no false positives, and it also catches an artifact edited
+ *  by hand rather than measured. */
+export const notRegenerated = (base: BenchOutput, fresh: BenchOutput): boolean =>
+  base.meta.generatedAt === fresh.meta.generatedAt;
+
 /** CLI entry: the artifact at `base` vs the freshly merged one. Returns the process exit code —
- *  0 iff not one compared field moved and the row set is identical. */
+ *  0 iff not one compared field moved and the row set is identical, 2 if nothing was compared. */
 export function diffGate(base = 'HEAD'): number {
-  const report = compareMeasurements(
-    readCommitted(base),
-    JSON.parse(readFileSync(join(RESULTS_DIR, 'results.json'), 'utf8')) as BenchOutput,
+  const committed = readCommitted(base);
+  const fresh = JSON.parse(readFileSync(join(RESULTS_DIR, 'results.json'), 'utf8')) as BenchOutput;
+
+  // What was compared, before the verdict — a reader of a PR body can otherwise only take the
+  // tick on trust. The base by SHA (a branch name is a different commit on every machine), and
+  // the fresh artifact by the run that produced it.
+  const sha = shortSha(base);
+  const stamp = fresh.meta.asmlift;
+  console.log(
+    `diff: base ${base}${sha ? ` = ${sha}` : ''} (artifact generated ${committed.meta.generatedAt}) · ` +
+      `fresh ${RESULTS_PATH} generated ${fresh.meta.generatedAt}` +
+      (stamp ? ` at ${stamp.commit.slice(0, 7)}${stamp.dirty ? ' (dirty tree)' : ''}` : ''),
   );
+
+  if (notRegenerated(committed, fresh)) {
+    console.log(
+      `NOT REGENERATED — ${RESULTS_PATH} carries the same meta.generatedAt as ${base}'s, so it is still\n` +
+        `that committed file and no run stands behind this comparison. Run the benchmark first:\n` +
+        `  pnpm bench run && pnpm bench merge && pnpm bench diff --base ${base}\n` +
+        `Nothing was compared; this proves nothing.`,
+    );
+    return 2;
+  }
+
+  if (headContains(base) === false) {
+    console.log(
+      `WARNING: HEAD does not contain ${base} — everything ${base} gained meanwhile is being read as\n` +
+        `a change this branch made (or hidden by one). Rebase, re-run, then diff again.`,
+    );
+  }
+
+  const report = compareMeasurements(committed, fresh);
 
   for (const c of report.changed) {
     console.log(`CHANGED ${c.id} ${c.field}: ${c.from} → ${c.to}`);

--- a/apps/benchmark/test/diff.test.ts
+++ b/apps/benchmark/test/diff.test.ts
@@ -3,7 +3,7 @@
 import type { BenchOutput, DecompilerResult, FunctionResult, Outcome } from '@asmlift/bench-schema';
 import { describe, expect, test } from 'vitest';
 
-import { compareMeasurements } from '../src/report/diff';
+import { compareMeasurements, notRegenerated } from '../src/report/diff';
 
 const res = (over: Partial<DecompilerResult> = {}): DecompilerResult =>
   ({
@@ -25,6 +25,8 @@ const row = (
 
 const out = (...results: FunctionResult[]): BenchOutput =>
   ({ meta: { generatedAt: 'whenever' }, results }) as unknown as BenchOutput;
+
+const at = (generatedAt: string): BenchOutput => ({ meta: { generatedAt }, results: [] }) as unknown as BenchOutput;
 
 describe('compareMeasurements', () => {
   test('identical rows: nothing moved', () => {
@@ -73,5 +75,18 @@ describe('compareMeasurements', () => {
     (fresh.meta as Record<string, unknown>).generatedAt = 'much later';
     (fresh.results[0].asmlift as unknown as Record<string, unknown>).maxScore = 999;
     expect(compareMeasurements(base, fresh).ok).toBe(true);
+  });
+});
+
+// The gate reads a COMMITTED file, so on a clean source-only branch it is already the base's own
+// artifact: run it without running the benchmark and it compares the base against itself and
+// prints a green line in about a second. That line is what a PR publishes as its proof.
+describe('notRegenerated', () => {
+  test('the same stamp as the base means no run stands behind the comparison', () => {
+    expect(notRegenerated(at('2026-08-22T21:42:27.432Z'), at('2026-08-22T21:42:27.432Z'))).toBe(true);
+  });
+
+  test('a real merge re-mints generatedAt, so a genuine regeneration always passes', () => {
+    expect(notRegenerated(at('2026-08-22T21:42:27.432Z'), at('2026-08-23T09:01:04.005Z'))).toBe(false);
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,26 @@ import unusedImports from 'eslint-plugin-unused-imports';
 
 export default [
   {
-    ignores: ['**/dist/**', '**/node_modules/**', 'apps/benchmark/.cache/**'],
+    // `pnpm lint` is `eslint .`, and two of the trees under `.` are gitignored working dirs that
+    // are not this repo's code — so linting them makes the command mean one thing in CI (which
+    // clones neither) and another on a developer's machine.
+    //
+    //   research/                   scratch probes. Present only in a full checkout, and its
+    //                               errors are unfixable BY a commit — the files are gitignored,
+    //                               so `pnpm lint` sat permanently at "3 errors" locally while CI
+    //                               was green. A gate that is always red teaches you to skip it,
+    //                               and the house rule that grew around it (`eslint apps
+    //                               packages`, not `pnpm lint`) then drifted between two prompts.
+    //   apps/benchmark/checkouts/   the real tier's decomp projects, 2.2 GB of OTHER people's
+    //                               source. In a full checkout that is 218 more files linted
+    //                               against rules they never agreed to.
+    ignores: [
+      '**/dist/**',
+      '**/node_modules/**',
+      'apps/benchmark/.cache/**',
+      'research/**',
+      'apps/benchmark/checkouts/**',
+    ],
   },
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/scripts/pr-wait-selftest.sh
+++ b/scripts/pr-wait-selftest.sh
@@ -8,7 +8,13 @@
 # answers with for the first seconds of its life. Reading the exit status alone made all four a
 # red build, which is exactly the false red the script exists to remove.
 #
-# So gh is stubbed and each situation replayed. No network, no repo state, about a second.
+# The two deadlines are pinned here too: --timeout bounds a wait GitHub is answering, and
+# --unknown-timeout bounds one where it is not. Those cases assert the MESSAGE, not just the exit
+# code — both give up with 2, and a bug that let the silence budget cut short a healthy pending
+# wait would be invisible on the code alone.
+#
+# So gh is stubbed and each situation replayed. No network, no repo state, ~8s (measured 7.8-8.2s
+# over three runs here; the four cases that wait out a deadline are what it spends).
 #
 #   sh scripts/pr-wait-selftest.sh
 set -eu
@@ -43,13 +49,20 @@ STUB
 chmod +x "$tmp/bin/gh"
 
 fails=0
-expect() { # <situation> <expected exit> <why>
-  out=$(PATH="$tmp/bin:$PATH" GH_STUB="$1" sh "$target" 999 --timeout 1 --interval 1 2>&1) && rc=0 || rc=$?
-  if [ "$rc" -eq "$2" ]; then
+expect() { # <situation> <expected exit> <why> [flags] [output must contain]
+  flags=${4:-"--timeout 1 --interval 1"}
+  # shellcheck disable=SC2086 # $flags is a deliberate argument list
+  out=$(PATH="$tmp/bin:$PATH" GH_STUB="$1" sh "$target" 999 $flags 2>&1) && rc=0 || rc=$?
+  bad=""
+  [ "$rc" -eq "$2" ] || bad="exit $rc, expected $2"
+  if [ -n "${5:-}" ] && ! printf '%s\n' "$out" | grep -q -- "$5"; then
+    bad="${bad:+$bad; }said nothing matching '$5'"
+  fi
+  if [ -z "$bad" ]; then
     echo "ok   $1 → $rc   ($3)"
   else
     fails=$((fails + 1))
-    echo "FAIL $1 → $rc, expected $2   ($3)"
+    echo "FAIL $1: $bad   ($3)"
     printf '%s\n' "$out" | sed 's/^/       /'
   fi
 }
@@ -63,6 +76,14 @@ expect pending 2 "still running at the deadline — nothing decided"
 expect neterr 2 "unreachable API is not a red build"
 expect autherr 2 "an expired token is not a red build"
 expect nochecks 2 "no workflow has registered yet — the first call on a new PR"
+
+# The two deadlines are separate budgets. The prompts call this script with neither flag, so the
+# silence budget is the only thing standing between an expired token and an hour of a blocked
+# caller — and it must not shorten a wait GitHub is actually answering.
+expect neterr 2 "silence gives up on its OWN budget, not the whole --timeout" \
+  "--timeout 600 --interval 1 --unknown-timeout 1" "no check verdict at ALL for 1s"
+expect pending 2 "a pending check is an ANSWER: the silence budget must not cut it short" \
+  "--timeout 2 --interval 1 --unknown-timeout 1" "no check verdict after 2s"
 
 [ "$fails" -eq 0 ] || { echo "pr-wait-selftest: $fails case(s) failed"; exit 1; }
 echo "pr-wait-selftest: all cases hold"

--- a/scripts/pr-wait-selftest.sh
+++ b/scripts/pr-wait-selftest.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Offline self-test for scripts/pr-wait.sh's EXIT CONTRACT.
+#
+# The whole point of that script is that its exit code is an answer a caller can act on without
+# asking a human — so the one thing that must never rot is which situation produces which code.
+# The situations it has to tell apart are all things `gh` reports the same way (exit 1, nothing on
+# stdout): a failing check, a dead network, an expired token, and the "no checks reported" a PR
+# answers with for the first seconds of its life. Reading the exit status alone made all four a
+# red build, which is exactly the false red the script exists to remove.
+#
+# So gh is stubbed and each situation replayed. No network, no repo state, about a second.
+#
+#   sh scripts/pr-wait-selftest.sh
+set -eu
+
+here=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+target="$here/pr-wait.sh"
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/pr-wait-selftest.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+# The stub. `pr view` always says the PR is open, so every case below is decided by the checks
+# alone; `pr checks` replays one situation per $GH_STUB. The two spellings matter: the script asks
+# for `--json bucket` to get a verdict, and asks again bare to print the table for the log.
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/gh" <<'STUB'
+#!/bin/sh
+case "$2" in
+  view) echo "OPEN CLEAN"; exit 0 ;;
+  checks)
+    case "$GH_STUB" in
+      neterr)   echo "error connecting to api.github.com" >&2; exit 1 ;;
+      autherr)  echo "gh: authentication token expired" >&2; exit 4 ;;
+      nochecks) echo "no checks reported on the 'x' branch" >&2; exit 1 ;;
+      pending)  case "$*" in *--json*) printf 'pass\npending\n' ;; *) echo "ci	pending	-	link" ;; esac; exit 8 ;;
+      failing)  case "$*" in *--json*) printf 'pass\nfail\n' ;; *) echo "ci	fail	1m	link" ;; esac; exit 1 ;;
+      cancelled) case "$*" in *--json*) printf 'pass\ncancel\n' ;; *) echo "ci	cancel	1m	link" ;; esac; exit 1 ;;
+      skipped)  case "$*" in *--json*) printf 'pass\nskipping\n' ;; *) echo "ci	skipping	-	link" ;; esac; exit 0 ;;
+      green)    case "$*" in *--json*) printf 'pass\npass\n' ;; *) echo "ci	pass	1m	link" ;; esac; exit 0 ;;
+      *) echo "stub: unknown GH_STUB=$GH_STUB" >&2; exit 127 ;;
+    esac ;;
+esac
+STUB
+chmod +x "$tmp/bin/gh"
+
+fails=0
+expect() { # <situation> <expected exit> <why>
+  out=$(PATH="$tmp/bin:$PATH" GH_STUB="$1" sh "$target" 999 --timeout 1 --interval 1 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$2" ]; then
+    echo "ok   $1 → $rc   ($3)"
+  else
+    fails=$((fails + 1))
+    echo "FAIL $1 → $rc, expected $2   ($3)"
+    printf '%s\n' "$out" | sed 's/^/       /'
+  fi
+}
+
+# 1 is reserved for a verdict GitHub actually gave; everything gh could not answer is 2.
+expect green 3 "green and open: nothing missing, ready to merge"
+expect skipped 3 "a skipped check is not a failed one"
+expect failing 1 "a check GitHub reported as failed"
+expect cancelled 1 "a cancelled check is not green either"
+expect pending 2 "still running at the deadline — nothing decided"
+expect neterr 2 "unreachable API is not a red build"
+expect autherr 2 "an expired token is not a red build"
+expect nochecks 2 "no workflow has registered yet — the first call on a new PR"
+
+[ "$fails" -eq 0 ] || { echo "pr-wait-selftest: $fails case(s) failed"; exit 1; }
+echo "pr-wait-selftest: all cases hold"

--- a/scripts/pr-wait.sh
+++ b/scripts/pr-wait.sh
@@ -12,11 +12,17 @@
 #
 # Exit codes — each one is an ANSWER, so a caller never has to ask a human:
 #   0  merged
-#   1  a check failed (the failing checks are printed)
-#   2  timed out — still pending, nothing decided
+#   1  a check GitHub reported as failed or cancelled (the check table is printed)
+#   2  nothing decided within --timeout — still pending, or GitHub never gave an answer
 #   3  checks are green and the PR is still open: nothing is missing, it is ready to merge
 #   4  closed without merging
 #   64 usage / no such PR
+#
+# Exit 1 is reserved for a verdict GitHub actually gave. `gh` cannot supply that on its own: it
+# documents exit 8 for "checks pending" and 0 for all-green, but everything else is exit 1, "a
+# command fails for any reason" (`gh help exit-codes`) — a failing check, a network error, an
+# expired token and "no checks reported on this branch" are one code. So the buckets are read, not
+# the exit status, and an answer that did not arrive is UNKNOWN and keeps waiting.
 #
 # Waits on the PR's REAL state, never on a process pattern: both phases ask GitHub what the PR is
 # doing. A `pgrep -f` wait whose pattern matches the waiting shell deadlocks forever, and cost this
@@ -99,31 +105,51 @@ esac
 
 # Phase 1 — the checks, polled on our own clock rather than inside `gh … --watch`. `--watch` has
 # no timeout of its own (its --interval is just how often it re-asks), so a queued or stuck job
-# blocks it forever; this loop asks the same question at the same rate and can stop. gh's exit
-# codes ARE the three answers: 0 all complete and passing, 8 still pending, anything else a
-# failure.
+# blocks it forever; this loop asks the same question at the same rate and can stop.
+#
+# It asks for the BUCKETS (`pass`/`fail`/`pending`/`skipping`/`cancel`, gh's own categorisation of
+# each check's state) instead of reading gh's exit status, because the status cannot tell a red
+# build from an unreachable API: reading exit 1 as "a check failed" turns a network blip, an
+# expired token, or the "no checks reported" a freshly-opened PR answers with — the single most
+# likely FIRST call — into the false red this script exists to remove. Phase 2 already refuses to
+# read a transient error as an answer (`state_or_unknown`); this is the same discipline, one phase
+# earlier. No buckets came back ⇒ nothing is known ⇒ keep waiting, and let the deadline decide.
+ERRFILE=$(mktemp "${TMPDIR:-/tmp}/pr-wait.XXXXXX")
+trap 'rm -f "$ERRFILE"' EXIT INT TERM
+
 say "watching checks…"
-CHECKS=0
-PENDING=0
+VERDICT=""
+SAID=""
 while :; do
-  CHECKS=0
-  gh pr checks "$PR" >/dev/null 2>&1 || CHECKS=$?
-  [ "$CHECKS" -eq 8 ] || break
-  # 8 also covers "no workflow has reported yet", which is what a PR opened seconds ago looks
-  # like — the single most likely first call. Waiting it out is the answer the caller asked for.
-  if [ "$PENDING" -eq 0 ]; then
-    say "checks pending…"
+  # `--jq` is gh's own, so this needs no jq on PATH. Failure leaves BUCKETS empty, which is the
+  # UNKNOWN branch below — never a verdict.
+  BUCKETS=$(gh pr checks "$PR" --json bucket --jq '.[].bucket' 2>"$ERRFILE") || true
+  if [ -n "$BUCKETS" ]; then
+    case "$BUCKETS" in
+      *fail*) VERDICT=failed ;;
+      *pending*) VERDICT="" ;;
+      *cancel*) VERDICT=cancelled ;;
+      *) VERDICT=green ;;
+    esac
+    [ -z "$VERDICT" ] || break
+    SAY="checks pending…"
+  else
+    # gh answers "no checks reported on the 'x' branch" exactly as it answers a dead network and
+    # an expired token: exit 1, nothing on stdout. None of the three is a failing build, and the
+    # first is the normal state of a PR whose workflows have not registered yet.
+    SAY="no check verdict yet: $(tr '\n' ' ' < "$ERRFILE" | cut -c1-160 | sed 's/ *$//')"
   fi
-  PENDING=$((PENDING + 1))
+  [ "$SAY" = "$SAID" ] || say "$SAY" # once per distinct reason, not once per poll
+  SAID="$SAY"
   if expired; then
-    say "checks still pending after ${TIMEOUT}s — giving up, nothing decided"
+    say "no check verdict after ${TIMEOUT}s — giving up, nothing decided"
     exit 2
   fi
   sleep "$INTERVAL"
 done
 gh pr checks "$PR" || true # the table itself, for the caller's log
-if [ "$CHECKS" -ne 0 ]; then
-  say "a check FAILED — fix it before asking anyone about merging"
+if [ "$VERDICT" != green ]; then
+  say "a check $(echo "$VERDICT" | tr '[:lower:]' '[:upper:]') — fix it before asking anyone about merging"
   exit 1
 fi
 say "checks are green"

--- a/scripts/pr-wait.sh
+++ b/scripts/pr-wait.sh
@@ -10,10 +10,17 @@
 #   scripts/pr-wait.sh 82 --until-merged   # …and keep waiting until it is merged or closed
 #   scripts/pr-wait.sh 82 --timeout 900    # give up after 15 min (default 3600s) — the WHOLE run
 #
+# Two deadlines, because "GitHub says the checks are still running" and "GitHub is not answering
+# at all" are not the same wait. --timeout bounds the whole run and has to be generous: a queued
+# workflow with no free runner is a legitimate hour. --unknown-timeout (default 180s) bounds only
+# the state where no verdict has come back AT ALL — an expired token, a dead network, or a PR
+# whose workflows never register. Nothing is being learned in that state, so waiting out the full
+# --timeout there just blocks the caller for an hour to reach the same "nothing decided".
+#
 # Exit codes — each one is an ANSWER, so a caller never has to ask a human:
 #   0  merged
 #   1  a check GitHub reported as failed or cancelled (the check table is printed)
-#   2  nothing decided within --timeout — still pending, or GitHub never gave an answer
+#   2  nothing decided: still pending at --timeout, or no verdict at all for --unknown-timeout
 #   3  checks are green and the PR is still open: nothing is missing, it is ready to merge
 #   4  closed without merging
 #   64 usage / no such PR
@@ -32,7 +39,7 @@
 set -eu
 
 usage() {
-  echo "usage: scripts/pr-wait.sh <pr-number> [--until-merged] [--timeout <seconds>] [--interval <seconds>]" >&2
+  echo "usage: scripts/pr-wait.sh <pr-number> [--until-merged] [--timeout <seconds>] [--interval <seconds>] [--unknown-timeout <seconds>]" >&2
   exit 64
 }
 
@@ -40,6 +47,7 @@ PR=""
 UNTIL_MERGED=0
 TIMEOUT=3600
 INTERVAL=15
+UNKNOWN_TIMEOUT=180
 while [ $# -gt 0 ]; do
   case "$1" in
     --until-merged) UNTIL_MERGED=1 ;;
@@ -52,6 +60,11 @@ while [ $# -gt 0 ]; do
       shift
       [ $# -gt 0 ] || usage
       INTERVAL="$1"
+      ;;
+    --unknown-timeout)
+      shift
+      [ $# -gt 0 ] || usage
+      UNKNOWN_TIMEOUT="$1"
       ;;
     -h | --help) usage ;;
     -*) usage ;;
@@ -120,11 +133,15 @@ trap 'rm -f "$ERRFILE"' EXIT INT TERM
 say "watching checks…"
 VERDICT=""
 SAID=""
+# Set on the first poll that comes back with nothing, cleared the moment one comes back with
+# something: the budget is for a run of silence, not for the total.
+UNKNOWN_DEADLINE=""
 while :; do
   # `--jq` is gh's own, so this needs no jq on PATH. Failure leaves BUCKETS empty, which is the
   # UNKNOWN branch below — never a verdict.
   BUCKETS=$(gh pr checks "$PR" --json bucket --jq '.[].bucket' 2>"$ERRFILE") || true
   if [ -n "$BUCKETS" ]; then
+    UNKNOWN_DEADLINE="" # GitHub is answering again; only --timeout bounds us now
     case "$BUCKETS" in
       *fail*) VERDICT=failed ;;
       *pending*) VERDICT="" ;;
@@ -138,9 +155,17 @@ while :; do
     # an expired token: exit 1, nothing on stdout. None of the three is a failing build, and the
     # first is the normal state of a PR whose workflows have not registered yet.
     SAY="no check verdict yet: $(tr '\n' ' ' < "$ERRFILE" | cut -c1-160 | sed 's/ *$//')"
+    [ -n "$UNKNOWN_DEADLINE" ] || UNKNOWN_DEADLINE=$(($(date +%s) + UNKNOWN_TIMEOUT))
   fi
   [ "$SAY" = "$SAID" ] || say "$SAY" # once per distinct reason, not once per poll
   SAID="$SAY"
+  # The silence budget, checked before the global one: the prompts call this script with no
+  # --timeout at all, so without it an expired token blocks the caller for the full default hour
+  # to arrive at exactly the answer the first two polls already had.
+  if [ -n "$UNKNOWN_DEADLINE" ] && [ "$(date +%s)" -ge "$UNKNOWN_DEADLINE" ]; then
+    say "no check verdict at ALL for ${UNKNOWN_TIMEOUT}s — GitHub is not answering, nothing decided"
+    exit 2
+  fi
   if expired; then
     say "no check verdict after ${TIMEOUT}s — giving up, nothing decided"
     exit 2


### PR DESCRIPTION
Three defects in the loop's own instruments, all in things that answer a yes/no question the round
then acts on. Nothing here touches the decompiler; the per-row neutrality proof is at the bottom.

## 1. The hard invariant was satisfiable in a second, having measured nothing

`bench diff` reads whatever bytes sit at `apps/benchmark/results/results.json` — and that file is
**committed**. So on a source-only branch with a clean tree it already *is* the base's artifact, and
the gate compares the base against itself:

```
$ git status --porcelain            # clean, nothing run
$ npx tsx apps/benchmark/src/cli.ts diff --base origin/main
diff vs origin/main: 0 field change(s), 0 added, 0 removed (834 base rows, 834 fresh rows)
exit=0                                                            (0.888s)
```

That is the exact line a meta PR publishes as its proof of output neutrality. A real one costs a
full `bench run` (this branch's took 271s); nothing in the output told them apart.
`scripts/check-artifact-provenance.sh` does not catch it either — in precisely this case the
artifact blob equals the base's, so it concludes "this branch publishes no numbers of its own,
UNKNOWN, not checked" and exits 0.

`report/committed.ts` already names this failure mode and guards one side of it ("on a branch that
has already committed its own artifact, `HEAD` compares the branch against ITSELF and every gate
passes vacuously"). That is the BASE side. This is the FRESH side.

**Fix.** `bench diff` now exits **2** — "nothing was compared" — when the on-disk artifact carries
the base's own `meta.generatedAt`. `bench merge` re-mints that stamp from `new Date()` on every run
(`run/runner.ts` `benchMeta`), so a genuine regeneration can never trip it and there are no false
positives; it also catches an artifact edited by hand rather than measured. And the gate now says
what it compared, so a reader of a PR body need not take the tick on trust:

```
diff: base origin/main = 0c8166f (artifact generated 2026-08-22T21:42:27.432Z) · fresh
apps/benchmark/results/results.json generated 2026-08-22T23:37:45.119Z at 0c8166f (dirty tree)
```

plus a warning when HEAD does not contain the base — the second, quieter hole in the same command
(a comparison against a base the branch has not merged in is credited with everything the base
gained meanwhile).

## 2. `pnpm lint` was permanently red, on files no commit can fix

`pnpm lint` is `eslint .`, which is what CI runs. In a full checkout it walks two **gitignored**
trees that are not this repo's code, and one of them makes it fail. Deterministic counts, same
machine, same commit:

| command | files linted | errors | warnings |
|---|---|---|---|
| `eslint .` (= `pnpm lint`, = CI) | 678 | **3** | 279 |
| `eslint apps packages` (the house rule) | 570 | 0 | 61 |
| `eslint .` + the two ignores | **355** | 0 | 61 |

All three errors are in `research/` (`git check-ignore` → `.gitignore:35`), which does not exist in
a CI clone — so CI is green on `0c8166f` while the identical command exits 1 locally. The other 218
files are `apps/benchmark/checkouts/`, the real tier's vendored decomp projects: 2.2 GB of other
people's source, linted against rules they never agreed to.

The two prompts had already drifted around it — `attribute-function.md` said "`npx eslint apps
packages` (not `pnpm lint`)", `match-function.md` said "`pnpm lint`". Both spellings appear in live
use across the agent corpus (69 and 60 distinct transcripts). That is the same drift class as PR #79.

**Fix.** `eslint.config.mjs` ignores `research/**` and `apps/benchmark/checkouts/**`; both prompts
now say `pnpm lint`, which is what CI runs. The verdict is **byte-identical** to the house-rule
command — same 0 errors, and the same 61 warnings file-by-file, rule-by-rule:

```
$ diff <(eslint apps packages --format json | …file:line:rule…) \
       <(eslint . --ignore-pattern 'research/**' --ignore-pattern 'apps/benchmark/checkouts/**' | …)
   (no output)
```

Scope note, deliberately visible: `eslint.config.mjs` is repo-root tooling, in neither the IN nor
the OUT list of this lane's brief. It is a separate commit so it can be dropped on its own.
Honesty note on the payoff: this is worth 323 fewer files in a **full checkout** and **nothing at
all in a worktree** — `research/` is absent there and `apps/benchmark/checkouts` is a symlink eslint
does not follow, so `eslint .` already lints 357 files with 0 errors. The win here is a gate that
stops being red on files a commit cannot fix, not a speedup.

## 3. `scripts/pr-wait.sh` called an unreachable API a red build

Phase 1 read `gh`'s exit status: `[ "$CHECKS" -eq 8 ] || break`, then "anything not 0 FAILED". But
`gh help exit-codes` documents 8 for pending and 0 for all-green and **1 for "a command fails for
any reason"** — so a failing check, a network error, an expired token (4) and the "no checks
reported on this branch" a freshly-opened PR answers with are one code. The script's own header
defines exit 1 as "a check failed (the failing checks are printed)"; nothing was printed, because
nothing failed. Its phase 2 already refuses to read a transient error as an answer
(`state_or_unknown`, "a single network blip sent the caller hunting a red build that does not
exist") — phase 1, the phase both prompts call, had no such guard.

**Fix.** Phase 1 reads the **buckets** (`gh pr checks --json bucket`, gh's own
pass/fail/pending/skipping/cancel categorisation), not the exit status. No buckets came back ⇒
nothing is known ⇒ keep polling, and the deadline decides (exit 2, "nothing decided"). Exit 1 is
now reserved for a verdict GitHub actually gave.

`scripts/pr-wait-selftest.sh` replays all eight situations against a stubbed `gh` — offline, ~1s —
and CI runs it, because the loop reads these codes instead of asking a human:

```
ok   green → 3      ok   skipped → 3     ok   failing → 1    ok   cancelled → 1
ok   pending → 2    ok   neterr → 2      ok   autherr → 2    ok   nochecks → 2
```

Against `origin/main`'s script the same self-test fails exactly the three cases the fix addresses
(`neterr`, `autherr`, `nochecks` → 1, expected 2) and passes the other five — so it is a real guard,
not a restatement of the new code.

---

## Rejected, with the measurement

**"`docs/ranked-repro.md`'s canonical command does not run — `--proto` is file-only."** Already
fixed, in #86 (`0c8166f`), the commit this branch is based on; the finding was measured on
`f60cb42`, one commit earlier. `packages/cli/src/main.ts` accepts inline JSON since that commit and
carries the same evidence in its comment. Re-run as written, from the klonoa checkout, on
`origin/main`:

```
$ npx tsx …/packages/cli/src/main.ts asm/nonmatchings/gfx/LoadBGTilemapData.s \
    --config decomp.yaml --proto '{"thunk_HeapFree":{"params":1}}'
exit=0
```

Root cause worth more than the finding: the loop's ledger stops at #84, so an iteration re-derived
a defect the previous iteration had closed. The ledger, not the corpus, is what the next pass reads.

## Out of scope — proposed, not implemented

- `notRegenerated` guards `diff`; `regression` and `stale-check` read the same committed file
  through the same `readCommitted` and have the same vacuity. One shared pre-flight in
  `report/committed.ts` would cover all three (touches `apps/benchmark/src`, so it *is* in scope —
  left out only because neither is the gate this lane's invariant rests on, and both deserve their
  own neutrality run).
- `scripts/check-artifact-provenance.sh` reports UNKNOWN in exactly the do-nothing case. It cannot
  tell "this branch published no numbers" from "this branch ran nothing"; the artifact's
  `generatedAt` vs the base's would separate them there too.
- The meta lane deliberately does not commit its regenerated artifact, so the on-disk file is the
  only evidence a reviewer has and nothing in the repo records it. A `--json` mode on `bench diff`,
  pasted into the PR body, would make the proof re-readable after the working tree is gone.

## Output neutrality

`pnpm bench run && pnpm bench merge` on this branch, `source /tmp/wt-env.sh` first, **0 SKIPs**,
834 rows merged (594 synthetic + 240 real) — the same counts as the base. 271s wall-clock, on a
10-core box with a ranked `--jobs 6` run from another track and load average 30 at start, so the
timing is reported and not compared to anything.

Then a comparator written for this PR — deliberately **not** `bench diff`, because this branch
changes `bench diff`. It reads `origin/main`'s artifact straight out of `git show` and the fresh one
off disk, compares `asmlift.{outcome,score,candidateLabel,source}` and `m2c.{outcome,score,source}`
for every row (sources scrubbed of run-local scratch names, as the harness does), then walks every
OTHER key in the artifact and names the ones that differ:

```
base origin/main rows=834  fresh rows=834
COMPARED FIELDS THAT MOVED: 0
other keys that differ (permitted — name them):
  meta.asmlift.commit  (1)
  meta.asmlift.dirty   (1)
  meta.generatedAt     (1)
```

Three keys, all provenance, all in `meta`. Not one row differs in any key at all — no timing, no
`droppedCandidates`, nothing.

Corroborated by the repo's own gates:

```
$ npx tsx apps/benchmark/src/cli.ts diff --base origin/main
diff: base origin/main = 0c8166f (artifact generated 2026-08-22T21:42:27.432Z) · fresh
apps/benchmark/results/results.json generated 2026-08-22T23:37:45.119Z at 0c8166f (dirty tree)
diff vs origin/main: 0 field change(s), 0 added, 0 removed (834 base rows, 834 fresh rows)   exit=0

$ npx tsx apps/benchmark/src/cli.ts regression --base origin/main
regression: 0 lost, 0 missing, 0 gained, 0 other flips (834 committed rows)                  exit=0
```

Gates: `pnpm typecheck` clean · `npx vitest run --maxWorkers=3` 130 files / 1610 tests, 0 failures ·
`npx eslint apps packages` and `pnpm lint` both 0 errors / 61 warnings · `pnpm format:check` clean ·
`sh scripts/pr-wait-selftest.sh` all 8 cases.

The regenerated artifacts are **not** committed — this PR is source-only, and they exist only as
the proof above.

---

## Reviewer's audit (agent 3, iteration 2)

Branch `review/v3-2` at `origin/meta/v3-2`. Every claim below is re-derived, not taken on trust.

**Scope — clean.** `git diff --stat origin/main...HEAD` touches nothing owned by a live track: no
`packages/core/**`, no `apps/benchmark/dataset/**`, no `bench-schema`, no `cases/features.ts`.
`/tmp/wt-stackaddr`, `/tmp/wt-readkey` and `/tmp/wt-rows12` were never opened.

**Neutrality, re-proved independently** — my own walker, not `report/diff.ts`, full `bench run`
(834 rows, 0 skips) + `merge` at the branch **tip** (`meta.asmlift.dirty: false`), against
`origin/main`'s committed artifact:

```
base origin/main = 0c8166f  (834 rows, generatedAt 2026-08-22T21:42:27.432Z)
fresh apps/benchmark/results/results.json  (834 rows, 2026-08-23T00:01:27.824Z, asmlift b3659d7 dirty=false)
compared: asmlift.{outcome,score,candidateLabel,source} m2c.{outcome,score,source} over 834 base rows
rows added: 0 · rows removed: 0
RAW field moves (no scrubbing): 0
SCRUBBED field moves: 0
base  asmlift {declined:211, nonmatch:184, match:435, noncompile:4}  m2c {noncompile:211, nonmatch:217, match:357, declined:49}
fresh asmlift {declined:211, nonmatch:184, match:435, noncompile:4}  m2c {noncompile:211, nonmatch:217, match:357, declined:49}
NEUTRAL: every compared field identical
```

A structural walk of every leaf of every row (not just the seven gated fields — timings,
`droppedCandidates`, `scripts`, `quality` included) reports **0 row differences**. The only keys
that differ in the whole artifact are `meta.generatedAt` and `meta.asmlift.commit`. Those are the
permitted two, and they are the ones that differed.

The proof is meaningful rather than a cache replay: `apps/benchmark/src/cache.ts` caches reference
builds, the PPC objdump and m2c, and states "Deliberately NOT cached: asmlift's own decompile/score
work — that is the thing under test."

**Finding 1 — `bench diff` vacuity: SOUND.** All three paths exercised here:

| situation | result |
|---|---|
| clean tree, nothing run | `NOT REGENERATED …` **exit 2** in 0.77s |
| after `run` + `merge` | `0 field change(s), 0 added, 0 removed (834 base rows, 834 fresh rows)` exit 0 |
| `--base origin/meta/v3-1` (not an ancestor) | `WARNING: HEAD does not contain …`, then compares |

No false alarm: the warning did **not** fire for `origin/main`, and the exit-2 path did not fire
after a real run. The no-false-positive argument holds at the source — `report/merge.ts:64` builds
`meta` from `benchMeta(results)`, and `run/runner.ts:27` mints `generatedAt: new Date().toISOString()`
there unconditionally, so a genuine merge can never reproduce the base's stamp. Nothing in CI calls
`bench diff` (grep: only the two prompts and the README), so exit 2 cannot break a pipeline.

**Finding 2 — the lint ignores: SOUND, and the implementer's own correction is right.** Reproduced
from one `eslint . -f json` over the full checkout, counting files rather than seconds:

| | files | errors | warnings |
|---|---|---|---|
| `eslint .` (= `pnpm lint`, = CI) | 678 | **3** | 279 |
| `eslint apps packages` (the old house rule) | 570 | 0 | 61 |
| `eslint .` + the two ignores | **355** | 0 | 61 |

All 3 errors are `unused-imports/no-unused-imports` in a gitignored scratch tree. Verdict
equivalence checked as SETS, not counts: the `file:line:col:rule:severity` lists for
`eslint apps packages` and post-fix `eslint .` are **identical** (61 messages each, empty symmetric
difference); the only files the post-fix command adds are `eslint.config.mjs`,
`vitest.config.ts`, `vitest.matching.config.ts`, and they emit nothing. Nothing is hidden:
`git ls-files` returns **0** tracked files under either newly-ignored path, so no error a commit
could fix is being suppressed. The correction stands too — in a worktree `eslint .` is 357 files /
0 errors both before and after, so the payoff there is zero and the case is correctness only.
`grep -rn eslint --include='*.md' --include='*.yml'` now returns nothing: the retired house rule
survives in no prompt or doc.

**Finding 3 — `pr-wait.sh` reading buckets: SOUND, one hole closed (commit `b3659d7`).** The
selftest is a genuine guard, not a restatement: run against `origin/main`'s script it fails exactly
the 3 cases the fix addresses and passes the other 5. Bucket matching is collision-free — none of
`pass`/`fail`/`pending`/`skipping`/`cancel` is a substring of another, and the tokens are
newline-separated, so no cross-boundary match exists. Verified against the live API too:
`sh scripts/pr-wait.sh 87 --timeout 120 --interval 10` → exit 3, all three checks listed.

The hole: reading buckets turned one *wrong* answer into a *slow* one. With no verdict ever
arriving — expired token, dead network, a PR whose workflows never register — the script now waits
out the **whole** `--timeout` to say "nothing decided", and both prompts call it as
`scripts/pr-wait.sh <pr>` with no flags, i.e. the 3600s default. So `--unknown-timeout` (default
180s) now bounds *only* the state where GitHub answers nothing; it is armed on the first empty poll
and disarmed the moment a bucket comes back, leaving a healthy pending wait bounded by `--timeout`
as before. Two new cases assert the **message**, not just the code (both give up with 2, so a bug
that let the silence budget cut short a pending wait would be invisible on the exit code alone);
both fail against this branch's pre-review script. All 10 cases hold locally (7.8–8.2s over three
runs) and in CI (7.2s on the runner) — the "~1s" the CI comment claimed is now the measured number.

**Gates, all re-run on the merged tip:** `pnpm typecheck` clean · `npx vitest run apps/benchmark/test`
22 files / 222 tests · `pnpm lint` 0 errors / 61 warnings · `pnpm format:check` clean ·
`sh scripts/pr-wait-selftest.sh` 10/10 · `pnpm bench diff --base origin/main` exit 0 ·
`pnpm bench regression --base origin/main` 0 lost, 0 missing, 0 gained, 0 other flips.

**Deliberately not fixed here**, and recorded as known-open rather than left silent:

- `regression` and `stale-check` share `readCommitted` and the same vacuity. Extending the guard
  would change the semantics of `benchmark.yml`, which calls both and which cannot be exercised
  locally — a reviewer should not land a new blocking gate on a workflow they cannot run.
- `pr-wait.sh` phase 2 (`--until-merged`) still bounds its own UNKNOWN only by the global timeout.
  Pinning it needs a **stateful** gh stub (succeed for phase 1, then fail), which the offline
  selftest cannot express today; no prompt passes `--until-merged`. Fix the stub first.
- `notRegenerated` is unit-pinned as a predicate, but `diffGate`'s exit-2 path is exercised only by
  hand. A fixture-backed test of the gate itself is the missing pin.

The regenerated artifacts are **not** committed: this PR stays source-only, and they exist only as
the proof above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
