### PR TITLE
Save the meta-optimisation loop as a reusable workflow

### DIFF
--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -1,0 +1,36 @@
+# Saved workflows
+
+Multi-agent workflows worth re-running. Invoke by name — `Workflow({name: "meta-optimizer-loop"})`
+— optionally with `args`.
+
+## `meta-optimizer-loop`
+
+Supervises the rounds that are running (`/match-function`, `/attribute-function`) and improves the
+*loop itself*: the command prompts, the harness ergonomics, and the wall-clock of the expensive
+paths. Three agents per iteration, looped:
+
+1. **Supervise** — read the ledger, then only what is new since the last iteration. Produces at
+   most four evidenced findings; an empty list is a valid result.
+2. **Implement** — *challenges* each finding first (verify the cited evidence, ask whether the
+   proposal would really have prevented the failure, weigh the churn), builds only the survivors,
+   proves output-neutrality mechanically, opens a PR. No PR if nothing survives.
+3. **Review** — audits scope, **re-proves neutrality independently**, re-runs every gate, applies
+   fixes itself, and merges on green.
+
+`args: {since: "<sha>"}` starts the incremental window at a specific commit.
+
+**The hard invariant** is that nothing it ships may change a measurement: a full bench run, then a
+per-row diff of the regenerated `results.json` against `origin/main`'s, comparing
+`asmlift.{outcome,score,candidateLabel,source}` and `m2c.{outcome,score,source}`. Every row
+identical, or it does not ship. The reviewer re-proves this rather than trusting the implementer —
+a "harmless" speedup that silently moved one row would poison every measurement in the project.
+
+**`meta-optimizer-ledger.md` is load-bearing.** It records what has already shipped, which harness
+traps are already fixed, and which items are known-open. The supervisor reads it instead of
+re-deriving from the whole transcript corpus, which otherwise grows without bound and crowds out the
+analysis. **Keep it current** — each iteration returns `ledger_additions` for exactly this.
+
+Shipped in its first four iterations: a canonical ranked-repro command (`docs/ranked-repro.md`),
+skipped rows made visible on the tier line, `scripts/check-artifact-provenance.sh` + its CI job, a
+compile pool for the ranked run (36m10s → 21m32s at `--jobs 6`), a liveness pulse, and an
+empty-filter guard.

