### PR TITLE
chore(web): nuqs 2.9.0 → 2.10.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,7 @@
     "echarts": "^5.5.1",
     "echarts-for-react": "^3.0.2",
     "lz-string": "^1.5.0",
-    "nuqs": "^2.9.0",
+    "nuqs": "^2.10.1",
     "objdiff-wasm": "3.7.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       nuqs:
-        specifier: ^2.9.0
-        version: 2.9.0(react@19.2.7)
+        specifier: ^2.10.1
+        version: 2.10.1(react@19.2.7)
       objdiff-wasm:
         specifier: 3.7.0
         version: 3.7.0
@@ -805,8 +805,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
@@ -1591,8 +1591,8 @@ packages:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
-  nuqs@2.9.0:
-    resolution: {integrity: sha512-1ckQBhVHaQYjLZ3kWhhH40A32lPJ7TNTQMa2T+SUvl5azyVt7swCQfUXt9xOXJV3YidWq8VHIHcMzVAJ0knRsw==}
+  nuqs@2.10.1:
+    resolution: {integrity: sha512-7lPZrPJVOsD0VvfQSKtodYBBPGPLsLzkFU8ueYIap9yMMJvSw6UC12p8luA5NW7aKe7AbPHKxcxb3OluH6iAJA==}
     peerDependencies:
       '@remix-run/react': '>=2'
       '@tanstack/react-router': ^1
@@ -2455,7 +2455,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
-  '@standard-schema/spec@1.0.0': {}
+  '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.3.2':
     dependencies:
@@ -3273,9 +3273,9 @@ snapshots:
 
   node-releases@2.0.51: {}
 
-  nuqs@2.9.0(react@19.2.7):
+  nuqs@2.10.1(react@19.2.7):
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       react: 19.2.7
 
   objdiff-wasm@3.7.0: {}


### PR DESCRIPTION
A dependency bump with no behaviour change, verified rather than assumed.

## What was checked

| | 2.9.0 | 2.10.1 |
|---|---|---|
| top-level export list | — | **diffs to nothing** |
| peer-dependency ranges | — | **identical** |
| symbols `apps/web` imports | 7 | all 7 still exported |

The symbols: `useQueryState`, `useQueryStates`, `parseAsString`, `parseAsStringLiteral`, `parseAsArrayOf`, `createParser`, `inferParserType`.

Also compared, because a fragment-based permalink is being weighed separately and it would rest on these:

- `unstable_AdapterInterface` — same six fields
- `nuqs/adapters/custom` — same two exports (`renderQueryString`, `unstable_createAdapterProvider`)
- `URL_MAX_LENGTH` — still `2e3`, with `warnIfURLIsTooLong` still inside `renderQueryString` behind a `NODE_ENV === 'production'` guard
- the key-isolation helper — still internal, not re-exported

So the bump neither helps nor hinders that decision.

## Scope

```
apps/web/package.json |  2 +-
pnpm-lock.yaml        | 18 +++++++++---------
```

The only other lockfile movement is nuqs's own dependency, `@standard-schema/spec` 1.0.0 → 1.1.0.

## Gates

```
pnpm typecheck                                 exit 0
pnpm exec vitest run apps/web/test             15 files / 88 tests passed
cd apps/web && pnpm run check-deps             no violations (98 modules, 202 dependencies)
cd apps/web && VITE_BASE_URL=/asmlift/ build   built in 4.89s; dist/index.html present
pnpm lint                                      0 errors, 109 pre-existing warnings
pnpm format:check                              clean
```

**No `pnpm bench run`.** nuqs is an `apps/web` dependency and nothing under `packages/` or `apps/benchmark/` changes, so no benchmark row can move and the artifact is untouched — running it would be ~20 minutes of machine time proving that.