--- a/.claude/workflows/meta-optimizer-ledger.md
+++ b/.claude/workflows/meta-optimizer-ledger.md
@@ -1,0 +1,59 @@
+# Meta-optimisation ledger — what is ALREADY shipped or already ruled out
+# The supervisor reads THIS instead of re-deriving from the full transcript corpus.
+
+## Shipped and merged (do not re-report, do not re-implement)
+
+- **#79** canonical LBG repro command in `match-function.md`; skipped rows totalled on the tier
+  line; `scripts/check-artifact-provenance.sh` + a PR-only CI job.
+- **#81** the headline re-measured; the second adversarial wave re-briefed; an unmeasured asmlift
+  claim actually run. (`.claude/commands/` only.)
+- **#82** the ranked run gets a **compile pool** (measured **36m10s serial → 21m32s at `--jobs 6`**,
+  20608 candidates, 0 dropped, identical winner; scaling 2.00x/3.44x/4.44x/4.86x at p2/p4/p6/p8),
+  a **liveness pulse** (the serial ranked run had written 0 bytes for 36 minutes), and a
+  neutrality command for this loop.
+- **#84** the provenance check survives a rebase; an empty `--only` filter stops reporting a green
+  tick; the ranked repro gets one home.
+- **#86** one queue for both tier fans; the ranked run's counts as an `asmlift: [ranked]` line;
+  `scripts/pr-wait.sh` (the loop's mechanical answer to "is CI green / did it merge"); **`--proto`
+  accepts INLINE JSON as well as a path** (`packages/cli/src/main.ts`), so
+  `docs/ranked-repro.md`'s canonical command runs verbatim — iteration 2 re-derived this as a
+  live defect because the ledger stopped at #84.
+- **#87** `bench diff` exits **2** ("nothing was compared") when `results.json` still carries the
+  base's `meta.generatedAt`, and prints base sha + fresh stamp — the loop's hard invariant was
+  satisfiable in 0.9s on a clean tree, having run nothing, and that green line is what #86's body
+  published as its proof; `eslint.config.mjs` ignores `research/**` and
+  `apps/benchmark/checkouts/**`, so `pnpm lint` stops being permanently red locally (678→355 files,
+  3 errors→0, verdict byte-identical to `eslint apps packages`) and BOTH prompts now say
+  `pnpm lint` — the `npx eslint apps packages` house rule is retired; `pr-wait.sh` phase 1 reads
+  `gh pr checks --json bucket` instead of gh's exit code, so a network blip / expired token / "no
+  checks reported" is exit 2 ("nothing decided") not exit 1 ("a check FAILED"), guarded forever by
+  `scripts/pr-wait-selftest.sh` in CI.
+
+## Harness traps already found and fixed — never re-report
+
+1. Sibling checkouts resolve from the repo root, which in a worktree is `/private/tmp` → rows
+   silently SKIP. Fixed by `/tmp/wt-env.sh` + asserting 0 SKIPs.
+2. `apps/benchmark/{checkouts,toolchains}/` are gitignored → absent from a worktree. Symlinked.
+3. Those symlinks stamp `meta.asmlift.dirty: true`. Fixed via `.git/info/exclude`.
+4. `pgrep -f` waits matching the waiting shell → deadlock (cost 8 hours once).
+5. The LBG repro needs `--proto '{"thunk_HeapFree":{"params":1}}'` — worth 60 points.
+6. `pnpm bench regression` is weak once a branch commits artifacts; the real check is a per-row
+   diff against `origin/main`'s `results.json`.
+7. Diffing the two `.s` TEXTS instead of objdiff's rendering produced 145 bogus rows once;
+   alignment padding rendered as `lsl rN,#0` vs `.hword 0` produced 8 more.
+8. A full `pnpm bench run` is **~5 minutes**, not ~30. The expensive thing is the ranked LBG run.
+9. Rebasing a capability branch conflicts in the three generated artifacts and usually nothing
+   else — never hand-merge `results.json`; discard both sides and regenerate.
+
+## Known-open, already named — report only with NEW evidence or a concrete fix
+
+- **Machine-wide job budget.** Every track gets a flat `--jobs`, on a 10-core box running 4-6
+  workflows; the pool delivered **1.68x of its achievable 2.83x** under self-inflicted contention.
+- **39% of agent Bash wall-clock is spent blocking on jobs the agent itself backgrounded.**
+- `onLeverError` is wired nowhere in the CLI or benchmark, so a lever that always throws is
+  invisible there.
+- `regression` and `stale-check` read the same committed artifact through the same
+  `readCommitted` and have the SAME vacuity #87 closed in `diff`; only `diff` is guarded.
+- `scripts/check-artifact-provenance.sh` reports "UNKNOWN, not checked" in exactly the
+  do-nothing case (artifact blob identical to the base's) — it cannot tell "published no numbers
+  of its own" from "ran nothing".

--- a/.claude/workflows/meta-optimizer-loop.js
+++ b/.claude/workflows/meta-optimizer-loop.js
@@ -1,0 +1,278 @@
+export const meta = {
+  name: 'meta-optimizer-loop',
+  description: 'Supervise the running rounds, challenge and build the best optimisation, review and merge \u2014 looped, incremental',
+  phases: [
+    { title: 'Supervise', detail: 'read the ledger + only what is NEW since last iteration' },
+    { title: 'Implement', detail: 'challenge, build, prove output-neutrality, open a PR' },
+    { title: 'Review', detail: 'audit, re-prove neutrality independently, fix, merge' },
+  ],
+}
+
+const REPO = '/Users/macabeus/ApenasMeu/decompiler/asmlift'
+// Workflow transcripts for THIS session — the runtime prints the dir when a workflow launches.
+const WF = process.env.ASMLIFT_WF_DIR ?? '<this session\'s subagents/workflows dir>'
+const MEM = '~/.claude/projects/-Users-macabeus-ApenasMeu-decompiler-asmlift/memory'
+const LEDGER = `${REPO}/.claude/workflows/meta-optimizer-ledger.md`
+
+const CONTEXT = `
+## What this project is doing
+
+asmlift is a TS matching-decompiler. A loop runs \`/attribute-function\` on the klonoa function
+\`LoadBGTilemapData\` (LBG) to name missing capabilities and author benchmark rows, then
+\`/match-function\` builds the capability those rows gate. Each round is a Workflow of ~8 agents.
+**LBG has gone 547 → 473; the corpus is 834 rows, asmlift 433 / m2c 357.**
+
+## READ THIS FIRST — the ledger, not the whole corpus
+
+\`${LEDGER}\` lists everything this loop has already shipped, every harness trap already fixed, and
+the known-open items already named. **Read it before anything else.** It exists because the previous
+incarnation re-read all 44 agent transcripts (38+ MB) on every iteration, so each pass spent more of
+itself re-deriving history than analysing anything new. Do not re-report a ledger entry; if you
+believe a ledger entry is wrong, say so with the measurement that shows it.
+
+## Then look ONLY at what is new
+
+- \`git -C ${REPO} log --oneline <last-iteration-sha>..origin/main\` and the PRs in that range.
+- Workflow journals **modified since your last iteration**: \`ls -t ${WF}/*/journal.jsonl | head\`,
+  and read the per-agent transcripts only for agents whose result you have not seen. Prefer
+  \`journal.jsonl\` (one \`{"type":"result"}\` line per agent) over the raw transcripts — it carries
+  each agent's own report, which is usually enough.
+- \`${MEM}/\` — durable lessons, including the live-tracks table.
+- Run logs: \`/tmp/lbg8/*.log\`.
+
+**Budget rule: spend at most a third of your effort reading, and the rest analysing.** If you find
+yourself opening a fourth transcript, stop and work with what the journals told you.
+
+## Live tracks you must NOT disturb
+
+Other rounds run in parallel git worktrees and OWN files. **Read the live-tracks table in
+\`asmlift-parallel-worktree-harness.md\` under the memory dir before touching anything** — it is
+kept current as tracks start and finish. As a rule: capability rounds own \`packages/core/**\` and
+the bench artifacts on their own branches; attribution rounds own \`apps/benchmark/dataset/**\` and
+\`packages/bench-schema/**\`. Never edit another worktree or the main checkout.
+`
+const SCOPE = `
+## Scope
+
+**IN scope:**
+- \`${REPO}/.claude/commands/**\` — the prompts driving every round. Highest leverage available.
+- \`docs/**\`, \`scripts/**\`, \`.github/workflows/**\`.
+- \`apps/benchmark/src/**\` and \`packages/cli/src/**\` — surgical changes that make the flow FASTER
+  or SMOOTHER **without changing any output**.
+- New developer tooling nothing yet depends on.
+
+**THE HARD INVARIANT — output neutrality, proved mechanically.**
+
+Run the full bench on your branch and diff the regenerated \`results.json\` against \`origin/main\`'s
+committed one, comparing for EVERY row: \`asmlift.{outcome, score, candidateLabel, source}\` and
+\`m2c.{outcome, score, source}\`. **Every one must be identical.** Timings, the provenance stamp and
+\`droppedCandidates\` ordering are the only permitted differences, and you must name which differed.
+A change you cannot prove neutral this way does not ship, however obviously safe it looks.
+
+**OUT of scope — propose in the PR body, never implement:**
+- \`packages/core/**\`, \`apps/benchmark/dataset/**\`, \`packages/bench-schema/**\`,
+  \`apps/benchmark/src/cases/features.ts\`
+- artifacts as an END in themselves (you regenerate them only as the neutrality proof)
+- the other worktrees and \`${REPO}\` itself.
+
+**Measuring speed honestly.** Several workflows share this 10-core box, so wall-clock is noisy and a
+single before/after pair proves nothing. Prefer counting WORK — compiles issued, scoring calls,
+candidates, cache hits, processes spawned — which is deterministic. Report wall-clock too, but say
+what else was running. Never quote a speedup measured once under different load.
+`
+
+const HOUSE = `
+## Hard house rules
+
+- **NEVER \`git stash\`.**
+- \`research/\` is gitignored — never cite a research/ path in a commit, a PR body, or a doc.
+- **Numbers come from commands.** Never state a timing, a count or a behaviour you did not observe.
+- Lint is \`npx eslint apps packages\` (NOT \`pnpm lint\`). \`pnpm format\` before committing.
+- \`source /tmp/wt-env.sh\` in every shell before any harness command, or rows silently SKIP.
+- Never wait with a \`pgrep -f\` pattern matching your own shell; use a log marker.
+- Commit messages end with:
+  \`Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>\`
+  PR bodies end with:
+  \`🤖 Generated with [Claude Code](https://claude.com/claude-code)\`
+`
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings', 'summary', 'ledger_additions'],
+  properties: {
+    summary: { type: 'string' },
+    ledger_additions: { type: 'string', description: 'lines to append to the ledger so the next iteration does not re-derive this pass' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['title', 'evidence', 'proposal', 'expected_payoff', 'scope', 'confidence'],
+        properties: {
+          title: { type: 'string' },
+          evidence: { type: 'string' },
+          proposal: { type: 'string' },
+          expected_payoff: { type: 'string' },
+          scope: { type: 'string', enum: ['in-scope', 'out-of-scope-propose-only'] },
+          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+        },
+      },
+    },
+  },
+}
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['pr_url', 'confirmed', 'rejected', 'report'],
+  properties: {
+    pr_url: { type: 'string' },
+    confirmed: { type: 'array', items: { type: 'string' } },
+    rejected: { type: 'array', items: { type: 'string' } },
+    neutrality_proof: { type: 'string' },
+    report: { type: 'string' },
+  },
+}
+
+const SUPERVISE = (i, lastSha) => `You are the SUPERVISOR (agent 1 of 3). Iteration ${i}.
+You change nothing — you produce findings the implementer will try to kill.
+
+${CONTEXT}
+${SCOPE}
+
+Your incremental window starts at **${lastSha}**.
+
+## What counts as a good finding, ranked
+
+1. **Wall-clock.** The ranked LBG run is the expensive path (now ~21m pooled, was 36m). Where does
+   the remaining time go? Candidate dedup before compiling, cache misses, an objdiff handle rebuilt
+   per call, work repeated across candidates differing in one axis. **Count the work before
+   proposing** — do not guess.
+2. **A recurring correctness trap** a prompt or a fail-loud check would prevent. Several agents have
+   quoted an LBG number without \`--proto\`; one shipped a false compiler premise; one compared a
+   branch against its own artifacts. What is the NEXT one, and what makes it impossible?
+3. **Wasted or duplicated work across agents.**
+4. **Silent degradation** — anywhere the harness continues with a wrong or reduced result.
+5. **Prompt defects** — an instruction demonstrably misread, or missing and supplied by the human.
+
+## What does NOT count
+
+- Anything in the ledger.
+- Any change that could alter a measurement (mark \`out-of-scope-propose-only\`).
+- A speedup you did not measure, or measured once on a contended machine.
+- Style opinions without a named defect.
+
+Return at most **4** findings, best first, plus \`ledger_additions\` summarising what this pass
+established so iteration ${i + 1} need not re-derive it. **An empty findings array is a valid and
+useful result** — say so plainly rather than manufacturing work.
+
+${HOUSE}`
+
+const IMPLEMENT = (i, findings, summary) => `You are the IMPLEMENTER (agent 2 of 3). Iteration ${i}.
+Worktree **/tmp/wt-meta-impl**.
+
+${CONTEXT}
+${SCOPE}
+
+## The supervisor's report
+
+${summary}
+
+## Its findings (JSON)
+
+${JSON.stringify(findings, null, 2)}
+
+## Your job — CHALLENGE FIRST, build only what survives
+
+1. **Verify the cited evidence yourself.** If it does not say what the finding claims — REJECTED.
+2. **Would the proposal really have prevented the problem?** Often the agent had the information
+   and ignored it. Reject those.
+3. **For a speed finding, measure before building.** Count the work on the current code; if the hot
+   path is not where the finding says, reject it.
+4. **Is it worth the churn?** \`.claude/commands\` edits change every future round, and a prompt that
+   grows without bound is itself a defect because agents skim.
+5. **Scope.** Anything out-of-scope goes in the PR body as a proposal, not into the diff.
+
+Then build the survivors:
+- \`cd /tmp/wt-meta-impl && source /tmp/wt-env.sh && git fetch origin && git checkout -B meta/v3-${i} origin/main\`
+- \`pnpm typecheck\`, \`npx vitest run --maxWorkers=3\`, \`npx eslint apps packages\`, \`pnpm format\`.
+- **PROVE OUTPUT NEUTRALITY** exactly as the scope section specifies; put the comparison script and
+  its output in your report. Any difference blocks the change.
+- Commit saying what defect it closes and what proved it. Push, open a PR titled for iteration ${i}.
+
+**If nothing survives, that is correct.** Open no PR, return \`pr_url: ""\`, report what you rejected.
+
+${HOUSE}`
+
+const REVIEW = (i, prUrl, implReport) => `You are the REVIEWER (agent 3 of 3). Iteration ${i}.
+Worktree **/tmp/wt-meta-review**. The implementer opened: **${prUrl}**
+
+${CONTEXT}
+${SCOPE}
+
+## Its report
+
+${implReport}
+
+## Your job — audit, fix, merge
+
+1. Get the branch without fighting the implementer's checkout (a branch lives in one worktree):
+   \`git fetch origin && git checkout -B review/v3-${i} origin/meta/v3-${i}\`; push fixes with
+   \`git push origin HEAD:meta/v3-${i}\`.
+2. **Scope audit — BLOCKING.** Confirm the diff touches nothing owned by the live tracks
+   (\`packages/core/**\`, \`apps/benchmark/dataset/**\`, \`bench-schema\`, \`cases/features.ts\`).
+3. **RE-PROVE OUTPUT NEUTRALITY YOURSELF** — do not take the implementer's word. Full bench on the
+   branch, per-row diff against \`origin/main\`'s committed \`results.json\` on
+   \`asmlift.{outcome,score,candidateLabel,source}\` and \`m2c.{outcome,score,source}\`. Any
+   difference is blocking. This is the most important thing you do: a "harmless" speedup that
+   silently moved one row would poison every measurement the project has.
+4. **Soundness.** General or a patch shaped like one incident? Does a cache key have a correct
+   invalidation story? Does added parallelism introduce output-order nondeterminism something
+   downstream depends on?
+5. **Re-run every gate yourself.** If the change adds a fail-loud check, verify it fires on the bad
+   condition AND does not fire on a clean run — a false-alarming guard stalls every future round.
+6. **Apply fixes yourself** rather than bouncing back; commit, push, say what you changed.
+7. **Merge when CI is green** (poll \`gh pr checks\`, never with a self-matching \`pgrep\`), then
+   \`gh pr merge <n> --squash\`, and **verify main is still green**.
+8. **Refuse to merge** if a blocking finding cannot be fixed soundly. Refusing is a valid outcome.
+
+Return: per finding — sound / fixed / blocking; your OWN neutrality proof; gate results; whether you
+merged; main's post-merge CI state.
+
+${HOUSE}`
+
+const ITERATIONS = 8
+const history = []
+// Start the incremental window at the last merged meta PR; the supervisor discovers it if unset.
+let lastSha = args?.since ?? 'the last merged meta-optimisation commit on origin/main'
+
+for (let i = 1; i <= ITERATIONS; i++) {
+  phase('Supervise')
+  const sup = await agent(SUPERVISE(i, lastSha), { label: `supervise:${i}`, phase: 'Supervise', schema: FINDINGS_SCHEMA })
+  const findings = sup?.findings ?? []
+  log(`iteration ${i}: ${findings.length} finding(s) since ${lastSha}`)
+  if (sup?.ledger_additions) {
+    log(`ledger += ${String(sup.ledger_additions).slice(0, 90)}…`)
+  }
+  if (findings.length === 0) {
+    history.push({ iteration: i, findings: 0, pr: null, note: 'nothing new — no-op iteration' })
+    continue
+  }
+
+  phase('Implement')
+  const impl = await agent(IMPLEMENT(i, findings, sup?.summary ?? ''), { label: `implement:${i}`, phase: 'Implement', schema: IMPL_SCHEMA })
+  if (!impl || !impl.pr_url) {
+    log(`iteration ${i}: nothing survived the challenge — no PR`)
+    history.push({ iteration: i, findings: findings.length, pr: null, rejected: impl?.rejected ?? [] })
+    continue
+  }
+
+  log(`iteration ${i}: PR ${impl.pr_url}`)
+  phase('Review')
+  const rev = await agent(REVIEW(i, impl.pr_url, impl.report ?? ''), { label: `review:${i}`, phase: 'Review' })
+  history.push({ iteration: i, findings: findings.length, confirmed: impl.confirmed ?? [], rejected: impl.rejected ?? [], pr: impl.pr_url, review: rev })
+  lastSha = 'origin/main'
+}
+
+return { iterations: ITERATIONS, history }


### PR DESCRIPTION
The three-agent loop that produced #79, #81, #82 and #84, saved under `.claude/workflows/` so it
can be re-run by name instead of re-authored from scratch.

- **`meta-optimizer-loop.js`** — supervise → challenge-and-build → review-and-merge, looped.
- **`meta-optimizer-ledger.md`** — what has already shipped, which harness traps are fixed, and
  what is known-open.
- **`README.md`** — how to invoke it and what its hard invariant is.

## Why the ledger travels with it

The supervisor originally read `wf_*/journal.jsonl` and the per-agent transcripts. That corpus was
7 workflows at its second iteration and 38 MB across 9 by the time this was written, so every pass
spent more of itself re-deriving history than analysing anything new. The ledger replaces that with
an incremental window, and each iteration returns `ledger_additions` to keep it current.

## What made it worth keeping

The implementer *challenges* before it builds — verify the cited evidence, ask whether the proposal
would really have prevented the failure, weigh the churn against a prompt that agents will skim —
and opens no PR when nothing survives. The reviewer then re-proves output-neutrality itself rather
than trusting the implementer: a full bench, then a per-row diff against `origin/main` on
`asmlift.{outcome,score,candidateLabel,source}` and `m2c.{outcome,score,source}`. That separation
caught a Buffer-concatenation bug in new async code, among five other fixes, in one PR.

Generalised out of the session it grew in: repo-relative ledger path, transcript dir from the
environment, and the incremental window starting from `args.since` rather than a baked-in sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)