### PR TITLE
A long run and a hung run looked identical: the ranking bar, its five phases, and the 117,760 candidates the browser cannot finish

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -21,6 +21,25 @@ body {
   background-attachment: fixed;
 }
 
+/* The ranking bar's INDETERMINATE stripe (RankPanel.tsx). A stripe that TRAVELS is what reads as
+   "an unknown amount of work"; a parked one reads as a percentage — Tailwind's `animate-pulse`
+   animates opacity only, so the previous spelling was pixel-identical to a determinate 33 % bar for
+   the whole of a 62 s enumeration. Applied through the `motion-safe:` variant ONLY: under
+   prefers-reduced-motion the element is not rendered at all rather than parked, so the reduced
+   state is an empty track, never a fill implying a fraction. */
+@theme {
+  --animate-rank-indeterminate: rank-indeterminate 1.4s ease-in-out infinite;
+
+  @keyframes rank-indeterminate {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(300%);
+    }
+  }
+}
+
 /* Slim slate scrollbars, app-wide (the family baseline) + the .scroll-slim opt-in. */
 ::-webkit-scrollbar,
 .scroll-slim::-webkit-scrollbar {

--- a/apps/web/src/pages/playground/RankPanel.tsx
+++ b/apps/web/src/pages/playground/RankPanel.tsx
@@ -7,7 +7,7 @@
 //    score, best first, plus the declarations asmlift refused to synthesize.
 import { renderDeclarations } from '@asmlift/core/declare';
 
-import { progressBar, progressLabel } from './rank-progress';
+import { progressBar, progressLabel } from './progress-view';
 import type { RefusedDeclaration } from './score-wasm';
 import type { Ranking } from './useRanking';
 

--- a/apps/web/src/pages/playground/RankPanel.tsx
+++ b/apps/web/src/pages/playground/RankPanel.tsx
@@ -35,39 +35,57 @@ export function RankBadge({ ranking }: { ranking: Ranking }) {
   const base = 'rounded-md px-2.5 py-1 text-[11px] font-medium';
   if (ranking.status === 'loading') {
     // A REAL progressbar, and only as determinate as the run actually is. The candidate total does
-    // not exist until `enumerateCandidates` returns — 62.3 s of one measured run — so three of the
-    // four phases render with `aria-valuenow` OMITTED, which is the ARIA spelling of
+    // not exist until `enumerateCandidates` returns — 62.3 s of one measured run — so four of the
+    // five phases render with `aria-valuenow` OMITTED, which is the ARIA spelling of
     // indeterminate; an invented 0 would not be. The phase sentence is visible text either way, so
     // this is never LESS informative than the bare div it replaces.
+    //
+    // THE SENTENCE IS A SIBLING OF THE PROGRESSBAR, NOT ITS CHILD. `progressbar` is a
+    // children-presentational role: everything inside it is pruned from the accessibility tree, so
+    // the visible label was being announced by nobody. Outside it, it stays readable text for AT
+    // that ignores `aria-valuetext`. `aria-label` names the widget itself — a `role=` with no
+    // accessible name announces as an unnamed progress bar, and it is the idiom the rest of this
+    // app already follows (MultiSelect pairs every role with an aria-label).
     //
     // No `aria-live`: a ~10 Hz live region is a screen-reader flood. `role="progressbar"` plus
     // `aria-valuetext` is the accessible channel.
     const bar = progressBar(ranking);
     return (
       <div className={`${base} border border-slate-700 bg-slate-900/60 text-slate-400`}>
+        <span>{bar.label}</span>
         <div
           role="progressbar"
+          aria-label="candidate ranking"
           aria-valuetext={bar.label}
           aria-valuemin={bar.determinate ? 0 : undefined}
           aria-valuemax={bar.determinate ? bar.valueMax : undefined}
           aria-valuenow={bar.determinate ? bar.valueNow : undefined}
+          className="mt-1 h-1 overflow-hidden rounded bg-slate-800"
         >
-          <span>{bar.label}</span>
-          <div className="mt-1 h-1 overflow-hidden rounded bg-slate-800">
-            {bar.determinate ? (
-              // `bar.pct` is clamped to 99 while `aria-valuenow` above stays EXACT: the last
-              // scoring tick is followed by the sort and a six-figure structured clone, and a full
-              // bar over that is the lie a bar most easily tells. The phase then changes to
-              // `ranking` and this element falls back to the indeterminate stripe — a visible
-              // change of character rather than a bar sitting full.
-              <div
-                className="h-full rounded bg-teal-500 transition-[width] duration-200"
-                style={{ width: `${bar.pct}%` }}
-              />
-            ) : (
-              <div className="h-full w-1/3 animate-pulse rounded bg-slate-600" />
-            )}
-          </div>
+          {bar.determinate ? (
+            // `bar.pct` is clamped to 99 while `aria-valuenow` above stays EXACT: the last scoring
+            // tick is followed by the sort and a six-figure structured clone, and a full bar over
+            // that is the lie a bar most easily tells. The phase then changes to `ranking` and this
+            // falls back to the indeterminate stripe.
+            <div
+              className="h-full rounded bg-teal-500 motion-safe:transition-[width] motion-safe:duration-200"
+              style={{ width: `${bar.pct}%` }}
+            />
+          ) : (
+            // INDETERMINATE = a stripe that TRAVELS, or nothing at all. It used to be
+            // `w-1/3 animate-pulse`: `animate-pulse` animates opacity only, so the stripe parked at
+            // one third of the track and gently faded — pixel-identical to a determinate 33 % bar,
+            // and shown for the whole 62 s enumeration, which is the entire wait anyone has
+            // actually watched. That is precisely the precision the phase does not have. Travel
+            // reads as "unknown"; parked reads as a number.
+            //
+            // Under `prefers-reduced-motion` there is no travel to substitute for, so the fill is
+            // simply not rendered — an empty track plus the sentence, which is LESS wrong than a
+            // static third. This is the app's only animation and it is the only place that has to
+            // answer the reduced-motion question; the determinate width transition above is gated
+            // the same way.
+            <div className="hidden h-full w-1/3 rounded bg-slate-600 motion-safe:block motion-safe:animate-rank-indeterminate" />
+          )}
         </div>
       </div>
     );

--- a/apps/web/src/pages/playground/RankPanel.tsx
+++ b/apps/web/src/pages/playground/RankPanel.tsx
@@ -34,21 +34,18 @@ export function RankBadge({ ranking }: { ranking: Ranking }) {
 
   const base = 'rounded-md px-2.5 py-1 text-[11px] font-medium';
   if (ranking.status === 'loading') {
-    // A REAL progressbar, and only as determinate as the run actually is. The candidate total does
-    // not exist until `enumerateCandidates` returns — 62.3 s of one run measured 2026-08-30 — so four of the
-    // five phases render with `aria-valuenow` OMITTED, which is the ARIA spelling of
-    // indeterminate; an invented 0 would not be. The phase sentence is visible text either way, so
-    // this is never LESS informative than the bare div it replaces.
+    // A REAL progressbar, and only as determinate as the run actually is: the candidate total does
+    // not exist until `enumerateCandidates` returns (62.3 s on one measured run, 2026-08-30), so
+    // four of the five phases render with `aria-valuenow` OMITTED — the ARIA spelling of
+    // indeterminate, which an invented 0 would not be.
     //
     // THE SENTENCE IS A SIBLING OF THE PROGRESSBAR, NOT ITS CHILD. `progressbar` is a
     // children-presentational role: everything inside it is pruned from the accessibility tree, so
-    // the visible label was being announced by nobody. Outside it, it stays readable text for AT
-    // that ignores `aria-valuetext`. `aria-label` names the widget itself — a `role=` with no
-    // accessible name announces as an unnamed progress bar, and it is the idiom the rest of this
-    // app already follows (MultiSelect pairs every role with an aria-label).
-    //
-    // No `aria-live`: a ~10 Hz live region is a screen-reader flood. `role="progressbar"` plus
-    // `aria-valuetext` is the accessible channel.
+    // a label placed there is announced by nobody. Outside it, it stays readable text for AT that
+    // ignores `aria-valuetext`. `aria-label` names the widget itself — a `role=` with no accessible
+    // name announces as an unnamed progress bar — and it is the idiom the rest of this app follows
+    // (MultiSelect pairs every role with an aria-label). No `aria-live`: a ~10 Hz live region is a
+    // screen-reader flood, and `role="progressbar"` plus `aria-valuetext` is the channel.
     const bar = progressBar(ranking);
     return (
       <div className={`${base} border border-slate-700 bg-slate-900/60 text-slate-400`}>
@@ -63,27 +60,25 @@ export function RankBadge({ ranking }: { ranking: Ranking }) {
           className="mt-1 h-1 overflow-hidden rounded bg-slate-800"
         >
           {bar.determinate ? (
-            // `bar.pct` is clamped to 99 while `aria-valuenow` above stays EXACT: the last scoring
-            // tick is followed by the sort and a six-figure structured clone, and a full bar over
-            // that is the lie a bar most easily tells. The phase then changes to `ranking` and this
+            // `bar.pct` is clamped to 99 while `aria-valuenow` stays EXACT: the last scoring tick
+            // is followed by the sort and a six-figure structured clone, and a full bar over that
+            // is the lie a bar most easily tells. The phase then changes to `ranking` and this
             // falls back to the indeterminate stripe.
             <div
               className="h-full rounded bg-teal-500 motion-safe:transition-[width] motion-safe:duration-200"
               style={{ width: `${bar.pct}%` }}
             />
           ) : (
-            // INDETERMINATE = a stripe that TRAVELS, or nothing at all. It used to be
-            // `w-1/3 animate-pulse`: `animate-pulse` animates opacity only, so the stripe parked at
-            // one third of the track and gently faded — pixel-identical to a determinate 33 % bar,
-            // and shown for the whole 62 s enumeration, which is the entire wait anyone has
-            // actually watched. That is precisely the precision the phase does not have. Travel
-            // reads as "unknown"; parked reads as a number.
+            // INDETERMINATE = a stripe that TRAVELS, or nothing at all. Not `animate-pulse`: it
+            // animates opacity only, so the stripe parks at one third of the track and fades —
+            // pixel-identical to a determinate 33 % bar, for the whole 62 s enumeration, claiming
+            // a precision the phase does not have. Travel reads as "unknown"; parked reads as a
+            // number.
             //
             // Under `prefers-reduced-motion` there is no travel to substitute for, so the fill is
-            // simply not rendered — an empty track plus the sentence, which is LESS wrong than a
-            // static third. This is the app's only animation and it is the only place that has to
-            // answer the reduced-motion question; the determinate width transition above is gated
-            // the same way.
+            // simply not rendered — an empty track plus the sentence, which is less wrong than a
+            // static third. This is the app's only animation; the determinate width transition is
+            // gated the same way.
             <div className="hidden h-full w-1/3 rounded bg-slate-600 motion-safe:block motion-safe:animate-rank-indeterminate" />
           )}
         </div>

--- a/apps/web/src/pages/playground/RankPanel.tsx
+++ b/apps/web/src/pages/playground/RankPanel.tsx
@@ -7,6 +7,7 @@
 //    score, best first, plus the declarations asmlift refused to synthesize.
 import { renderDeclarations } from '@asmlift/core/declare';
 
+import { progressBar, progressLabel } from './rank-progress';
 import type { RefusedDeclaration } from './score-wasm';
 import type { Ranking } from './useRanking';
 
@@ -33,9 +34,41 @@ export function RankBadge({ ranking }: { ranking: Ranking }) {
 
   const base = 'rounded-md px-2.5 py-1 text-[11px] font-medium';
   if (ranking.status === 'loading') {
+    // A REAL progressbar, and only as determinate as the run actually is. The candidate total does
+    // not exist until `enumerateCandidates` returns — 62.3 s of one measured run — so three of the
+    // four phases render with `aria-valuenow` OMITTED, which is the ARIA spelling of
+    // indeterminate; an invented 0 would not be. The phase sentence is visible text either way, so
+    // this is never LESS informative than the bare div it replaces.
+    //
+    // No `aria-live`: a ~10 Hz live region is a screen-reader flood. `role="progressbar"` plus
+    // `aria-valuetext` is the accessible channel.
+    const bar = progressBar(ranking);
     return (
       <div className={`${base} border border-slate-700 bg-slate-900/60 text-slate-400`}>
-        scoring candidates with agbcc + objdiff…
+        <div
+          role="progressbar"
+          aria-valuetext={bar.label}
+          aria-valuemin={bar.determinate ? 0 : undefined}
+          aria-valuemax={bar.valueMax}
+          aria-valuenow={bar.valueNow}
+        >
+          <span>{bar.label}</span>
+          <div className="mt-1 h-1 overflow-hidden rounded bg-slate-800">
+            {bar.determinate ? (
+              // `bar.pct` is clamped to 99 while `aria-valuenow` above stays EXACT: the last
+              // scoring tick is followed by the sort and a six-figure structured clone, and a full
+              // bar over that is the lie a bar most easily tells. The phase then changes to
+              // `ranking` and this element falls back to the indeterminate stripe — a visible
+              // change of character rather than a bar sitting full.
+              <div
+                className="h-full rounded bg-teal-500 transition-[width] duration-200"
+                style={{ width: `${bar.pct}%` }}
+              />
+            ) : (
+              <div className="h-full w-1/3 animate-pulse rounded bg-slate-600" />
+            )}
+          </div>
+        </div>
       </div>
     );
   }
@@ -117,7 +150,9 @@ export function RankCandidates({ ranking }: { ranking: Ranking }) {
     );
   }
   if (ranking.status === 'loading') {
-    return <p className="pt-1 text-[11px] italic text-slate-500">scoring candidates with agbcc + objdiff…</p>;
+    // The SAME sentence the badge shows, from the same helper — two views that spell the phase
+    // themselves are two views that come to disagree about one run.
+    return <p className="pt-1 text-[11px] italic text-slate-500">{progressLabel(ranking)}</p>;
   }
   if (ranking.status === 'error') {
     return (

--- a/apps/web/src/pages/playground/RankPanel.tsx
+++ b/apps/web/src/pages/playground/RankPanel.tsx
@@ -35,7 +35,7 @@ export function RankBadge({ ranking }: { ranking: Ranking }) {
   const base = 'rounded-md px-2.5 py-1 text-[11px] font-medium';
   if (ranking.status === 'loading') {
     // A REAL progressbar, and only as determinate as the run actually is. The candidate total does
-    // not exist until `enumerateCandidates` returns — 62.3 s of one measured run — so four of the
+    // not exist until `enumerateCandidates` returns — 62.3 s of one run measured 2026-08-30 — so four of the
     // five phases render with `aria-valuenow` OMITTED, which is the ARIA spelling of
     // indeterminate; an invented 0 would not be. The phase sentence is visible text either way, so
     // this is never LESS informative than the bare div it replaces.

--- a/apps/web/src/pages/playground/RankPanel.tsx
+++ b/apps/web/src/pages/playground/RankPanel.tsx
@@ -49,8 +49,8 @@ export function RankBadge({ ranking }: { ranking: Ranking }) {
           role="progressbar"
           aria-valuetext={bar.label}
           aria-valuemin={bar.determinate ? 0 : undefined}
-          aria-valuemax={bar.valueMax}
-          aria-valuenow={bar.valueNow}
+          aria-valuemax={bar.determinate ? bar.valueMax : undefined}
+          aria-valuenow={bar.determinate ? bar.valueNow : undefined}
         >
           <span>{bar.label}</span>
           <div className="mt-1 h-1 overflow-hidden rounded bg-slate-800">

--- a/apps/web/src/pages/playground/progress-view.ts
+++ b/apps/web/src/pages/playground/progress-view.ts
@@ -10,11 +10,12 @@
 //    structured clone and the render still run, while `aria-valuenow` keeps the TRUE count.
 import type { RankPhase, RankProgress } from './rank-progress';
 
-const PHASE_TEXT: Record<RankPhase, string> = {
+// `scoring` has no entry: it is the one phase that cannot be spelled without its counts, so
+// `progressLabel` returns before reaching this table and a sentence here would be unreachable.
+const PHASE_TEXT: Record<Exclude<RankPhase, 'scoring'>, string> = {
   queued: 'waiting for the ranking worker…',
   assembling: 'assembling the target asm…',
   enumerating: 'enumerating candidate spellings…',
-  scoring: 'scoring candidates with agbcc + objdiff…',
   ranking: 'ranking scored candidates…',
 };
 
@@ -28,8 +29,8 @@ export function progressLabel(p: RankProgress): string {
 }
 
 /** The bar's props, also discriminated: `pct`/`valueNow`/`valueMax` exist ONLY on the determinate
- *  arm. They used to be optional fields the indeterminate arm filled with `pct: 0` — a number no
- *  caller read, and the exact "0 % of an unknown denominator" this module's header forbids. */
+ *  arm. As optional fields, the indeterminate arm would carry a `pct: 0` — the exact "0 % of an
+ *  unknown denominator" this module's header forbids, one careless reader away from being drawn. */
 export type RankProgressBar =
   | { determinate: false; label: string }
   | {

--- a/apps/web/src/pages/playground/progress-view.ts
+++ b/apps/web/src/pages/playground/progress-view.ts
@@ -1,0 +1,56 @@
+// asmlift webapp — the ranking progress VIEW: the one sentence the UI shows for a phase, and the
+// bar geometry it renders. Split out of rank-progress.ts (the phase model + the transport throttle)
+// so the compute driver's import graph does not reach user-facing copy: score-wasm.ts and
+// rank.worker.ts import the MODEL, RankPanel.tsx imports this. Same testability — both halves are
+// plain functions outside the `agbcc` import — with the altitudes no longer fused.
+//
+// The rules here are honesty rules, not styling ones:
+//  • a determinate bar exists ONLY while scoring with a real, non-zero total;
+//  • the fill is clamped below 100 so the pixels never read "finished" while the sort, the
+//    structured clone and the render still run, while `aria-valuenow` keeps the TRUE count.
+import type { RankPhase, RankProgress } from './rank-progress';
+
+const PHASE_TEXT: Record<RankPhase, string> = {
+  queued: 'waiting for the ranking worker…',
+  assembling: 'assembling the target asm…',
+  enumerating: 'enumerating candidate spellings…',
+  scoring: 'scoring candidates with agbcc + objdiff…',
+  ranking: 'ranking scored candidates…',
+};
+
+/** The one sentence both the badge and the Pipeline card show, so they cannot disagree about what
+ *  the run is doing. Determinate only when a REAL total is in hand. */
+export function progressLabel(p: RankProgress): string {
+  if (p.phase === 'scoring') {
+    return `scoring ${p.done.toLocaleString()} / ${p.total.toLocaleString()} candidates`;
+  }
+  return PHASE_TEXT[p.phase];
+}
+
+/** The bar's props, also discriminated: `pct`/`valueNow`/`valueMax` exist ONLY on the determinate
+ *  arm. They used to be optional fields the indeterminate arm filled with `pct: 0` — a number no
+ *  caller read, and the exact "0 % of an unknown denominator" this module's header forbids. */
+export type RankProgressBar =
+  | { determinate: false; label: string }
+  | {
+      determinate: true;
+      /** the EXACT count for `aria-valuenow` (the fill is clamped, this is not). */
+      valueNow: number;
+      valueMax: number;
+      /** the fill WIDTH in percent, clamped to 99 so a full bar never sits over unfinished work. */
+      pct: number;
+      label: string;
+    };
+
+export function progressBar(p: RankProgress): RankProgressBar {
+  const label = progressLabel(p);
+  // A ZERO total is a real emission — an enumeration that produced nothing, which then throws
+  // `no scorable candidate` — and it is NOT determinate: ARIA requires `aria-valuemax` to exceed
+  // `aria-valuemin`, so equal bounds leave the AT-computed percentage undefined. 0/0 has no
+  // percentage on either channel; the label still carries the true counts.
+  if (p.phase !== 'scoring' || p.total === 0) {
+    return { determinate: false, label };
+  }
+  const pct = Math.min(99, Math.round((100 * p.done) / p.total));
+  return { determinate: true, valueNow: p.done, valueMax: p.total, pct, label };
+}

--- a/apps/web/src/pages/playground/rank-progress.ts
+++ b/apps/web/src/pages/playground/rank-progress.ts
@@ -1,0 +1,102 @@
+// asmlift webapp — the ranking PROGRESS model: the phases a browser ranking passes through, the
+// emission throttle, and the pure props the UI renders a bar from.
+//
+// WHY IT IS ITS OWN MODULE. Two reasons, both load-bearing. (1) score-wasm.ts imports the `agbcc`
+// package, which cannot be imported under vitest (candidate-compile.test.ts's header documents
+// why), and apps/web has no jsdom — so anything that needs a test has to be a plain function
+// outside both. (2) The throttle and the labels are shared by the worker driver and by two views
+// (RankBadge, RankCandidates); one copy is how they cannot drift into saying different things
+// about the same run.
+//
+// THE HONESTY RULES THIS FILE ENCODES:
+//  • The total does not exist until `enumerateCandidates` has returned, so three of the four
+//    phases are INDETERMINATE and carry no number at all. No estimate, no "0 %" of an unknown
+//    denominator — a fabricated total is a lie the user cannot check.
+//  • A determinate bar is rendered ONLY while scoring, and the scoring phase ends by moving to
+//    `ranking`, not by sitting at done === total. The fill is additionally clamped below 100 so
+//    the pixels never read "finished" while the sort + structured clone + render still run;
+//    `aria-valuenow` keeps the TRUE count, so assistive tech gets the exact number.
+
+/** The four phases of `rankCandidatesInBrowser`, in the order they run. Only `scoring` is
+ *  determinate. `assembling` runs FIRST (it is milliseconds, and it is the phase that fails on a
+ *  pret-dialect `.s`); `enumerating` is synchronous inside core and cannot be subdivided, so it
+ *  gets a name and no number. */
+export type RankPhase = 'assembling' | 'enumerating' | 'scoring' | 'ranking';
+
+/** One progress observation. `done`/`total` exist only once the candidate array does. */
+export interface RankProgress {
+  phase: RankPhase;
+  done?: number;
+  total?: number;
+}
+
+const PHASE_TEXT: Record<RankPhase, string> = {
+  assembling: 'assembling the target asm…',
+  enumerating: 'enumerating candidate spellings…',
+  scoring: 'scoring candidates with agbcc + objdiff…',
+  ranking: 'ranking scored candidates…',
+};
+
+/** The one sentence both the badge and the Pipeline card show, so they cannot disagree about what
+ *  the run is doing. Determinate only when a REAL total is in hand. */
+export function progressLabel(p: RankProgress): string {
+  if (p.phase === 'scoring' && p.total !== undefined && p.done !== undefined) {
+    return `scoring ${p.done.toLocaleString()} / ${p.total.toLocaleString()} candidates`;
+  }
+  return PHASE_TEXT[p.phase];
+}
+
+export interface RankProgressBar {
+  /** true ⇔ a real total exists ⇔ the bar may show a fill and an `aria-valuenow`. */
+  determinate: boolean;
+  /** the EXACT count for `aria-valuenow`; omitted while indeterminate (that omission is the ARIA
+   *  spelling of "indeterminate" — an invented 0 would not be). */
+  valueNow?: number;
+  valueMax?: number;
+  /** the fill WIDTH in percent, clamped to 99 so a full bar never sits over unfinished work. */
+  pct: number;
+  label: string;
+}
+
+export function progressBar(p: RankProgress): RankProgressBar {
+  const label = progressLabel(p);
+  if (p.phase !== 'scoring' || p.total === undefined || p.done === undefined) {
+    return { determinate: false, pct: 0, label };
+  }
+  const pct = p.total > 0 ? Math.min(99, Math.round((100 * p.done) / p.total)) : 0;
+  return { determinate: true, valueNow: p.done, valueMax: p.total, pct, label };
+}
+
+/** Wrap an emitter so it posts at most once per `intervalMs` of WALL TIME.
+ *
+ *  WHY A THROTTLE AT ALL: one real function enumerates 117,760 candidates in the browser (measured;
+ *  the CLI's number for the same function, WITH a symbol map, is 66,816). A postMessage per
+ *  candidate would flood the main thread the worker exists to protect.
+ *
+ *  WHY THE CLOCK AND NOT A COUNT: per-candidate cost on that same fan was measured between 25 ms
+ *  and 167 ms, so "every 64th candidate" posts at wildly different rates per function, while a
+ *  100 ms clock bounds the rate whatever the shape.
+ *
+ *  TWO EXEMPTIONS, both about not lying:
+ *   • a PHASE CHANGE is never suppressed — a swallowed one leaves the bar showing a stale phase
+ *     for the whole tail;
+ *   • the FINAL tick of a determinate phase (`done === total`) is never suppressed — a bar that
+ *     stops at 41,318 / 117,760 and then jumps to another phase reads as work that was skipped.
+ *  The first tick of any phase is emitted immediately, so the count appears at once. */
+export function throttleProgress(
+  emit: (p: RankProgress) => void,
+  now: () => number = () => performance.now(),
+  intervalMs = 100,
+): (p: RankProgress) => void {
+  let lastPhase: RankPhase | null = null;
+  let lastAt = 0;
+  return (p) => {
+    const final = p.total !== undefined && p.done === p.total;
+    if (p.phase === lastPhase && !final && now() - lastAt < intervalMs) {
+      return;
+    }
+    lastPhase = p.phase;
+    lastAt = now();
+    emit(p);
+  };
+}

--- a/apps/web/src/pages/playground/rank-progress.ts
+++ b/apps/web/src/pages/playground/rank-progress.ts
@@ -70,3 +70,26 @@ export function throttleProgress(
     emit(p);
   };
 }
+
+/** Wrap a poster so it goes silent once `isCurrent()` stops holding — the RATE half of the
+ *  stale-guard, and only the rate half.
+ *
+ *  `self.onmessage` is async, so a second request is dequeued at the first `await` of the first and
+ *  the two runs interleave: a superseded run keeps scoring, and keeps emitting, for the rest of its
+ *  natural life. Measured (2026-08-30): bumping the reqId 9.9 s into an 800-candidate run left the
+ *  abandoned run posting 286 further ticks over 78 s, every one waking the main thread to be thrown
+ *  away. The throttle bounds ONE run to ~10 msg/s; nothing bounded the number of live superseded
+ *  runs, so the aggregate rate scaled with edits-during-a-run.
+ *
+ *  This may only ever DROP. The H1 stale-guard stays on the main thread as the sole authority over
+ *  what is DISPLAYED (`applyRankMessage`), and dropping more here cannot route around it: the
+ *  worker learns of a new id only from the message the main thread posted after adopting it, so
+ *  everything suppressed here would have been dropped there. */
+export function whileCurrent(isCurrent: () => boolean, post: (p: RankProgress) => void): (p: RankProgress) => void {
+  return (p) => {
+    if (!isCurrent()) {
+      return;
+    }
+    post(p);
+  };
+}

--- a/apps/web/src/pages/playground/rank-progress.ts
+++ b/apps/web/src/pages/playground/rank-progress.ts
@@ -1,67 +1,65 @@
 // asmlift webapp — the ranking PROGRESS model: the phases a browser ranking passes through, and
 // the emission throttle that bounds how often they cross a postMessage boundary. The SENTENCES and
 // the bar geometry are one altitude up, in progress-view.ts — the driver that emits progress must
-// not have to reach through the UI's copy to do it.
+// not have to reach through the UI's copy to do it. It is its own module rather than part of
+// score-wasm.ts because score-wasm.ts imports the `agbcc` package, which cannot be imported under
+// vitest (candidate-compile.test.ts's header documents why), and apps/web has no jsdom.
 //
-// WHY IT IS ITS OWN MODULE rather than living in score-wasm.ts: score-wasm.ts imports the `agbcc`
-// package, which cannot be imported under vitest (candidate-compile.test.ts's header documents
-// why), and apps/web has no jsdom — so anything that needs a test has to be a plain function
-// outside both.
-//
-// THE HONESTY RULE THIS FILE ENCODES: the total does not exist until `enumerateCandidates` has
+// THE HONESTY RULE THESE TYPES ENCODE: the total does not exist until `enumerateCandidates` has
 // returned, so four of the five phases are INDETERMINATE and carry no number at all — no estimate,
 // no "0 %" of an unknown denominator. A fabricated total is a lie the user cannot check, and the
-// type below makes one unspellable rather than merely discouraged.
+// union below makes one unspellable rather than merely discouraged.
 
 /** The phases a ranking passes through, in the order they run. Only `scoring` is determinate.
  *
- *  `queued` is the one phase the WORKER NEVER EMITS — it is what the main thread knows between
- *  `postMessage` and the worker's first tick, and it is a real state rather than a formality: the
- *  worker is single-threaded and `enumerateCandidates` is synchronous, so a request posted while a
- *  superseded run is still enumerating cannot even be DEQUEUED for the length of that enumeration
- *  (62.3 s on one measured run, 2026-08-30). Calling that `assembling` would assert work that has
- *  not started — the badge asserting a phase nobody observed is the same class of lie as a
- *  fabricated total, so it gets its own name.
+ *  `queued` is the one phase the WORKER NEVER EMITS: it is what the main thread knows between
+ *  `postMessage` and the first tick, and it is a real wait, not a formality — the worker is
+ *  single-threaded and `enumerateCandidates` is synchronous, so a request posted while a superseded
+ *  run is still enumerating cannot even be DEQUEUED for the length of it (62.3 s on one measured
+ *  run, 2026-08-30). Naming that `assembling` would assert work nobody has observed, the same class
+ *  of lie as a fabricated total.
  *
- *  `assembling` then runs FIRST inside the worker (it is milliseconds, and it is the phase that
- *  fails on a pret-dialect `.s`); `enumerating` is synchronous inside core and cannot be
- *  subdivided, so it gets a name and no number. */
+ *  `assembling` runs first inside the worker (milliseconds, and the phase that fails on a
+ *  pret-dialect `.s`); `enumerating` is synchronous inside core and cannot be subdivided, so it
+ *  gets a name and no number. */
 export type RankPhase = 'queued' | 'assembling' | 'enumerating' | 'scoring' | 'ranking';
 
 /** One progress observation, DISCRIMINATED on the phase: `done`/`total` exist if and only if the
- *  phase is `scoring`, because the candidate array is what mints them. As two optional fields on
- *  one shape the type admitted four states no emitter can produce (`enumerating` with a count,
- *  `scoring` with only a `done`, …), each of which then needed a defensive branch in the view and
- *  a test asserting an unreachable state; as a union there is nothing to defend against. */
-export type RankProgress =
-  | { phase: Exclude<RankPhase, 'scoring'>; done?: undefined; total?: undefined }
+ *  phase is `scoring`, because the candidate array is what mints them. Two optional fields on one
+ *  shape would admit four states no emitter can produce (`enumerating` with a count, `scoring` with
+ *  only a `done`, …), each needing a defensive branch in the view; a union has nothing to defend.
+ *
+ *  `EmittedProgress` is the same model minus `queued`, and the whole emitter chain — the driver's
+ *  `onProgress`, the throttle, the poster, the wire type — is typed on IT, so the phase the worker
+ *  cannot observe cannot be posted. The VIEW takes `RankProgress`, because the main thread's own
+ *  `queued` is a real thing to render. */
+export type EmittedProgress =
+  | { phase: Exclude<RankPhase, 'scoring' | 'queued'>; done?: undefined; total?: undefined }
   | { phase: 'scoring'; done: number; total: number };
+export type RankProgress = EmittedProgress | { phase: 'queued'; done?: undefined; total?: undefined };
 
-/** Wrap an emitter so it posts at most once per `intervalMs` of WALL TIME.
+/** Wrap an emitter so it posts at most once per `intervalMs` of WALL TIME. (Every number here is
+ *  one machine on 2026-08-30, not a property of the code: the argument is durable, the numbers rot.)
  *
- *  EVERY NUMBER BELOW IS ONE MACHINE'S MEASUREMENT ON 2026-08-30, not a property of the code — it
- *  is the ARGUMENT that is durable, and the numbers will rot.
- *
- *  WHY A THROTTLE AT ALL: one real function enumerates 117,760 candidates in the browser (measured;
- *  the CLI's number for the same function, WITH a symbol map, is 66,816). A postMessage per
- *  candidate would flood the main thread the worker exists to protect.
+ *  WHY A THROTTLE AT ALL: one real function enumerates 117,760 candidates in the browser (the CLI's
+ *  number for the same function, WITH a symbol map, is 66,816), and a postMessage per candidate
+ *  would flood the main thread the worker exists to protect.
  *
  *  WHY THE CLOCK AND NOT A COUNT: per-candidate cost on that same fan was measured between 25 ms
  *  and 167 ms, so "every 64th candidate" posts at wildly different rates per function, while a
  *  100 ms clock bounds the rate whatever the shape.
  *
- *  TWO EXEMPTIONS, both about not lying:
- *   • a PHASE CHANGE is never suppressed — a swallowed one leaves the bar showing a stale phase
- *     for the whole tail;
- *   • the FINAL tick of a determinate phase (`done === total`) is never suppressed — a bar that
- *     stops at 41,318 / 117,760 and then jumps to another phase reads as work that was skipped.
- *  The first tick of any phase is emitted immediately, so the count appears at once. */
+ *  TWO EXEMPTIONS, both about not lying: a PHASE CHANGE is never suppressed (a swallowed one leaves
+ *  the bar on a stale phase for the whole tail), and neither is the FINAL tick of a determinate
+ *  phase (`done === total`) — a bar that stops at 41,318 / 117,760 and then jumps to another phase
+ *  reads as work that was skipped. The first tick of a phase is emitted at once, so the count
+ *  appears immediately. */
 export function throttleProgress(
-  emit: (p: RankProgress) => void,
+  emit: (p: EmittedProgress) => void,
   now: () => number = () => performance.now(),
   intervalMs = 100,
-): (p: RankProgress) => void {
-  let lastPhase: RankPhase | null = null;
+): (p: EmittedProgress) => void {
+  let lastPhase: EmittedProgress['phase'] | null = null;
   let lastAt = 0;
   return (p) => {
     const final = p.total !== undefined && p.done === p.total;
@@ -77,18 +75,22 @@ export function throttleProgress(
 /** Wrap a poster so it goes silent once `isCurrent()` stops holding — the RATE half of the
  *  stale-guard, and only the rate half.
  *
- *  `self.onmessage` is async, so a second request is dequeued at the first `await` of the first and
- *  the two runs interleave: a superseded run keeps scoring, and keeps emitting, for the rest of its
- *  natural life. Measured (2026-08-30): bumping the reqId 9.9 s into an 800-candidate run left the
- *  abandoned run posting 286 further ticks over 78 s, every one waking the main thread to be thrown
- *  away. The throttle bounds ONE run to ~10 msg/s; nothing bounded the number of live superseded
- *  runs, so the aggregate rate scaled with edits-during-a-run.
+ *  `self.onmessage` is async, so a second message is dequeued at the first `await` of the first and
+ *  two runs interleave: a superseded run keeps scoring, and keeps emitting, for the rest of its
+ *  natural life. Measured 2026-08-30, bumping the reqId 9.9 s into an 800-candidate run: 286
+ *  further ticks over 78 s, every one waking the main thread to be thrown away. The throttle bounds
+ *  ONE run to ~10 msg/s; nothing bounded the number of live superseded runs, so the aggregate rate
+ *  scaled with edits-during-a-run.
  *
  *  This may only ever DROP. The H1 stale-guard stays on the main thread as the sole authority over
  *  what is DISPLAYED (`applyRankMessage`), and dropping more here cannot route around it: the
- *  worker learns of a new id only from the message the main thread posted after adopting it, so
+ *  worker learns of a new id only from a message the main thread posted after adopting it — a
+ *  request, or the `supersede` it posts when it abandons ranking without asking for anything — so
  *  everything suppressed here would have been dropped there. */
-export function whileCurrent(isCurrent: () => boolean, post: (p: RankProgress) => void): (p: RankProgress) => void {
+export function whileCurrent(
+  isCurrent: () => boolean,
+  post: (p: EmittedProgress) => void,
+): (p: EmittedProgress) => void {
   return (p) => {
     if (!isCurrent()) {
       return;

--- a/apps/web/src/pages/playground/rank-progress.ts
+++ b/apps/web/src/pages/playground/rank-progress.ts
@@ -1,21 +1,17 @@
-// asmlift webapp — the ranking PROGRESS model: the phases a browser ranking passes through, the
-// emission throttle, and the pure props the UI renders a bar from.
+// asmlift webapp — the ranking PROGRESS model: the phases a browser ranking passes through, and
+// the emission throttle that bounds how often they cross a postMessage boundary. The SENTENCES and
+// the bar geometry are one altitude up, in progress-view.ts — the driver that emits progress must
+// not have to reach through the UI's copy to do it.
 //
-// WHY IT IS ITS OWN MODULE. Two reasons, both load-bearing. (1) score-wasm.ts imports the `agbcc`
+// WHY IT IS ITS OWN MODULE rather than living in score-wasm.ts: score-wasm.ts imports the `agbcc`
 // package, which cannot be imported under vitest (candidate-compile.test.ts's header documents
 // why), and apps/web has no jsdom — so anything that needs a test has to be a plain function
-// outside both. (2) The throttle and the labels are shared by the worker driver and by two views
-// (RankBadge, RankCandidates); one copy is how they cannot drift into saying different things
-// about the same run.
+// outside both.
 //
-// THE HONESTY RULES THIS FILE ENCODES:
-//  • The total does not exist until `enumerateCandidates` has returned, so four of the five
-//    phases are INDETERMINATE and carry no number at all. No estimate, no "0 %" of an unknown
-//    denominator — a fabricated total is a lie the user cannot check.
-//  • A determinate bar is rendered ONLY while scoring, and the scoring phase ends by moving to
-//    `ranking`, not by sitting at done === total. The fill is additionally clamped below 100 so
-//    the pixels never read "finished" while the sort + structured clone + render still run;
-//    `aria-valuenow` keeps the TRUE count, so assistive tech gets the exact number.
+// THE HONESTY RULE THIS FILE ENCODES: the total does not exist until `enumerateCandidates` has
+// returned, so four of the five phases are INDETERMINATE and carry no number at all — no estimate,
+// no "0 %" of an unknown denominator. A fabricated total is a lie the user cannot check, and the
+// type below makes one unspellable rather than merely discouraged.
 
 /** The phases a ranking passes through, in the order they run. Only `scoring` is determinate.
  *
@@ -40,51 +36,6 @@ export type RankPhase = 'queued' | 'assembling' | 'enumerating' | 'scoring' | 'r
 export type RankProgress =
   | { phase: Exclude<RankPhase, 'scoring'>; done?: undefined; total?: undefined }
   | { phase: 'scoring'; done: number; total: number };
-
-const PHASE_TEXT: Record<RankPhase, string> = {
-  queued: 'waiting for the ranking worker…',
-  assembling: 'assembling the target asm…',
-  enumerating: 'enumerating candidate spellings…',
-  scoring: 'scoring candidates with agbcc + objdiff…',
-  ranking: 'ranking scored candidates…',
-};
-
-/** The one sentence both the badge and the Pipeline card show, so they cannot disagree about what
- *  the run is doing. Determinate only when a REAL total is in hand. */
-export function progressLabel(p: RankProgress): string {
-  if (p.phase === 'scoring') {
-    return `scoring ${p.done.toLocaleString()} / ${p.total.toLocaleString()} candidates`;
-  }
-  return PHASE_TEXT[p.phase];
-}
-
-/** The bar's props, also discriminated: `pct`/`valueNow`/`valueMax` exist ONLY on the determinate
- *  arm. They used to be optional fields the indeterminate arm filled with `pct: 0` — a number no
- *  caller read, and the exact "0 % of an unknown denominator" this module's header forbids. */
-export type RankProgressBar =
-  | { determinate: false; label: string }
-  | {
-      determinate: true;
-      /** the EXACT count for `aria-valuenow` (the fill is clamped, this is not). */
-      valueNow: number;
-      valueMax: number;
-      /** the fill WIDTH in percent, clamped to 99 so a full bar never sits over unfinished work. */
-      pct: number;
-      label: string;
-    };
-
-export function progressBar(p: RankProgress): RankProgressBar {
-  const label = progressLabel(p);
-  // A ZERO total is a real emission — an enumeration that produced nothing, which then throws
-  // `no scorable candidate` — and it is NOT determinate: ARIA requires `aria-valuemax` to exceed
-  // `aria-valuemin`, so equal bounds leave the AT-computed percentage undefined. 0/0 has no
-  // percentage on either channel; the label still carries the true counts.
-  if (p.phase !== 'scoring' || p.total === 0) {
-    return { determinate: false, label };
-  }
-  const pct = Math.min(99, Math.round((100 * p.done) / p.total));
-  return { determinate: true, valueNow: p.done, valueMax: p.total, pct, label };
-}
 
 /** Wrap an emitter so it posts at most once per `intervalMs` of WALL TIME.
  *

--- a/apps/web/src/pages/playground/rank-progress.ts
+++ b/apps/web/src/pages/playground/rank-progress.ts
@@ -39,6 +39,9 @@ export type RankProgress =
 
 /** Wrap an emitter so it posts at most once per `intervalMs` of WALL TIME.
  *
+ *  EVERY NUMBER BELOW IS ONE MACHINE'S MEASUREMENT ON 2026-08-30, not a property of the code — it
+ *  is the ARGUMENT that is durable, and the numbers will rot.
+ *
  *  WHY A THROTTLE AT ALL: one real function enumerates 117,760 candidates in the browser (measured;
  *  the CLI's number for the same function, WITH a symbol map, is 66,816). A postMessage per
  *  candidate would flood the main thread the worker exists to protect.

--- a/apps/web/src/pages/playground/rank-progress.ts
+++ b/apps/web/src/pages/playground/rank-progress.ts
@@ -9,7 +9,7 @@
 // about the same run.
 //
 // THE HONESTY RULES THIS FILE ENCODES:
-//  • The total does not exist until `enumerateCandidates` has returned, so three of the four
+//  • The total does not exist until `enumerateCandidates` has returned, so four of the five
 //    phases are INDETERMINATE and carry no number at all. No estimate, no "0 %" of an unknown
 //    denominator — a fabricated total is a lie the user cannot check.
 //  • A determinate bar is rendered ONLY while scoring, and the scoring phase ends by moving to
@@ -32,12 +32,14 @@
  *  subdivided, so it gets a name and no number. */
 export type RankPhase = 'queued' | 'assembling' | 'enumerating' | 'scoring' | 'ranking';
 
-/** One progress observation. `done`/`total` exist only once the candidate array does. */
-export interface RankProgress {
-  phase: RankPhase;
-  done?: number;
-  total?: number;
-}
+/** One progress observation, DISCRIMINATED on the phase: `done`/`total` exist if and only if the
+ *  phase is `scoring`, because the candidate array is what mints them. As two optional fields on
+ *  one shape the type admitted four states no emitter can produce (`enumerating` with a count,
+ *  `scoring` with only a `done`, …), each of which then needed a defensive branch in the view and
+ *  a test asserting an unreachable state; as a union there is nothing to defend against. */
+export type RankProgress =
+  | { phase: Exclude<RankPhase, 'scoring'>; done?: undefined; total?: undefined }
+  | { phase: 'scoring'; done: number; total: number };
 
 const PHASE_TEXT: Record<RankPhase, string> = {
   queued: 'waiting for the ranking worker…',
@@ -50,30 +52,37 @@ const PHASE_TEXT: Record<RankPhase, string> = {
 /** The one sentence both the badge and the Pipeline card show, so they cannot disagree about what
  *  the run is doing. Determinate only when a REAL total is in hand. */
 export function progressLabel(p: RankProgress): string {
-  if (p.phase === 'scoring' && p.total !== undefined && p.done !== undefined) {
+  if (p.phase === 'scoring') {
     return `scoring ${p.done.toLocaleString()} / ${p.total.toLocaleString()} candidates`;
   }
   return PHASE_TEXT[p.phase];
 }
 
-export interface RankProgressBar {
-  /** true ⇔ a real total exists ⇔ the bar may show a fill and an `aria-valuenow`. */
-  determinate: boolean;
-  /** the EXACT count for `aria-valuenow`; omitted while indeterminate (that omission is the ARIA
-   *  spelling of "indeterminate" — an invented 0 would not be). */
-  valueNow?: number;
-  valueMax?: number;
-  /** the fill WIDTH in percent, clamped to 99 so a full bar never sits over unfinished work. */
-  pct: number;
-  label: string;
-}
+/** The bar's props, also discriminated: `pct`/`valueNow`/`valueMax` exist ONLY on the determinate
+ *  arm. They used to be optional fields the indeterminate arm filled with `pct: 0` — a number no
+ *  caller read, and the exact "0 % of an unknown denominator" this module's header forbids. */
+export type RankProgressBar =
+  | { determinate: false; label: string }
+  | {
+      determinate: true;
+      /** the EXACT count for `aria-valuenow` (the fill is clamped, this is not). */
+      valueNow: number;
+      valueMax: number;
+      /** the fill WIDTH in percent, clamped to 99 so a full bar never sits over unfinished work. */
+      pct: number;
+      label: string;
+    };
 
 export function progressBar(p: RankProgress): RankProgressBar {
   const label = progressLabel(p);
-  if (p.phase !== 'scoring' || p.total === undefined || p.done === undefined) {
-    return { determinate: false, pct: 0, label };
+  // A ZERO total is a real emission — an enumeration that produced nothing, which then throws
+  // `no scorable candidate` — and it is NOT determinate: ARIA requires `aria-valuemax` to exceed
+  // `aria-valuemin`, so equal bounds leave the AT-computed percentage undefined. 0/0 has no
+  // percentage on either channel; the label still carries the true counts.
+  if (p.phase !== 'scoring' || p.total === 0) {
+    return { determinate: false, label };
   }
-  const pct = p.total > 0 ? Math.min(99, Math.round((100 * p.done) / p.total)) : 0;
+  const pct = Math.min(99, Math.round((100 * p.done) / p.total));
   return { determinate: true, valueNow: p.done, valueMax: p.total, pct, label };
 }
 

--- a/apps/web/src/pages/playground/rank-progress.ts
+++ b/apps/web/src/pages/playground/rank-progress.ts
@@ -17,11 +17,20 @@
 //    the pixels never read "finished" while the sort + structured clone + render still run;
 //    `aria-valuenow` keeps the TRUE count, so assistive tech gets the exact number.
 
-/** The four phases of `rankCandidatesInBrowser`, in the order they run. Only `scoring` is
- *  determinate. `assembling` runs FIRST (it is milliseconds, and it is the phase that fails on a
- *  pret-dialect `.s`); `enumerating` is synchronous inside core and cannot be subdivided, so it
- *  gets a name and no number. */
-export type RankPhase = 'assembling' | 'enumerating' | 'scoring' | 'ranking';
+/** The phases a ranking passes through, in the order they run. Only `scoring` is determinate.
+ *
+ *  `queued` is the one phase the WORKER NEVER EMITS — it is what the main thread knows between
+ *  `postMessage` and the worker's first tick, and it is a real state rather than a formality: the
+ *  worker is single-threaded and `enumerateCandidates` is synchronous, so a request posted while a
+ *  superseded run is still enumerating cannot even be DEQUEUED for the length of that enumeration
+ *  (62.3 s on one measured run, 2026-08-30). Calling that `assembling` would assert work that has
+ *  not started — the badge asserting a phase nobody observed is the same class of lie as a
+ *  fabricated total, so it gets its own name.
+ *
+ *  `assembling` then runs FIRST inside the worker (it is milliseconds, and it is the phase that
+ *  fails on a pret-dialect `.s`); `enumerating` is synchronous inside core and cannot be
+ *  subdivided, so it gets a name and no number. */
+export type RankPhase = 'queued' | 'assembling' | 'enumerating' | 'scoring' | 'ranking';
 
 /** One progress observation. `done`/`total` exist only once the candidate array does. */
 export interface RankProgress {
@@ -31,6 +40,7 @@ export interface RankProgress {
 }
 
 const PHASE_TEXT: Record<RankPhase, string> = {
+  queued: 'waiting for the ranking worker…',
   assembling: 'assembling the target asm…',
   enumerating: 'enumerating candidate spellings…',
   scoring: 'scoring candidates with agbcc + objdiff…',

--- a/apps/web/src/pages/playground/rank.worker.ts
+++ b/apps/web/src/pages/playground/rank.worker.ts
@@ -4,6 +4,7 @@
 // RankRequest and receives a RankResponse. The H1 stale-guard (discarding a superseded response)
 // is enforced by the MAIN thread against the echoed `reqId` — the worker just processes each
 // request and echoes its id back.
+import { throttleProgress } from './rank-progress';
 import {
   type RankMessage,
   type RankRequest,
@@ -18,12 +19,17 @@ preloadScorers();
 self.onmessage = async (e: MessageEvent<RankRequest>) => {
   const { reqId, name, asm, target, symbols } = e.data;
   try {
+    // THE THROTTLE LIVES HERE, at the transport boundary it is a policy about: the driver observes
+    // every candidate, and this is what bounds how many of those observations become postMessages
+    // (~10/s, whatever the fan shape — 117,760 candidates would otherwise be 117,760 wake-ups of
+    // the main thread the worker exists to protect). A fresh throttle per request, so one run's
+    // clock cannot suppress another's first tick.
+    //
     // Progress carries the SAME echoed `reqId` as the result, for the same reason: the main
     // thread's H1 guard drops anything stamped with a superseded id. The worker still does not
     // learn about staleness — it only stamps and posts.
-    const result = await rankCandidatesInBrowser(name, asm, target, symbols, (p) =>
-      postMessage({ kind: 'progress', reqId, ...p } satisfies RankMessage),
-    );
+    const post = throttleProgress((p) => postMessage({ kind: 'progress', reqId, ...p } satisfies RankMessage));
+    const result = await rankCandidatesInBrowser(name, asm, target, symbols, post);
     postMessage({ kind: 'result', reqId, ok: true, result } satisfies RankResponse);
   } catch (err) {
     postMessage({

--- a/apps/web/src/pages/playground/rank.worker.ts
+++ b/apps/web/src/pages/playground/rank.worker.ts
@@ -6,8 +6,8 @@
 // request and echoes its id back.
 import { throttleProgress, whileCurrent } from './rank-progress';
 import {
+  type RankInbound,
   type RankMessage,
-  type RankRequest,
   type RankResponse,
   preloadScorers,
   rankCandidatesInBrowser,
@@ -16,36 +16,36 @@ import {
 // Warm the wasm modules as soon as the worker spawns (the UI spawns it on an agbcc target).
 preloadScorers();
 
-// The newest request this worker has RECEIVED. `self.onmessage` is async, so a second request is
-// dequeued at the first `await` of the first and the two runs interleave — a superseded run keeps
-// scoring for the rest of its natural life. Measured: bumping the reqId 9.9 s into an 800-candidate
-// run left the abandoned run posting 286 further ticks over 78 s, every one waking the main thread
-// to be thrown away. The per-run throttle bounds ONE run to ~10 msg/s; nothing bounded the number
-// of live superseded runs, so the aggregate rate scaled with edits-during-a-run — the precise load
-// the worker exists to prevent.
+// The newest id this worker has been TOLD ABOUT — a RATE policy and nothing else, whose argument
+// and measurement live with `whileCurrent` in rank-progress.ts. It may only ever DROP a message;
+// the H1 stale-guard stays on the main thread as the sole authority over what is displayed, which
+// is why a superseded run's RESULT is still posted.
 //
-// This id is a RATE policy and NOTHING ELSE. It may only ever DROP a message: the H1 stale-guard
-// stays on the main thread, sole authority over what is displayed, and this cannot route around it
-// — the worker learns of id N only from the message the main thread posted after setting its own
-// current id to N, so `latestReqId <= currentReqId` always, and everything suppressed here would
-// have been dropped there. The superseded run's RESULT is still posted for exactly that reason:
-// deciding a verdict is the main thread's job, not this file's.
+// It does NOT stop the abandoned run. Its agbcc + objdiff compiles keep going, and they are the
+// larger cost by far: measured 2026-08-30, a live run scores 52.8 candidates/s alone and 40.6
+// while one abandoned run is still working. Stopping that needs an abort seam the scoring loop
+// does not have, and silencing is not a substitute for it — cancelling is a follow-up.
 let latestReqId = 0;
 
-self.onmessage = async (e: MessageEvent<RankRequest>) => {
-  const { reqId, name, asm, target, symbols } = e.data;
-  latestReqId = reqId;
+self.onmessage = async (e: MessageEvent<RankInbound>) => {
+  const msg = e.data;
+  // BOTH kinds advance the id: the main thread also abandons a run without starting another one,
+  // and a `supersede` is the only way it can say so.
+  latestReqId = msg.reqId;
+  if (msg.kind === 'supersede') {
+    return;
+  }
+  const { reqId, name, asm, target, symbols } = msg;
   try {
     // THE THROTTLE LIVES HERE, at the transport boundary it is a policy about: the driver observes
     // every candidate, and this is what bounds how many of those observations become postMessages
     // (~10/s, whatever the fan shape — 117,760 candidates would otherwise be 117,760 wake-ups of
-    // the main thread the worker exists to protect). A fresh throttle per request, so one run's
-    // clock cannot suppress another's first tick.
+    // the main thread the worker exists to protect). One per request, so one run's clock cannot
+    // suppress another's first tick.
     //
-    // Progress carries the SAME echoed `reqId` as the result, for the same reason: the main
-    // thread's H1 guard drops anything stamped with a superseded id. The worker never decides what
-    // is SHOWN — it stamps, and it declines to spend a postMessage on a run it already knows the
-    // main thread will discard.
+    // Progress carries the SAME echoed `reqId` as the result, because it answers to the same H1
+    // guard. The worker never decides what is SHOWN — it stamps, and it declines to spend a
+    // postMessage on a run it already knows the main thread will discard.
     const post = throttleProgress(
       whileCurrent(
         () => reqId === latestReqId,

--- a/apps/web/src/pages/playground/rank.worker.ts
+++ b/apps/web/src/pages/playground/rank.worker.ts
@@ -4,7 +4,7 @@
 // RankRequest and receives a RankResponse. The H1 stale-guard (discarding a superseded response)
 // is enforced by the MAIN thread against the echoed `reqId` — the worker just processes each
 // request and echoes its id back.
-import { throttleProgress } from './rank-progress';
+import { throttleProgress, whileCurrent } from './rank-progress';
 import {
   type RankMessage,
   type RankRequest,
@@ -16,8 +16,25 @@ import {
 // Warm the wasm modules as soon as the worker spawns (the UI spawns it on an agbcc target).
 preloadScorers();
 
+// The newest request this worker has RECEIVED. `self.onmessage` is async, so a second request is
+// dequeued at the first `await` of the first and the two runs interleave — a superseded run keeps
+// scoring for the rest of its natural life. Measured: bumping the reqId 9.9 s into an 800-candidate
+// run left the abandoned run posting 286 further ticks over 78 s, every one waking the main thread
+// to be thrown away. The per-run throttle bounds ONE run to ~10 msg/s; nothing bounded the number
+// of live superseded runs, so the aggregate rate scaled with edits-during-a-run — the precise load
+// the worker exists to prevent.
+//
+// This id is a RATE policy and NOTHING ELSE. It may only ever DROP a message: the H1 stale-guard
+// stays on the main thread, sole authority over what is displayed, and this cannot route around it
+// — the worker learns of id N only from the message the main thread posted after setting its own
+// current id to N, so `latestReqId <= currentReqId` always, and everything suppressed here would
+// have been dropped there. The superseded run's RESULT is still posted for exactly that reason:
+// deciding a verdict is the main thread's job, not this file's.
+let latestReqId = 0;
+
 self.onmessage = async (e: MessageEvent<RankRequest>) => {
   const { reqId, name, asm, target, symbols } = e.data;
+  latestReqId = reqId;
   try {
     // THE THROTTLE LIVES HERE, at the transport boundary it is a policy about: the driver observes
     // every candidate, and this is what bounds how many of those observations become postMessages
@@ -26,9 +43,15 @@ self.onmessage = async (e: MessageEvent<RankRequest>) => {
     // clock cannot suppress another's first tick.
     //
     // Progress carries the SAME echoed `reqId` as the result, for the same reason: the main
-    // thread's H1 guard drops anything stamped with a superseded id. The worker still does not
-    // learn about staleness — it only stamps and posts.
-    const post = throttleProgress((p) => postMessage({ kind: 'progress', reqId, ...p } satisfies RankMessage));
+    // thread's H1 guard drops anything stamped with a superseded id. The worker never decides what
+    // is SHOWN — it stamps, and it declines to spend a postMessage on a run it already knows the
+    // main thread will discard.
+    const post = throttleProgress(
+      whileCurrent(
+        () => reqId === latestReqId,
+        (p) => postMessage({ kind: 'progress', reqId, ...p } satisfies RankMessage),
+      ),
+    );
     const result = await rankCandidatesInBrowser(name, asm, target, symbols, post);
     postMessage({ kind: 'result', reqId, ok: true, result } satisfies RankResponse);
   } catch (err) {

--- a/apps/web/src/pages/playground/rank.worker.ts
+++ b/apps/web/src/pages/playground/rank.worker.ts
@@ -4,7 +4,13 @@
 // RankRequest and receives a RankResponse. The H1 stale-guard (discarding a superseded response)
 // is enforced by the MAIN thread against the echoed `reqId` — the worker just processes each
 // request and echoes its id back.
-import { type RankRequest, type RankResponse, preloadScorers, rankCandidatesInBrowser } from './score-wasm';
+import {
+  type RankMessage,
+  type RankRequest,
+  type RankResponse,
+  preloadScorers,
+  rankCandidatesInBrowser,
+} from './score-wasm';
 
 // Warm the wasm modules as soon as the worker spawns (the UI spawns it on an agbcc target).
 preloadScorers();
@@ -12,9 +18,19 @@ preloadScorers();
 self.onmessage = async (e: MessageEvent<RankRequest>) => {
   const { reqId, name, asm, target, symbols } = e.data;
   try {
-    const result = await rankCandidatesInBrowser(name, asm, target, symbols);
-    postMessage({ reqId, ok: true, result } satisfies RankResponse);
+    // Progress carries the SAME echoed `reqId` as the result, for the same reason: the main
+    // thread's H1 guard drops anything stamped with a superseded id. The worker still does not
+    // learn about staleness — it only stamps and posts.
+    const result = await rankCandidatesInBrowser(name, asm, target, symbols, (p) =>
+      postMessage({ kind: 'progress', reqId, ...p } satisfies RankMessage),
+    );
+    postMessage({ kind: 'result', reqId, ok: true, result } satisfies RankResponse);
   } catch (err) {
-    postMessage({ reqId, ok: false, error: err instanceof Error ? err.message : String(err) } satisfies RankResponse);
+    postMessage({
+      kind: 'result',
+      reqId,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    } satisfies RankResponse);
   }
 };

--- a/apps/web/src/pages/playground/score-wasm.ts
+++ b/apps/web/src/pages/playground/score-wasm.ts
@@ -29,6 +29,7 @@ import { assemble, compileToObject } from 'agbcc';
 import type * as ObjdiffWasm from 'objdiff-wasm';
 
 import { toolFailureLine } from './candidate-compile';
+import { type RankProgress, throttleProgress } from './rank-progress';
 
 // ── Web-Worker protocol ──────────────────────────────────────────────────────────────────────
 // Scoring runs in a worker (rank.worker.ts) so the agbcc + objdiff wasm compiles never jank
@@ -57,7 +58,16 @@ export interface RefusedDeclaration {
  *  declarations were synthesized) as a count on its own `[ranked]` line. */
 export type BrowserRanking = RankedResult<MatchScore> & { refused: RefusedDeclaration[] };
 export type RankResponse =
-  { reqId: number; ok: true; result: BrowserRanking } | { reqId: number; ok: false; error: string };
+  | { kind: 'result'; reqId: number; ok: true; result: BrowserRanking }
+  | { kind: 'result'; reqId: number; ok: false; error: string };
+/** A phase/count observation from a run in flight. It carries the SAME `reqId` the result echoes,
+ *  because it is subject to the SAME H1 stale-guard: progress for a superseded asm must be dropped,
+ *  not rendered. */
+export type RankProgressMessage = { kind: 'progress'; reqId: number } & RankProgress;
+/** Everything the worker can post. Read on the explicit `kind` discriminant — never by sniffing for
+ *  a property, which is how a fourth shape later gets silently mis-routed. */
+export type RankMessage = RankProgressMessage | RankResponse;
+export type { RankPhase, RankProgress } from './rank-progress';
 
 export interface DiffBreakdown {
   insert: number;
@@ -200,27 +210,49 @@ export async function scoreObjectBytes(
  *  the refusals with it.
  *
  *  Ranking always uses `cBackend` regardless of the UI backend selector — choosing cpp/pascal
- *  turns ranking off (it is gated to the agbcc target + C backend in Playground.tsx). */
+ *  turns ranking off (it is gated to the agbcc target + C backend in Playground.tsx).
+ *
+ *  PROGRESS: `onProgress` (optional — the existing 4-arg call sites stay valid) is called with the
+ *  phase, and with `done`/`total` once the candidate array exists. It is throttled HERE rather than
+ *  in the worker because this is the only place that knows the loop index, and a second driver over
+ *  this enumeration would inherit the throttle for free. */
 export async function rankCandidatesInBrowser(
   name: string,
   asm: string,
   target: TargetDescription,
   symbols?: SymbolMap,
+  onProgress?: (p: RankProgress) => void,
 ): Promise<BrowserRanking> {
+  const emit = onProgress ? throttleProgress(onProgress) : () => {};
+
+  // ASSEMBLE FIRST. This used to run AFTER `enumerateCandidates`, and the ordering cost a measured
+  // 62.3 s of discarded work on every pret-dialect `.s`: agbcc's `assemble()` hands the source to
+  // GNU as AS-IS, which does not know `thumb_func_start`, so `LoadBGTilemapData` enumerated 117,760
+  // candidates and THEN died on line 1. `enumerateCandidates` does not consume `t`, so the swap is
+  // behaviour-neutral whenever assembly succeeds and turns a minute into milliseconds when it does
+  // not — and it gives the UI a real, cheap first phase to name instead of a minute-long unnamed
+  // void. (The pret dialect itself is a separate gap: asmlift's own frontend reads it, the
+  // in-browser scorer cannot.)
+  emit({ phase: 'assembling' });
+  const t = await assemble(asm);
+  if (!t.ok) {
+    throw new Error(`could not assemble the target asm: ${toolFailureLine(t.stderr)}`);
+  }
+
   // A refused declaration is a name asmlift DECIDED not to declare. Collected here so the UI can
   // attribute an undeclared name to that decision instead of leaving the user to guess — and,
   // for `emitter-name`, so a row that produced NO candidate at all says which symbol collided.
+  //
+  // `enumerateCandidates` is SYNCHRONOUS and returns a finished array (62.3 s of it, measured, on
+  // the function above), so there is no honest number to show inside it — the phase is named and
+  // carries none. Subdividing it is a core change and a follow-up, not this round's.
+  emit({ phase: 'enumerating' });
   const refused: RefusedDeclaration[] = [];
   const candidates = enumerateCandidates(name, asm, target, {
     backend: cBackend,
     ...(symbols ? { symbols } : {}),
     onRefusedDeclaration: (n, reason) => refused.push({ name: n, reason }),
   });
-
-  const t = await assemble(asm);
-  if (!t.ok) {
-    throw new Error(`could not assemble the target asm: ${toolFailureLine(t.stderr)}`);
-  }
 
   // Mirrors core's `rankBy` (which this cannot reuse — the wasm scorer is async): a candidate
   // that fails to build is DROPPED rather than allowed to sink a sibling that compiles, and each
@@ -233,7 +265,15 @@ export async function rankCandidatesInBrowser(
   const dropped: DroppedCandidate[] = [];
   const withheld: WithheldCandidate[] = [];
   let lastErr: unknown = null;
+  // The total is only ever `candidates.length` — the number actually returned. No estimate, and no
+  // borrowing the CLI's count for the same function (66,816 with a symbol map, against the
+  // browser's map-less 117,760: a fabricated denominator would have been 76 % wrong).
+  const total = candidates.length;
+  emit({ phase: 'scoring', done: 0, total });
   for (const [order, c] of candidates.entries()) {
+    // `order` is how many candidates are FINISHED, and the tick is emitted at the top so the
+    // `continue` on a withheld spelling cannot skip it.
+    emit({ phase: 'scoring', done: order, total });
     try {
       const cc = await compileToObject(c.source, { context: selfDeclaredContextFor(c.symbolRefs) });
       if (!cc.ok) {
@@ -254,6 +294,12 @@ export async function rankCandidatesInBrowser(
       dropped.push({ label: c.label, error: e instanceof Error ? toolFailureLine(e.message) : String(e) });
     }
   }
+  emit({ phase: 'scoring', done: total, total });
+  // The scoring phase ends by CHANGING PHASE, never by sitting at done === total: the sort and the
+  // structured clone of a six-figure array back to the main thread are real work, and a bar full
+  // while the tab is still busy is the lie constraint 3 forbids. The UI falls back to an
+  // indeterminate bar with a different label here.
+  emit({ phase: 'ranking' });
   if (results.length === 0) {
     const why = lastErr instanceof Error ? lastErr.message.split('\n')[0] : String(lastErr ?? 'no candidate produced');
     throw new Error(`no scorable candidate for '${name}': ${why}`, { cause: lastErr });

--- a/apps/web/src/pages/playground/score-wasm.ts
+++ b/apps/web/src/pages/playground/score-wasm.ts
@@ -29,7 +29,7 @@ import { assemble, compileToObject } from 'agbcc';
 import type * as ObjdiffWasm from 'objdiff-wasm';
 
 import { toolFailureLine } from './candidate-compile';
-import type { RankProgress } from './rank-progress';
+import type { EmittedProgress } from './rank-progress';
 
 // ── Web-Worker protocol ──────────────────────────────────────────────────────────────────────
 // Scoring runs in a worker (rank.worker.ts) so the agbcc + objdiff wasm compiles never jank
@@ -37,6 +37,7 @@ import type { RankProgress } from './rank-progress';
 // remembers the latest, and DISCARDS any response whose id is not the current one — so a score
 // computed for a previous asm can never be shown against the asm now on screen.
 export interface RankRequest {
+  kind: 'request';
   reqId: number;
   name: string;
   asm: string;
@@ -45,6 +46,22 @@ export interface RankRequest {
    *  objects); absent ⇒ the plain raw-globals-only enumeration */
   symbols?: SymbolMap;
 }
+/** "I have moved on to `reqId`, and I am not asking for anything." The main thread abandons a run
+ *  WITHOUT starting another one every time ranking becomes ineligible — switching to the Benchmark
+ *  tab, switching the backend to C++, clearing the function name — and a run whose every message
+ *  the H1 guard will discard must stop spending postMessages then too. Without this the worker only
+ *  ever learned a new id from a new REQUEST, so the abandoned run kept waking the main thread for
+ *  its whole life (measured 2026-08-30: 108 further ticks over 11.9 s at 9.1 Hz).
+ *
+ *  It abandons the MESSAGES, not the WORK: there is no abort seam in the scoring loop, so the run
+ *  finishes scoring in the background. Cancelling it is a follow-up. */
+export interface RankSupersede {
+  kind: 'supersede';
+  reqId: number;
+}
+/** Everything the MAIN THREAD can post. Read on `kind` for the reason `RankMessage` is: a shape
+ *  told apart by sniffing for a property is how a third one later gets silently mis-routed. */
+export type RankInbound = RankRequest | RankSupersede;
 /** A name the candidate's tree references that asmlift REFUSED to declare
  *  (core `RefusedDeclarationReason`) — surfaced so the UI can say which `'x' undeclared` was
  *  asmlift's own decision. */
@@ -62,8 +79,9 @@ export type RankResponse =
   | { kind: 'result'; reqId: number; ok: false; error: string };
 /** A phase/count observation from a run in flight. It carries the SAME `reqId` the result echoes,
  *  because it is subject to the SAME H1 stale-guard: progress for a superseded asm must be dropped,
- *  not rendered. */
-export type RankProgressMessage = { kind: 'progress'; reqId: number } & RankProgress;
+ *  not rendered. Built on `EmittedProgress`, so the one phase the worker cannot observe (`queued`)
+ *  is not spellable on the wire. */
+type RankProgressMessage = { kind: 'progress'; reqId: number } & EmittedProgress;
 /** Everything the worker can post. Read on the explicit `kind` discriminant — never by sniffing for
  *  a property, which is how a fourth shape later gets silently mis-routed. */
 export type RankMessage = RankProgressMessage | RankResponse;
@@ -211,31 +229,29 @@ export async function scoreObjectBytes(
  *  Ranking always uses `cBackend` regardless of the UI backend selector — choosing cpp/pascal
  *  turns ranking off (it is gated to the agbcc target + C backend in Playground.tsx).
  *
- *  PROGRESS: `onProgress` (optional — the existing 4-arg call sites stay valid) is called with the
- *  phase, and with `done`/`total` once the candidate array exists. It is called for EVERY
- *  candidate and is NOT throttled here: the rate limit is a property of the transport (a
- *  postMessage per candidate is what would jank the main thread this worker exists to protect), so
- *  it lives at that boundary, in rank.worker.ts. A closure call per candidate is free next to the
- *  25-167 ms each one spends in agbcc + objdiff, and a second driver — a test rig, a node harness,
- *  a future ETA estimator — gets to observe every candidate instead of inheriting a 10 Hz ceiling
- *  it never asked for and cannot opt out of. */
+ *  PROGRESS: `onProgress` is called with the phase, and with `done`/`total` once the candidate
+ *  array exists. It is called for EVERY candidate and is NOT throttled here: the rate limit is a
+ *  property of the transport (a postMessage per candidate is what would jank the main thread the
+ *  worker exists to protect), so it lives at that boundary, in rank.worker.ts. A closure call per
+ *  candidate is free next to the 25-167 ms each one spends in agbcc + objdiff, and a second driver
+ *  — a test rig, a node harness, a future ETA estimator — gets to observe every candidate instead
+ *  of inheriting a 10 Hz ceiling it never asked for and cannot opt out of. */
 export async function rankCandidatesInBrowser(
   name: string,
   asm: string,
   target: TargetDescription,
   symbols?: SymbolMap,
-  onProgress?: (p: RankProgress) => void,
+  onProgress?: (p: EmittedProgress) => void,
 ): Promise<BrowserRanking> {
-  const emit: (p: RankProgress) => void = onProgress ?? (() => {});
+  const emit: (p: EmittedProgress) => void = onProgress ?? (() => {});
 
-  // ASSEMBLE FIRST. This used to run AFTER `enumerateCandidates`, and the ordering cost a measured
-  // 62.3 s (2026-08-30) of discarded work on every pret-dialect `.s`: agbcc's `assemble()` hands the source to
-  // GNU as AS-IS, which does not know `thumb_func_start`, so `LoadBGTilemapData` enumerated 117,760
-  // candidates and THEN died on line 1. `enumerateCandidates` does not consume `t`, so the swap is
-  // behaviour-neutral whenever assembly succeeds and turns a minute into milliseconds when it does
-  // not — and it gives the UI a real, cheap first phase to name instead of a minute-long unnamed
-  // void. (The pret dialect itself is a separate gap: asmlift's own frontend reads it, the
-  // in-browser scorer cannot.)
+  // ASSEMBLE FIRST, and keep it first. agbcc's `assemble()` hands the source to GNU as AS-IS, which
+  // does not know `thumb_func_start`, so a pret-dialect `.s` dies here on line 1 — with the
+  // enumeration ahead of it that death cost a measured 62.3 s (2026-08-30, `LoadBGTilemapData`,
+  // 117,760 candidates) of work thrown away. `enumerateCandidates` does not consume `t`, so this
+  // order is behaviour-neutral whenever assembly succeeds, and it gives the UI a cheap first phase
+  // to name instead of a minute-long unnamed void. (The pret dialect is a separate gap: asmlift's
+  // own frontend reads it, the in-browser scorer cannot.)
   emit({ phase: 'assembling' });
   const t = await assemble(asm);
   if (!t.ok) {
@@ -246,9 +262,9 @@ export async function rankCandidatesInBrowser(
   // attribute an undeclared name to that decision instead of leaving the user to guess — and,
   // for `emitter-name`, so a row that produced NO candidate at all says which symbol collided.
   //
-  // `enumerateCandidates` is SYNCHRONOUS and returns a finished array (62.3 s of it, measured
-  // 2026-08-30, on the function above), so there is no honest number to show inside it — the phase is named and
-  // carries none. Subdividing it is a core change and a follow-up, not this round's.
+  // `enumerateCandidates` is SYNCHRONOUS and returns a finished array (62.3 s of it on that same
+  // function), so there is no honest number to show inside it — the phase is named and carries
+  // none. Subdividing it is a core change and a follow-up, not this round's.
   emit({ phase: 'enumerating' });
   const refused: RefusedDeclaration[] = [];
   const candidates = enumerateCandidates(name, asm, target, {
@@ -272,10 +288,11 @@ export async function rankCandidatesInBrowser(
   // borrowing the CLI's count for the same function (66,816 with a symbol map, against the
   // browser's map-less 117,760: a fabricated denominator would have been 76 % wrong).
   const total = candidates.length;
-  emit({ phase: 'scoring', done: 0, total });
   for (const [order, c] of candidates.entries()) {
     // `order` is how many candidates are FINISHED, and the tick is emitted at the top so the
-    // `continue` on a withheld spelling cannot skip it.
+    // `continue` on a withheld spelling cannot skip it. Iteration 0 is therefore the phase change
+    // itself (`0 / total`, never suppressed by the throttle); an empty enumeration emits nothing
+    // here and is announced by the `done === total` tick below.
     emit({ phase: 'scoring', done: order, total });
     try {
       const cc = await compileToObject(c.source, { context: selfDeclaredContextFor(c.symbolRefs) });

--- a/apps/web/src/pages/playground/score-wasm.ts
+++ b/apps/web/src/pages/playground/score-wasm.ts
@@ -29,7 +29,7 @@ import { assemble, compileToObject } from 'agbcc';
 import type * as ObjdiffWasm from 'objdiff-wasm';
 
 import { toolFailureLine } from './candidate-compile';
-import { type RankProgress, throttleProgress } from './rank-progress';
+import type { RankProgress } from './rank-progress';
 
 // ── Web-Worker protocol ──────────────────────────────────────────────────────────────────────
 // Scoring runs in a worker (rank.worker.ts) so the agbcc + objdiff wasm compiles never jank
@@ -212,9 +212,13 @@ export async function scoreObjectBytes(
  *  turns ranking off (it is gated to the agbcc target + C backend in Playground.tsx).
  *
  *  PROGRESS: `onProgress` (optional — the existing 4-arg call sites stay valid) is called with the
- *  phase, and with `done`/`total` once the candidate array exists. It is throttled HERE rather than
- *  in the worker because this is the only place that knows the loop index, and a second driver over
- *  this enumeration would inherit the throttle for free. */
+ *  phase, and with `done`/`total` once the candidate array exists. It is called for EVERY
+ *  candidate and is NOT throttled here: the rate limit is a property of the transport (a
+ *  postMessage per candidate is what would jank the main thread this worker exists to protect), so
+ *  it lives at that boundary, in rank.worker.ts. A closure call per candidate is free next to the
+ *  25-167 ms each one spends in agbcc + objdiff, and a second driver — a test rig, a node harness,
+ *  a future ETA estimator — gets to observe every candidate instead of inheriting a 10 Hz ceiling
+ *  it never asked for and cannot opt out of. */
 export async function rankCandidatesInBrowser(
   name: string,
   asm: string,
@@ -222,7 +226,7 @@ export async function rankCandidatesInBrowser(
   symbols?: SymbolMap,
   onProgress?: (p: RankProgress) => void,
 ): Promise<BrowserRanking> {
-  const emit = onProgress ? throttleProgress(onProgress) : () => {};
+  const emit: (p: RankProgress) => void = onProgress ?? (() => {});
 
   // ASSEMBLE FIRST. This used to run AFTER `enumerateCandidates`, and the ordering cost a measured
   // 62.3 s of discarded work on every pret-dialect `.s`: agbcc's `assemble()` hands the source to

--- a/apps/web/src/pages/playground/score-wasm.ts
+++ b/apps/web/src/pages/playground/score-wasm.ts
@@ -229,7 +229,7 @@ export async function rankCandidatesInBrowser(
   const emit: (p: RankProgress) => void = onProgress ?? (() => {});
 
   // ASSEMBLE FIRST. This used to run AFTER `enumerateCandidates`, and the ordering cost a measured
-  // 62.3 s of discarded work on every pret-dialect `.s`: agbcc's `assemble()` hands the source to
+  // 62.3 s (2026-08-30) of discarded work on every pret-dialect `.s`: agbcc's `assemble()` hands the source to
   // GNU as AS-IS, which does not know `thumb_func_start`, so `LoadBGTilemapData` enumerated 117,760
   // candidates and THEN died on line 1. `enumerateCandidates` does not consume `t`, so the swap is
   // behaviour-neutral whenever assembly succeeds and turns a minute into milliseconds when it does
@@ -246,8 +246,8 @@ export async function rankCandidatesInBrowser(
   // attribute an undeclared name to that decision instead of leaving the user to guess — and,
   // for `emitter-name`, so a row that produced NO candidate at all says which symbol collided.
   //
-  // `enumerateCandidates` is SYNCHRONOUS and returns a finished array (62.3 s of it, measured, on
-  // the function above), so there is no honest number to show inside it — the phase is named and
+  // `enumerateCandidates` is SYNCHRONOUS and returns a finished array (62.3 s of it, measured
+  // 2026-08-30, on the function above), so there is no honest number to show inside it — the phase is named and
   // carries none. Subdividing it is a core change and a follow-up, not this round's.
   emit({ phase: 'enumerating' });
   const refused: RefusedDeclaration[] = [];

--- a/apps/web/src/pages/playground/score-wasm.ts
+++ b/apps/web/src/pages/playground/score-wasm.ts
@@ -67,7 +67,6 @@ export type RankProgressMessage = { kind: 'progress'; reqId: number } & RankProg
 /** Everything the worker can post. Read on the explicit `kind` discriminant — never by sniffing for
  *  a property, which is how a fourth shape later gets silently mis-routed. */
 export type RankMessage = RankProgressMessage | RankResponse;
-export type { RankPhase, RankProgress } from './rank-progress';
 
 export interface DiffBreakdown {
   insert: number;

--- a/apps/web/src/pages/playground/useRanking.ts
+++ b/apps/web/src/pages/playground/useRanking.ts
@@ -3,8 +3,10 @@
 // H1 (audit CRITICAL): today's decompile is synchronous; ranking is async, so a score can resolve
 // AFTER the user has edited the asm. If the resolved (best) source were then shown against the new
 // asm, the badge would claim "matched (0)" for the wrong input — a false byte-exact match, the
-// cardinal sin. Two layers close it: (1) every input change immediately resets ranking to
-// "loading", clearing any prior result from the view; (2) each request carries a monotonic reqId,
+// cardinal sin. Two layers close it: (1) the view is DERIVED from the input it is about, so a
+// render for a changed input shows `loading` and never the previous input's badge — this used to be
+// a reset inside the posting effect, which lands one commit too late (measured: a 27 ms window with
+// the new function named beside the old run's counts); (2) each request carries a monotonic reqId,
 // the latest is remembered, and the worker's response is ACCEPTED ONLY when its reqId is still the
 // current one — a superseded response is dropped. So the ranked source shown is always for the asm
 // on screen, or nothing.
@@ -66,11 +68,67 @@ export interface RankingInput {
   symbols?: SymbolMap;
 }
 
+/** Do two renders' inputs describe the SAME ranking question? Compared field by field, on exactly
+ *  the fields the request-posting effect depends on — `asm` is compared by reference in the common
+ *  case (same string object), never rebuilt into a key, so this costs nothing at 10 Hz. */
+export function sameRankingInput(a: RankingInput, b: RankingInput): boolean {
+  return (
+    a.eligible === b.eligible &&
+    a.asm === b.asm &&
+    a.name === b.name &&
+    a.targetId === b.targetId &&
+    a.target === b.target &&
+    a.symbols === b.symbols
+  );
+}
+
+/** What to SHOW for `input`, given the state that was last stored and the input that state is
+ *  about. H1 LAYER 1, MOVED OFF THE EFFECT.
+ *
+ *  Resetting to `loading` inside a `useEffect` runs one commit too late: the effect fires AFTER the
+ *  render that already painted the new input, so for that one commit the badge belongs to the
+ *  previous one. Measured in the app on 2026-08-30, switching examples mid-run on an 800-candidate
+ *  fan: the FUNCTION field read the new `half` at t=935 ms while the badge still counted
+ *  `scoring 52 / 800`, and the reset landed at t=962 ms — a 27 ms window, one commit wide. (The
+ *  ~1 s that precedes it is the deliberate 250 ms input debounce, stretched by Chrome's background-
+ *  tab timer clamp; during it the WHOLE pipeline still shows the previous input, which is coherent.
+ *  Only the editor text is ahead.) Derived instead, the window is zero: re-measured after this
+ *  change, the first frame carrying the new function already reads `waiting for the ranking
+ *  worker…`.
+ *
+ *  27 ms is not the point — a scheduled invariant is. The counts this round added are what made the
+ *  mismatch legible at all, and the same window renders a settled VERDICT for an asm no longer on
+ *  screen, which is the cardinal sin H1 exists to prevent. Derived, it cannot lag: state carries
+ *  the input it is about, and anything else renders as the honest `queued`. The reqId guard still
+ *  does its own job on the message side — this closes the window BEFORE a request even exists. */
+export function viewRanking(input: RankingInput, stored: { input: RankingInput; ranking: Ranking }): Ranking {
+  if (!input.eligible || !input.name) {
+    return { status: 'off' };
+  }
+  return sameRankingInput(stored.input, input) ? stored.ranking : { status: 'loading', phase: 'queued' };
+}
+
 export function useRanking(input: RankingInput): Ranking {
   const { eligible, asm, name, targetId, target, symbols } = input;
-  const [ranking, setRanking] = useState<Ranking>({ status: 'off' });
+  // The state carries the INPUT it is about, so a render for a different input cannot show it.
+  const [stored, setStored] = useState<{ input: RankingInput; ranking: Ranking }>({
+    input,
+    ranking: { status: 'off' },
+  });
+  const setRanking = (next: Ranking | ((prev: Ranking) => Ranking)) =>
+    setStored((prev) => ({
+      input: prev.input,
+      ranking: typeof next === 'function' ? next(prev.ranking) : next,
+    }));
   const workerRef = useRef<Worker | null>(null);
   const currentReqId = useRef(0); // the id of the latest posted request — the stale-guard anchor
+  // The last COMMITTED input, for the one writer that is not a reply to a request: `worker.onerror`
+  // fires from a closure created once, and an error stored against a stale input would be derived
+  // away — a loud failure silently swallowed, which is the trade this repo never makes.
+  const latestInput = useRef(input);
+  useEffect(() => {
+    latestInput.current = input;
+  });
 
   // One worker per mounted app. Its onmessage applies the H1 guard: a response is accepted only
   // while its reqId is still the current one.
@@ -87,7 +145,10 @@ export function useRanking(input: RankingInput): Ranking {
       if (currentReqId.current === 0) {
         return;
       }
-      setRanking({ status: 'error', error: e.message || 'the ranking worker failed to load' });
+      setStored({
+        input: latestInput.current,
+        ranking: { status: 'error', error: e.message || 'the ranking worker failed to load' },
+      });
     };
     workerRef.current = worker;
     return () => {
@@ -99,7 +160,7 @@ export function useRanking(input: RankingInput): Ranking {
   useEffect(() => {
     if (!eligible || !name) {
       currentReqId.current++; // invalidate any in-flight response
-      setRanking({ status: 'off' });
+      setStored({ input, ranking: { status: 'off' } });
       return;
     }
     const reqId = ++currentReqId.current; // new request supersedes anything in flight
@@ -109,9 +170,9 @@ export function useRanking(input: RankingInput): Ranking {
     // handed over and nothing has been observed back. Naming `assembling` would be an assertion,
     // not an observation, and it is wrong for a measured 62.3 s (2026-08-30) whenever the worker is still
     // enumerating a superseded run (its event loop cannot dequeue this message until it returns).
-    setRanking({ status: 'loading', phase: 'queued' });
+    setStored({ input, ranking: { status: 'loading', phase: 'queued' } });
     workerRef.current?.postMessage({ reqId, name, asm, target, ...(symbols ? { symbols } : {}) } satisfies RankRequest);
   }, [eligible, asm, name, targetId, target, symbols]);
 
-  return ranking;
+  return viewRanking(input, stored);
 }

--- a/apps/web/src/pages/playground/useRanking.ts
+++ b/apps/web/src/pages/playground/useRanking.ts
@@ -12,7 +12,7 @@ import type { SymbolMap } from '@asmlift/core/symbols';
 import type { TargetDescription } from '@asmlift/core/target';
 import { useEffect, useRef, useState } from 'react';
 
-import type { BrowserRanking, RankRequest, RankResponse } from './score-wasm';
+import type { BrowserRanking, RankMessage, RankRequest } from './score-wasm';
 
 export type Ranking =
   | { status: 'off' } // not an agbcc/C run, or no valid input
@@ -42,8 +42,11 @@ export function useRanking(input: RankingInput): Ranking {
   // while its reqId is still the current one.
   useEffect(() => {
     const worker = new Worker(new URL('./rank.worker.ts', import.meta.url), { type: 'module' });
-    worker.onmessage = (e: MessageEvent<RankResponse>) => {
+    worker.onmessage = (e: MessageEvent<RankMessage>) => {
       const res = e.data;
+      if (res.kind !== 'result') {
+        return;
+      } // progress is carried in the next commit; routing it here would settle a run that is running
       if (res.reqId !== currentReqId.current) {
         return;
       } // superseded by a newer input — drop it

--- a/apps/web/src/pages/playground/useRanking.ts
+++ b/apps/web/src/pages/playground/useRanking.ts
@@ -8,17 +8,47 @@
 // the latest is remembered, and the worker's response is ACCEPTED ONLY when its reqId is still the
 // current one — a superseded response is dropped. So the ranked source shown is always for the asm
 // on screen, or nothing.
+//
+// PROGRESS IS UNDER THE SAME GUARD. A progress tick is a message from the worker, so a tick
+// stamped with a superseded reqId is dropped exactly like a superseded result — otherwise the bar
+// would report another input's run against the asm now on screen. Both rules live in ONE pure
+// function, `applyRankMessage`, which returns null for "drop this message"; the hook has no second
+// way to settle state, and the rules are testable without a DOM (apps/web has no jsdom).
 import type { SymbolMap } from '@asmlift/core/symbols';
 import type { TargetDescription } from '@asmlift/core/target';
 import { useEffect, useRef, useState } from 'react';
 
+import type { RankProgress } from './rank-progress';
 import type { BrowserRanking, RankMessage, RankRequest } from './score-wasm';
 
 export type Ranking =
   | { status: 'off' } // not an agbcc/C run, or no valid input
-  | { status: 'loading' }
+  // progress is carried ONLY here, so it structurally cannot survive into a finished state
+  | ({ status: 'loading' } & RankProgress)
   | { status: 'ok'; result: BrowserRanking }
   | { status: 'error'; error: string };
+
+/** Apply one worker message to the current state, or return null to DROP it.
+ *
+ *  Three refusals, each closing a way the UI could tell a lie:
+ *   1. any message (progress or result) whose reqId is not the current one — it belongs to an asm
+ *      the user has already edited away from, and rendering it is the cardinal sin H1 names;
+ *   2. a progress tick arriving after its own request has settled — it would re-open the spinner
+ *      over a finished verdict;
+ *   3. progress into anything but `loading` — enforced by the type, not by a convention. */
+export function applyRankMessage(prev: Ranking, msg: RankMessage, currentReqId: number): Ranking | null {
+  if (msg.reqId !== currentReqId) {
+    return null; // superseded by a newer input — drop it, progress included
+  }
+  if (msg.kind === 'progress') {
+    if (prev.status !== 'loading') {
+      return null; // its own result already landed; a bar must never outlive the verdict
+    }
+    const { kind: _kind, reqId: _reqId, ...progress } = msg;
+    return { status: 'loading', ...progress };
+  }
+  return msg.ok ? { status: 'ok', result: msg.result } : { status: 'error', error: msg.error };
+}
 
 export interface RankingInput {
   /** true only for an agbcc target + C backend with a valid function name and non-empty asm. */
@@ -42,16 +72,10 @@ export function useRanking(input: RankingInput): Ranking {
   // while its reqId is still the current one.
   useEffect(() => {
     const worker = new Worker(new URL('./rank.worker.ts', import.meta.url), { type: 'module' });
-    worker.onmessage = (e: MessageEvent<RankMessage>) => {
-      const res = e.data;
-      if (res.kind !== 'result') {
-        return;
-      } // progress is carried in the next commit; routing it here would settle a run that is running
-      if (res.reqId !== currentReqId.current) {
-        return;
-      } // superseded by a newer input — drop it
-      setRanking(res.ok ? { status: 'ok', result: res.result } : { status: 'error', error: res.error });
-    };
+    // The functional form is what gives `applyRankMessage` the PREVIOUS state (rule 2 needs it)
+    // without a second ref; returning `prev` unchanged is a React bail-out.
+    worker.onmessage = (e: MessageEvent<RankMessage>) =>
+      setRanking((prev) => applyRankMessage(prev, e.data, currentReqId.current) ?? prev);
     // A worker that fails to LOAD (a bad wasm import, a syntax error) would otherwise never reply,
     // leaving ranking stuck on "loading" forever. Surface it as an error instead — never a silent
     // perpetual spinner. Only while a request is actually in flight, so a benign teardown is quiet.
@@ -75,7 +99,9 @@ export function useRanking(input: RankingInput): Ranking {
       return;
     }
     const reqId = ++currentReqId.current; // new request supersedes anything in flight
-    setRanking({ status: 'loading' }); // clear any prior result from the view immediately (H1 layer 1)
+    // clear any prior result from the view immediately (H1 layer 1) — with a NAMED phase from the
+    // first frame, never an empty message
+    setRanking({ status: 'loading', phase: 'assembling' });
     workerRef.current?.postMessage({ reqId, name, asm, target, ...(symbols ? { symbols } : {}) } satisfies RankRequest);
   }, [eligible, asm, name, targetId, target, symbols]);
 

--- a/apps/web/src/pages/playground/useRanking.ts
+++ b/apps/web/src/pages/playground/useRanking.ts
@@ -99,9 +99,13 @@ export function useRanking(input: RankingInput): Ranking {
       return;
     }
     const reqId = ++currentReqId.current; // new request supersedes anything in flight
-    // clear any prior result from the view immediately (H1 layer 1) — with a NAMED phase from the
-    // first frame, never an empty message
-    setRanking({ status: 'loading', phase: 'assembling' });
+    // Clear any prior result from the view immediately (H1 layer 1) — with a named phase from the
+    // first frame, never an empty message. The phase is `queued`, the one the worker never sends,
+    // because it is the only thing the MAIN THREAD can honestly claim here: the request has been
+    // handed over and nothing has been observed back. Naming `assembling` would be an assertion,
+    // not an observation, and it is wrong for a measured 62.3 s whenever the worker is still
+    // enumerating a superseded run (its event loop cannot dequeue this message until it returns).
+    setRanking({ status: 'loading', phase: 'queued' });
     workerRef.current?.postMessage({ reqId, name, asm, target, ...(symbols ? { symbols } : {}) } satisfies RankRequest);
   }, [eligible, asm, name, targetId, target, symbols]);
 

--- a/apps/web/src/pages/playground/useRanking.ts
+++ b/apps/web/src/pages/playground/useRanking.ts
@@ -33,8 +33,12 @@ export type Ranking =
  *  Three refusals, each closing a way the UI could tell a lie:
  *   1. any message (progress or result) whose reqId is not the current one — it belongs to an asm
  *      the user has already edited away from, and rendering it is the cardinal sin H1 names;
- *   2. a progress tick arriving after its own request has settled — it would re-open the spinner
- *      over a finished verdict;
+ *   2. a progress tick arriving into a request that has ALREADY SETTLED — it would re-open the
+ *      spinner over a finished verdict. Its live path is `worker.onerror` below, NOT "its own
+ *      result already landed": postMessage is FIFO per port, so a run's ticks always precede its
+ *      own result. `onerror` settles `{status:'error'}` while the still-CURRENT run keeps emitting
+ *      under the still-current reqId, and without this rule the bar would visibly re-open over the
+ *      loud error — constraint 4, a failure path that must stay loud;
  *   3. progress into anything but `loading` — enforced by the type, not by a convention. */
 export function applyRankMessage(prev: Ranking, msg: RankMessage, currentReqId: number): Ranking | null {
   if (msg.reqId !== currentReqId) {
@@ -42,7 +46,7 @@ export function applyRankMessage(prev: Ranking, msg: RankMessage, currentReqId: 
   }
   if (msg.kind === 'progress') {
     if (prev.status !== 'loading') {
-      return null; // its own result already landed; a bar must never outlive the verdict
+      return null; // settled (in practice: by worker.onerror) — a bar must never outlive a verdict
     }
     const { kind: _kind, reqId: _reqId, ...progress } = msg;
     return { status: 'loading', ...progress };
@@ -103,7 +107,7 @@ export function useRanking(input: RankingInput): Ranking {
     // first frame, never an empty message. The phase is `queued`, the one the worker never sends,
     // because it is the only thing the MAIN THREAD can honestly claim here: the request has been
     // handed over and nothing has been observed back. Naming `assembling` would be an assertion,
-    // not an observation, and it is wrong for a measured 62.3 s whenever the worker is still
+    // not an observation, and it is wrong for a measured 62.3 s (2026-08-30) whenever the worker is still
     // enumerating a superseded run (its event loop cannot dequeue this message until it returns).
     setRanking({ status: 'loading', phase: 'queued' });
     workerRef.current?.postMessage({ reqId, name, asm, target, ...(symbols ? { symbols } : {}) } satisfies RankRequest);

--- a/apps/web/src/pages/playground/useRanking.ts
+++ b/apps/web/src/pages/playground/useRanking.ts
@@ -4,24 +4,28 @@
 // AFTER the user has edited the asm. If the resolved (best) source were then shown against the new
 // asm, the badge would claim "matched (0)" for the wrong input — a false byte-exact match, the
 // cardinal sin. Two layers close it: (1) the view is DERIVED from the input it is about, so a
-// render for a changed input shows `loading` and never the previous input's badge — this used to be
-// a reset inside the posting effect, which lands one commit too late (measured: a 27 ms window with
-// the new function named beside the old run's counts); (2) each request carries a monotonic reqId,
-// the latest is remembered, and the worker's response is ACCEPTED ONLY when its reqId is still the
-// current one — a superseded response is dropped. So the ranked source shown is always for the asm
-// on screen, or nothing.
+// render for a changed input shows `loading` and never the previous input's badge; (2) each request
+// carries a monotonic reqId, the latest is remembered, and the worker's response is ACCEPTED ONLY
+// when its reqId is still the current one — a superseded response is dropped. So the ranked source
+// shown is always for the asm on screen, or nothing.
 //
 // PROGRESS IS UNDER THE SAME GUARD. A progress tick is a message from the worker, so a tick
 // stamped with a superseded reqId is dropped exactly like a superseded result — otherwise the bar
 // would report another input's run against the asm now on screen. Both rules live in ONE pure
 // function, `applyRankMessage`, which returns null for "drop this message"; the hook has no second
 // way to settle state, and the rules are testable without a DOM (apps/web has no jsdom).
+//
+// WHAT THIS GUARD DOES NOT COVER, measured 2026-08-30: the editor's own text leads the WHOLE
+// pipeline by Playground's 250 ms input debounce — 269 ms from a keystroke to the first `queued`
+// frame on one measured edit. During it the badge, the Source panel and the IR all still describe
+// the previous input, so they agree with each other and disagree only with the raw editor buffer.
+// That is a property of the debounce, not of this file; narrowing it is a Playground change.
 import type { SymbolMap } from '@asmlift/core/symbols';
 import type { TargetDescription } from '@asmlift/core/target';
 import { useEffect, useRef, useState } from 'react';
 
 import type { RankProgress } from './rank-progress';
-import type { BrowserRanking, RankMessage, RankRequest } from './score-wasm';
+import type { BrowserRanking, RankMessage, RankRequest, RankSupersede } from './score-wasm';
 
 export type Ranking =
   | { status: 'off' } // not an agbcc/C run, or no valid input
@@ -36,11 +40,10 @@ export type Ranking =
  *   1. any message (progress or result) whose reqId is not the current one — it belongs to an asm
  *      the user has already edited away from, and rendering it is the cardinal sin H1 names;
  *   2. a progress tick arriving into a request that has ALREADY SETTLED — it would re-open the
- *      spinner over a finished verdict. Its live path is `worker.onerror` below, NOT "its own
- *      result already landed": postMessage is FIFO per port, so a run's ticks always precede its
- *      own result. `onerror` settles `{status:'error'}` while the still-CURRENT run keeps emitting
- *      under the still-current reqId, and without this rule the bar would visibly re-open over the
- *      loud error — constraint 4, a failure path that must stay loud;
+ *      spinner over a finished verdict. Its live path is `worker.onerror`, NOT "its own result
+ *      already landed": postMessage is FIFO per port, so a run's ticks always precede its own
+ *      result. `onerror` settles `{status:'error'}` while the still-CURRENT run keeps emitting
+ *      under the still-current reqId, and without this rule the bar re-opens over the loud error;
  *   3. progress into anything but `loading` — enforced by the type, not by a convention. */
 export function applyRankMessage(prev: Ranking, msg: RankMessage, currentReqId: number): Ranking | null {
   if (msg.reqId !== currentReqId) {
@@ -56,6 +59,21 @@ export function applyRankMessage(prev: Ranking, msg: RankMessage, currentReqId: 
   return msg.ok ? { status: 'ok', result: msg.result } : { status: 'error', error: msg.error };
 }
 
+/** The stored pair: a ranking, and the input that ranking is ABOUT. */
+export interface StoredRanking {
+  input: RankingInput;
+  ranking: Ranking;
+}
+
+/** `applyRankMessage` lifted to the stored pair — the React updater itself, so it must be pure and
+ *  it must return the SAME OBJECT for a dropped message. Identity is the point: `Object.is` is what
+ *  makes React bail out, and rebuilding `{ ...stored }` for a message that changed nothing commits a
+ *  whole Playground render per dropped tick. Every tick of an abandoned run is a dropped tick. */
+export function applyToStored(stored: StoredRanking, msg: RankMessage, currentReqId: number): StoredRanking {
+  const ranking = applyRankMessage(stored.ranking, msg, currentReqId);
+  return ranking === null ? stored : { input: stored.input, ranking };
+}
+
 export interface RankingInput {
   /** true only for an agbcc target + C backend with a valid function name and non-empty asm. */
   eligible: boolean;
@@ -68,9 +86,12 @@ export interface RankingInput {
   symbols?: SymbolMap;
 }
 
-/** Do two renders' inputs describe the SAME ranking question? Compared field by field, on exactly
- *  the fields the request-posting effect depends on — `asm` is compared by reference in the common
- *  case (same string object), never rebuilt into a key, so this costs nothing at 10 Hz. */
+/** Do two renders' inputs describe the SAME ranking question? THE ONE LIST: `viewRanking` and the
+ *  request-posting effect both ask HERE, rather than one of them re-enumerating the fields as a
+ *  dependency array. Two lists that disagree is a specific silent failure — a field that reaches
+ *  the view's guard but not the effect's leaves the badge on `queued` with no request in flight,
+ *  the perpetual spinner this file's header swears off. `asm` is compared by reference in the
+ *  common case (same string object), never rebuilt into a key, so this costs nothing per render. */
 export function sameRankingInput(a: RankingInput, b: RankingInput): boolean {
   return (
     a.eligible === b.eligible &&
@@ -83,25 +104,19 @@ export function sameRankingInput(a: RankingInput, b: RankingInput): boolean {
 }
 
 /** What to SHOW for `input`, given the state that was last stored and the input that state is
- *  about. H1 LAYER 1, MOVED OFF THE EFFECT.
+ *  about. H1 LAYER 1, AND IT IS DERIVED, NEVER SCHEDULED.
  *
- *  Resetting to `loading` inside a `useEffect` runs one commit too late: the effect fires AFTER the
- *  render that already painted the new input, so for that one commit the badge belongs to the
- *  previous one. Measured in the app on 2026-08-30, switching examples mid-run on an 800-candidate
- *  fan: the FUNCTION field read the new `half` at t=935 ms while the badge still counted
- *  `scoring 52 / 800`, and the reset landed at t=962 ms — a 27 ms window, one commit wide. (The
- *  ~1 s that precedes it is the deliberate 250 ms input debounce, stretched by Chrome's background-
- *  tab timer clamp; during it the WHOLE pipeline still shows the previous input, which is coherent.
- *  Only the editor text is ahead.) Derived instead, the window is zero: re-measured after this
- *  change, the first frame carrying the new function already reads `waiting for the ranking
- *  worker…`.
+ *  Resetting to `loading` from a `useEffect` lands one commit too late: the effect fires AFTER the
+ *  render that already painted the new input, so for that commit the badge belongs to the previous
+ *  one — measured at 27 ms on 2026-08-30, switching examples mid-run on an 800-candidate fan (the
+ *  FUNCTION field read the new `half` while the badge still counted `scoring 52 / 800`). Derived,
+ *  the window is zero, because the state carries the input it is about and anything else renders
+ *  as the honest `queued`.
  *
- *  27 ms is not the point — a scheduled invariant is. The counts this round added are what made the
- *  mismatch legible at all, and the same window renders a settled VERDICT for an asm no longer on
- *  screen, which is the cardinal sin H1 exists to prevent. Derived, it cannot lag: state carries
- *  the input it is about, and anything else renders as the honest `queued`. The reqId guard still
- *  does its own job on the message side — this closes the window BEFORE a request even exists. */
-export function viewRanking(input: RankingInput, stored: { input: RankingInput; ranking: Ranking }): Ranking {
+ *  27 ms is not the point; a scheduled invariant is. The same window renders a settled VERDICT for
+ *  an asm no longer on screen, which is the cardinal sin H1 exists to prevent, and it closes here
+ *  BEFORE a request exists — the reqId guard still does its own job on the message side. */
+export function viewRanking(input: RankingInput, stored: StoredRanking): Ranking {
   if (!input.eligible || !input.name) {
     return { status: 'off' };
   }
@@ -109,19 +124,12 @@ export function viewRanking(input: RankingInput, stored: { input: RankingInput; 
 }
 
 export function useRanking(input: RankingInput): Ranking {
-  const { eligible, asm, name, targetId, target, symbols } = input;
   // The state carries the INPUT it is about, so a render for a different input cannot show it.
-  const [stored, setStored] = useState<{ input: RankingInput; ranking: Ranking }>({
-    input,
-    ranking: { status: 'off' },
-  });
-  const setRanking = (next: Ranking | ((prev: Ranking) => Ranking)) =>
-    setStored((prev) => ({
-      input: prev.input,
-      ranking: typeof next === 'function' ? next(prev.ranking) : next,
-    }));
+  const [stored, setStored] = useState<StoredRanking>({ input, ranking: { status: 'off' } });
   const workerRef = useRef<Worker | null>(null);
-  const currentReqId = useRef(0); // the id of the latest posted request — the stale-guard anchor
+  const currentReqId = useRef(0); // the id of the latest posted message — the stale-guard anchor
+  // The input the CURRENT worker was last told about — what makes `sameRankingInput` the only list.
+  const requested = useRef<RankingInput | null>(null);
   // The last COMMITTED input, for the one writer that is not a reply to a request: `worker.onerror`
   // fires from a closure created once, and an error stored against a stale input would be derived
   // away — a loud failure silently swallowed, which is the trade this repo never makes.
@@ -134,10 +142,14 @@ export function useRanking(input: RankingInput): Ranking {
   // while its reqId is still the current one.
   useEffect(() => {
     const worker = new Worker(new URL('./rank.worker.ts', import.meta.url), { type: 'module' });
-    // The functional form is what gives `applyRankMessage` the PREVIOUS state (rule 2 needs it)
-    // without a second ref; returning `prev` unchanged is a React bail-out.
-    worker.onmessage = (e: MessageEvent<RankMessage>) =>
-      setRanking((prev) => applyRankMessage(prev, e.data, currentReqId.current) ?? prev);
+    worker.onmessage = (e: MessageEvent<RankMessage>) => {
+      // The id is read HERE, not inside the updater: React may re-invoke an updater, and an
+      // updater that reads a ref is not a pure function of its argument.
+      const reqId = currentReqId.current;
+      // The functional form is what gives `applyRankMessage` the PREVIOUS state (rule 2 needs it)
+      // without a second ref; `applyToStored` returns that same state for a dropped message.
+      setStored((prev) => applyToStored(prev, e.data, reqId));
+    };
     // A worker that fails to LOAD (a bad wasm import, a syntax error) would otherwise never reply,
     // leaving ranking stuck on "loading" forever. Surface it as an error instead — never a silent
     // perpetual spinner. Only while a request is actually in flight, so a benign teardown is quiet.
@@ -154,25 +166,40 @@ export function useRanking(input: RankingInput): Ranking {
     return () => {
       worker.terminate();
       workerRef.current = null;
+      requested.current = null; // the next worker has been told nothing (StrictMode remounts one)
     };
   }, []);
 
+  // No dependency array: `sameRankingInput` IS the dependency check, so the fields live in one
+  // place. The body runs per render and returns after six identity comparisons.
   useEffect(() => {
-    if (!eligible || !name) {
-      currentReqId.current++; // invalidate any in-flight response
-      setStored({ input, ranking: { status: 'off' } });
+    if (requested.current && sameRankingInput(requested.current, input)) {
       return;
     }
-    const reqId = ++currentReqId.current; // new request supersedes anything in flight
-    // Clear any prior result from the view immediately (H1 layer 1) — with a named phase from the
-    // first frame, never an empty message. The phase is `queued`, the one the worker never sends,
-    // because it is the only thing the MAIN THREAD can honestly claim here: the request has been
-    // handed over and nothing has been observed back. Naming `assembling` would be an assertion,
-    // not an observation, and it is wrong for a measured 62.3 s (2026-08-30) whenever the worker is still
-    // enumerating a superseded run (its event loop cannot dequeue this message until it returns).
+    requested.current = input;
+    const reqId = ++currentReqId.current; // anything in flight is now superseded
+    if (!input.eligible || !input.name) {
+      setStored({ input, ranking: { status: 'off' } });
+      // Tell the worker, too. Bumping the id alone invalidates the in-flight RESPONSE and leaves
+      // the run posting ticks nobody will read for the rest of its life (`RankSupersede`).
+      workerRef.current?.postMessage({ kind: 'supersede', reqId } satisfies RankSupersede);
+      return;
+    }
+    // `queued`, not `assembling`: the request has been handed over and nothing has been observed
+    // back, which is the only thing the MAIN THREAD can honestly claim here. Naming a phase nobody
+    // observed would be wrong for a measured 62.3 s (2026-08-30) whenever the worker is still
+    // enumerating a superseded run — its event loop cannot dequeue this message until that
+    // returns.
     setStored({ input, ranking: { status: 'loading', phase: 'queued' } });
-    workerRef.current?.postMessage({ reqId, name, asm, target, ...(symbols ? { symbols } : {}) } satisfies RankRequest);
-  }, [eligible, asm, name, targetId, target, symbols]);
+    workerRef.current?.postMessage({
+      kind: 'request',
+      reqId,
+      name: input.name,
+      asm: input.asm,
+      target: input.target,
+      ...(input.symbols ? { symbols: input.symbols } : {}),
+    } satisfies RankRequest);
+  }, [input]);
 
   return viewRanking(input, stored);
 }

--- a/apps/web/test/progress-view.test.ts
+++ b/apps/web/test/progress-view.test.ts
@@ -62,21 +62,3 @@ describe('progressLabel', () => {
     expect(progressLabel({ phase: 'scoring', done: 1, total: 2 })).toBe('scoring 1 / 2 candidates');
   });
 });
-
-describe('progressLabel', () => {
-  test('`queued` is a phase the WORKER never emits — the main thread sets it, and it claims nothing', () => {
-    // The hook cannot observe `assembling`: it only knows it posted. On a busy worker (a superseded
-    // run enumerating for a measured 62.3 s) `assembling` would be false for the whole wait.
-    expect(progressLabel({ phase: 'queued' })).toBe('waiting for the ranking worker…');
-    expect(progressBar({ phase: 'queued' }).determinate).toBe(false);
-  });
-
-  test('every phase has a sentence — the badge is never empty', () => {
-    for (const phase of ['queued', 'assembling', 'enumerating', 'ranking'] as const) {
-      expect(progressLabel({ phase }).length).toBeGreaterThan(0);
-    }
-    // `scoring` is the one phase that CANNOT be spelled without counts — the union says so, and a
-    // count-less scoring tick is now a compile error rather than a defensive branch.
-    expect(progressLabel({ phase: 'scoring', done: 1, total: 2 })).toBe('scoring 1 / 2 candidates');
-  });
-});

--- a/apps/web/test/progress-view.test.ts
+++ b/apps/web/test/progress-view.test.ts
@@ -1,0 +1,82 @@
+// The ranking progress VIEW — the sentence and the bar geometry (src/pages/playground/progress-view.ts).
+// Split from rank-progress.test.ts along the same seam the modules split on: this half is what the
+// user reads, and every rule below is an honesty rule rather than a styling one.
+//
+//  • an indeterminate phase has NO total and NO percentage — no fabricated denominator, no "0 %";
+//  • a determinate bar's `aria-valuenow` is the EXACT count while its fill never reads 100 %,
+//    because the sort and a six-figure structured clone still follow the last scoring tick.
+import { describe, expect, test } from 'vitest';
+
+import { progressBar, progressLabel } from '../src/pages/playground/progress-view';
+
+describe('progressBar', () => {
+  test('an indeterminate phase carries NO total and no fabricated percentage', () => {
+    for (const phase of ['queued', 'assembling', 'enumerating', 'ranking'] as const) {
+      const bar = progressBar({ phase });
+      expect(bar.determinate).toBe(false);
+      expect('valueNow' in bar).toBe(false); // the ARIA spelling of indeterminate is OMISSION
+      expect('valueMax' in bar).toBe(false);
+      expect(bar.label).not.toMatch(/\d/); // no count, no "0%", no invented denominator
+    }
+  });
+
+  test('a determinate bar reports the exact counts and never fills to 100%', () => {
+    const bar = progressBar({ phase: 'scoring', done: 117760, total: 117760 });
+    if (!bar.determinate) {
+      throw new Error('a scoring tick with a real total must be determinate');
+    }
+    expect(bar.valueNow).toBe(117760); // aria-valuenow stays EXACT
+    expect(bar.valueMax).toBe(117760);
+    expect(bar.pct).toBeLessThanOrEqual(99); // the FILL never reads "finished" while work follows
+    expect(bar.label).toBe('scoring 117,760 / 117,760 candidates'); // grouped, not 117760
+  });
+
+  test('a zero total is indeterminate — no division by zero, and no equal ARIA bounds', () => {
+    // ARIA requires aria-valuemax > aria-valuemin; `0 / 0` on both would leave the AT-computed
+    // percentage undefined. The enumeration that produces it goes on to throw `no scorable
+    // candidate`, so this is a transient state — but it is a REACHABLE one.
+    const bar = progressBar({ phase: 'scoring', done: 0, total: 0 });
+    expect(bar.determinate).toBe(false);
+    expect('pct' in bar).toBe(false); // no "0 % of an unknown denominator" on the indeterminate arm
+  });
+
+  test('the indeterminate arm carries no pct at all — a number nobody may read', () => {
+    expect('pct' in progressBar({ phase: 'enumerating' })).toBe(false);
+  });
+});
+
+describe('progressLabel', () => {
+  test('`queued` is a phase the WORKER never emits — the main thread sets it, and it claims nothing', () => {
+    // The hook cannot observe `assembling`: it only knows it posted. On a busy worker (a superseded
+    // run enumerating for a measured 62.3 s) `assembling` would be false for the whole wait.
+    expect(progressLabel({ phase: 'queued' })).toBe('waiting for the ranking worker…');
+    expect(progressBar({ phase: 'queued' }).determinate).toBe(false);
+  });
+
+  test('every phase has a sentence — the badge is never empty', () => {
+    for (const phase of ['queued', 'assembling', 'enumerating', 'ranking'] as const) {
+      expect(progressLabel({ phase }).length).toBeGreaterThan(0);
+    }
+    // `scoring` is the one phase that CANNOT be spelled without counts — the union says so, and a
+    // count-less scoring tick is now a compile error rather than a defensive branch.
+    expect(progressLabel({ phase: 'scoring', done: 1, total: 2 })).toBe('scoring 1 / 2 candidates');
+  });
+});
+
+describe('progressLabel', () => {
+  test('`queued` is a phase the WORKER never emits — the main thread sets it, and it claims nothing', () => {
+    // The hook cannot observe `assembling`: it only knows it posted. On a busy worker (a superseded
+    // run enumerating for a measured 62.3 s) `assembling` would be false for the whole wait.
+    expect(progressLabel({ phase: 'queued' })).toBe('waiting for the ranking worker…');
+    expect(progressBar({ phase: 'queued' }).determinate).toBe(false);
+  });
+
+  test('every phase has a sentence — the badge is never empty', () => {
+    for (const phase of ['queued', 'assembling', 'enumerating', 'ranking'] as const) {
+      expect(progressLabel({ phase }).length).toBeGreaterThan(0);
+    }
+    // `scoring` is the one phase that CANNOT be spelled without counts — the union says so, and a
+    // count-less scoring tick is now a compile error rather than a defensive branch.
+    expect(progressLabel({ phase: 'scoring', done: 1, total: 2 })).toBe('scoring 1 / 2 candidates');
+  });
+});

--- a/apps/web/test/rank-badge-render.test.tsx
+++ b/apps/web/test/rank-badge-render.test.tsx
@@ -1,0 +1,45 @@
+// The progress BAR as it actually renders. apps/web has no jsdom and no @testing-library, but
+// these components are plain functions of props, so `renderToStaticMarkup` gives the real markup
+// without a DOM — enough to hold the two rules a bar breaks silently:
+//   • an INDETERMINATE phase emits no `aria-valuenow` (that omission is the ARIA spelling of
+//     indeterminate) and no fabricated denominator anywhere in the markup;
+//   • a determinate bar's `aria-valuenow` is the EXACT count while its fill width never reads 100 %,
+//     because sorting and the structured clone of a six-figure array still follow the last tick.
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, test } from 'vitest';
+
+import { RankBadge, RankCandidates } from '../src/pages/playground/RankPanel';
+import type { Ranking } from '../src/pages/playground/useRanking';
+
+const html = (r: Ranking) => renderToStaticMarkup(<RankBadge ranking={r} />);
+
+describe('RankBadge progress', () => {
+  test('an indeterminate phase is a progressbar with a text alternative and NO valuenow', () => {
+    const out = html({ status: 'loading', phase: 'enumerating' });
+    expect(out).toContain('role="progressbar"');
+    expect(out).not.toContain('aria-valuenow');
+    expect(out).not.toContain('aria-valuemax');
+    expect(out).toContain('enumerating candidate spellings');
+    expect(out).toContain('aria-valuetext="enumerating candidate spellings…"');
+  });
+
+  test('scoring with a real total is determinate: exact aria counts, fill below 100%', () => {
+    const out = html({ status: 'loading', phase: 'scoring', done: 117760, total: 117760 });
+    expect(out).toContain('aria-valuemin="0"');
+    expect(out).toContain('aria-valuemax="117760"');
+    expect(out).toContain('aria-valuenow="117760"'); // exact, not clamped
+    expect(out).toContain('scoring 117,760 / 117,760 candidates'); // grouped for the eye
+    expect(out).not.toMatch(/width:\s*100%/); // the pixels never say "finished" over live work
+    expect(out).toMatch(/width:\s*99%/);
+  });
+
+  test('the settled states carry no progressbar at all', () => {
+    expect(html({ status: 'error', error: 'boom' })).not.toContain('progressbar');
+    expect(html({ status: 'off' })).toBe('');
+  });
+
+  test('the Pipeline card shows the SAME sentence as the badge — one helper, no drift', () => {
+    const r: Ranking = { status: 'loading', phase: 'scoring', done: 5, total: 9 };
+    expect(renderToStaticMarkup(<RankCandidates ranking={r} />)).toContain('scoring 5 / 9 candidates');
+  });
+});

--- a/apps/web/test/rank-badge-render.test.tsx
+++ b/apps/web/test/rank-badge-render.test.tsx
@@ -4,7 +4,11 @@
 //   • an INDETERMINATE phase emits no `aria-valuenow` (that omission is the ARIA spelling of
 //     indeterminate) and no fabricated denominator anywhere in the markup;
 //   • a determinate bar's `aria-valuenow` is the EXACT count while its fill width never reads 100 %,
-//     because sorting and the structured clone of a six-figure array still follow the last tick.
+//     because sorting and the structured clone of a six-figure array still follow the last tick;
+//   • the widget has an accessible NAME and the visible sentence is not inside it (`progressbar` is
+//     a children-presentational role — anything inside it is pruned from the a11y tree);
+//   • the indeterminate stripe only exists under `motion-safe`, because parked it is pixel-identical
+//     to a determinate 33 % bar.
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, test } from 'vitest';
 
@@ -21,6 +25,32 @@ describe('RankBadge progress', () => {
     expect(out).not.toContain('aria-valuemax');
     expect(out).toContain('enumerating candidate spellings');
     expect(out).toContain('aria-valuetext="enumerating candidate spellings…"');
+  });
+
+  test('the progressbar has an accessible NAME, and the visible sentence sits OUTSIDE it', () => {
+    // `progressbar` is children-presentational: a label inside it is pruned from the accessibility
+    // tree, leaving an unnamed widget carrying only aria-valuetext. The sentence is a sibling.
+    const out = html({ status: 'loading', phase: 'enumerating' });
+    expect(out).toContain('aria-label="candidate ranking"');
+    expect(out.indexOf('<span>enumerating candidate spellings…</span>')).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf('<span>enumerating')).toBeLessThan(out.indexOf('role="progressbar"'));
+  });
+
+  test('the indeterminate stripe TRAVELS or is not rendered — never a parked third of a track', () => {
+    // animate-pulse fades opacity only, so `w-1/3 animate-pulse` was pixel-identical to a
+    // determinate 33 % fill for the whole 62 s enumeration. It travels under motion-safe, and under
+    // prefers-reduced-motion the track is simply empty.
+    const out = html({ status: 'loading', phase: 'enumerating' });
+    expect(out).toContain('motion-safe:animate-rank-indeterminate');
+    expect(out).toContain('hidden'); // …and `motion-safe:block` is what un-hides it
+    expect(out).toContain('motion-safe:block');
+    expect(out).not.toContain('animate-pulse');
+  });
+
+  test("the determinate width transition is motion-gated too — this is the app's only animation", () => {
+    const out = html({ status: 'loading', phase: 'scoring', done: 5, total: 9 });
+    expect(out).toContain('motion-safe:transition-[width]');
+    expect(out).not.toMatch(/(?<!motion-safe:)transition-\[width\]/); // never ungated
   });
 
   test('scoring with a real total is determinate: exact aria counts, fill below 100%', () => {

--- a/apps/web/test/rank-badge-render.test.tsx
+++ b/apps/web/test/rank-badge-render.test.tsx
@@ -41,9 +41,10 @@ describe('RankBadge progress', () => {
     // determinate 33 % fill for the whole 62 s enumeration. It travels under motion-safe, and under
     // prefers-reduced-motion the track is simply empty.
     const out = html({ status: 'loading', phase: 'enumerating' });
-    expect(out).toContain('motion-safe:animate-rank-indeterminate');
-    expect(out).toContain('hidden'); // …and `motion-safe:block` is what un-hides it
-    expect(out).toContain('motion-safe:block');
+    // Matched on the STRIPE's own class list: the track around it carries `overflow-hidden`, so a
+    // bare `toContain('hidden')` passes even with the stripe's `hidden` deleted — i.e. with the
+    // reduced-motion rule this test names broken.
+    expect(out).toMatch(/class="hidden [^"]*motion-safe:block[^"]*motion-safe:animate-rank-indeterminate/);
     expect(out).not.toContain('animate-pulse');
   });
 

--- a/apps/web/test/rank-progress.test.ts
+++ b/apps/web/test/rank-progress.test.ts
@@ -68,27 +68,34 @@ describe('progressBar', () => {
     for (const phase of ['queued', 'assembling', 'enumerating', 'ranking'] as const) {
       const bar = progressBar({ phase });
       expect(bar.determinate).toBe(false);
-      expect(bar.valueNow).toBeUndefined();
-      expect(bar.valueMax).toBeUndefined();
+      expect('valueNow' in bar).toBe(false); // the ARIA spelling of indeterminate is OMISSION
+      expect('valueMax' in bar).toBe(false);
       expect(bar.label).not.toMatch(/\d/); // no count, no "0%", no invented denominator
     }
   });
 
-  test('scoring before the total exists is still indeterminate', () => {
-    expect(progressBar({ phase: 'scoring' }).determinate).toBe(false);
-  });
-
   test('a determinate bar reports the exact counts and never fills to 100%', () => {
     const bar = progressBar({ phase: 'scoring', done: 117760, total: 117760 });
-    expect(bar.determinate).toBe(true);
+    if (!bar.determinate) {
+      throw new Error('a scoring tick with a real total must be determinate');
+    }
     expect(bar.valueNow).toBe(117760); // aria-valuenow stays EXACT
     expect(bar.valueMax).toBe(117760);
     expect(bar.pct).toBeLessThanOrEqual(99); // the FILL never reads "finished" while work follows
     expect(bar.label).toBe('scoring 117,760 / 117,760 candidates'); // grouped, not 117760
   });
 
-  test('a zero total cannot divide by zero', () => {
-    expect(progressBar({ phase: 'scoring', done: 0, total: 0 }).pct).toBe(0);
+  test('a zero total is indeterminate — no division by zero, and no equal ARIA bounds', () => {
+    // ARIA requires aria-valuemax > aria-valuemin; `0 / 0` on both would leave the AT-computed
+    // percentage undefined. The enumeration that produces it goes on to throw `no scorable
+    // candidate`, so this is a transient state — but it is a REACHABLE one.
+    const bar = progressBar({ phase: 'scoring', done: 0, total: 0 });
+    expect(bar.determinate).toBe(false);
+    expect('pct' in bar).toBe(false); // no "0 % of an unknown denominator" on the indeterminate arm
+  });
+
+  test('the indeterminate arm carries no pct at all — a number nobody may read', () => {
+    expect('pct' in progressBar({ phase: 'enumerating' })).toBe(false);
   });
 });
 
@@ -101,9 +108,12 @@ describe('progressLabel', () => {
   });
 
   test('every phase has a sentence — the badge is never empty', () => {
-    for (const phase of ['queued', 'assembling', 'enumerating', 'scoring', 'ranking'] as const) {
+    for (const phase of ['queued', 'assembling', 'enumerating', 'ranking'] as const) {
       expect(progressLabel({ phase }).length).toBeGreaterThan(0);
     }
+    // `scoring` is the one phase that CANNOT be spelled without counts — the union says so, and a
+    // count-less scoring tick is now a compile error rather than a defensive branch.
+    expect(progressLabel({ phase: 'scoring', done: 1, total: 2 })).toBe('scoring 1 / 2 candidates');
   });
 });
 

--- a/apps/web/test/rank-progress.test.ts
+++ b/apps/web/test/rank-progress.test.ts
@@ -10,7 +10,7 @@
 // or sit on a stale phase for a whole tail.
 import { describe, expect, test } from 'vitest';
 
-import { type RankProgress, throttleProgress } from '../src/pages/playground/rank-progress';
+import { type RankProgress, throttleProgress, whileCurrent } from '../src/pages/playground/rank-progress';
 import type { BrowserRanking, RankMessage } from '../src/pages/playground/score-wasm';
 import { type Ranking, applyRankMessage } from '../src/pages/playground/useRanking';
 
@@ -60,6 +60,45 @@ describe('throttleProgress', () => {
     advance(1);
     emit({ phase: 'scoring', done: 3, total: 3 }); // done === total: exempt from the throttle
     expect(seen.at(-1)).toEqual({ phase: 'scoring', done: 3, total: 3 });
+  });
+});
+
+describe('whileCurrent', () => {
+  test('a superseded run stops posting entirely — it does not merely get its ticks dropped later', () => {
+    // The worker's onmessage is async, so two runs interleave: before this, an abandoned 800-
+    // candidate run posted 286 ticks over 78 s after being superseded, every one a main-thread
+    // wake-up for a message `applyRankMessage` would discard.
+    let current = true;
+    const seen: RankProgress[] = [];
+    const post = whileCurrent(
+      () => current,
+      (p) => seen.push(p),
+    );
+    post({ phase: 'assembling' });
+    current = false;
+    for (let i = 0; i < 100; i++) {
+      post({ phase: 'scoring', done: i, total: 100 });
+    }
+    post({ phase: 'ranking' }); // not even a phase change survives supersession
+    expect(seen).toEqual([{ phase: 'assembling' }]);
+  });
+
+  test('composed under the throttle it changes nothing while the run IS current', () => {
+    let t = 0;
+    const seen: RankProgress[] = [];
+    const emit = throttleProgress(
+      whileCurrent(
+        () => true,
+        (p) => seen.push(p),
+      ),
+      () => t,
+      100,
+    );
+    emit({ phase: 'scoring', done: 0, total: 3 });
+    t += 1;
+    emit({ phase: 'scoring', done: 1, total: 3 }); // throttled, as before
+    emit({ phase: 'ranking' }); // a phase change is still exempt
+    expect(seen).toEqual([{ phase: 'scoring', done: 0, total: 3 }, { phase: 'ranking' }]);
   });
 });
 

--- a/apps/web/test/rank-progress.test.ts
+++ b/apps/web/test/rank-progress.test.ts
@@ -11,7 +11,8 @@
 import { describe, expect, test } from 'vitest';
 
 import { type RankProgress, progressBar, progressLabel, throttleProgress } from '../src/pages/playground/rank-progress';
-import type { RankMessage } from '../src/pages/playground/score-wasm';
+import type { BrowserRanking, RankMessage } from '../src/pages/playground/score-wasm';
+import { type Ranking, applyRankMessage } from '../src/pages/playground/useRanking';
 
 /** A hand-cranked clock: the throttle is keyed on elapsed WALL TIME (per-candidate cost was
  *  measured between 25 ms and 167 ms on one function, so a count-keyed throttle posts at wildly
@@ -127,5 +128,65 @@ describe('RankMessage', () => {
 
   test('both result shapes still route to the result branch', () => {
     expect(describeMessage({ kind: 'result', reqId: 1, ok: false, error: 'boom' })).toBe('error:boom');
+  });
+});
+
+// ── H1, the stale-guard, now with progress under it ──────────────────────────────────────────
+// useRanking.ts's whole file comment is about H1 (an audit CRITICAL): ranking is async, so a score
+// can resolve AFTER the user has edited the asm, and showing it would claim a byte-exact match for
+// the wrong input. A PROGRESS message is a message from the worker and is subject to exactly the
+// same guard. `applyRankMessage` is the one pure place both rules live, and it returns null for
+// "drop this message" so the hook has no second way to settle state.
+//
+// The existing H1 reasoning had no test at all before this file; case (d) pins it.
+const RESULT = {
+  best: { label: 'unsigned', source: '', symbolRefs: [], score: { score: 0 } },
+  candidates: [],
+  dropped: [],
+  withheld: [],
+  refused: [],
+} as unknown as BrowserRanking;
+
+describe('applyRankMessage (H1)', () => {
+  test('(a) a PROGRESS message from a superseded request is dropped', () => {
+    const prev: Ranking = { status: 'loading', phase: 'enumerating' };
+    expect(applyRankMessage(prev, { kind: 'progress', reqId: 1, phase: 'scoring', done: 5, total: 9 }, 2)).toBeNull();
+  });
+
+  test('(b) a progress tick that arrives after its own result cannot resurrect the spinner', () => {
+    const settled: Ranking = { status: 'ok', result: RESULT };
+    expect(
+      applyRankMessage(settled, { kind: 'progress', reqId: 3, phase: 'scoring', done: 5, total: 9 }, 3),
+    ).toBeNull();
+    const failed: Ranking = { status: 'error', error: 'boom' };
+    expect(applyRankMessage(failed, { kind: 'progress', reqId: 3, phase: 'ranking' }, 3)).toBeNull();
+  });
+
+  test('(c) a current-reqId progress message yields loading with the phase and counts', () => {
+    const prev: Ranking = { status: 'loading', phase: 'assembling' };
+    expect(applyRankMessage(prev, { kind: 'progress', reqId: 4, phase: 'scoring', done: 5, total: 9 }, 4)).toEqual({
+      status: 'loading',
+      phase: 'scoring',
+      done: 5,
+      total: 9,
+    });
+  });
+
+  test('(d) a superseded RESULT is still dropped — ok and error alike', () => {
+    const prev: Ranking = { status: 'loading', phase: 'scoring', done: 1, total: 2 };
+    expect(applyRankMessage(prev, { kind: 'result', reqId: 1, ok: true, result: RESULT }, 2)).toBeNull();
+    expect(applyRankMessage(prev, { kind: 'result', reqId: 1, ok: false, error: 'stale' }, 2)).toBeNull();
+  });
+
+  test('(e) progress does not leak into ok or error', () => {
+    const prev: Ranking = { status: 'loading', phase: 'scoring', done: 8, total: 9 };
+    const ok = applyRankMessage(prev, { kind: 'result', reqId: 5, ok: true, result: RESULT }, 5);
+    expect(ok).toEqual({ status: 'ok', result: RESULT });
+    const err = applyRankMessage(prev, { kind: 'result', reqId: 5, ok: false, error: 'no scorable candidate' }, 5);
+    expect(err).toEqual({ status: 'error', error: 'no scorable candidate' });
+    for (const next of [ok, err]) {
+      expect(next && 'phase' in next).toBe(false);
+      expect(next && 'done' in next).toBe(false);
+    }
   });
 });

--- a/apps/web/test/rank-progress.test.ts
+++ b/apps/web/test/rank-progress.test.ts
@@ -1,0 +1,99 @@
+// The playground's ranking PROGRESS, in the parts a node test can run: the emission throttle and
+// the pure view props the badge/pipeline card render from. They live in
+// src/pages/playground/rank-progress.ts rather than in score-wasm.ts for the reason
+// candidate-compile.test.ts documents: score-wasm.ts pulls in the `agbcc` package, which cannot be
+// imported under vitest's ESM loader.
+//
+// The rules under test are the ones a lying bar would break:
+//  • the throttle bounds the postMessage rate but NEVER swallows a phase change or the final tick,
+//    so the bar cannot stop short of the end or sit on a stale phase for a whole tail;
+//  • an indeterminate phase has NO total — no fabricated denominator, no "0%".
+import { describe, expect, test } from 'vitest';
+
+import { type RankProgress, progressBar, progressLabel, throttleProgress } from '../src/pages/playground/rank-progress';
+
+/** A hand-cranked clock: the throttle is keyed on elapsed WALL TIME (per-candidate cost was
+ *  measured between 25 ms and 167 ms on one function, so a count-keyed throttle posts at wildly
+ *  different rates), and an injected clock is how that is testable without timers. */
+function rig(intervalMs = 100) {
+  let t = 0;
+  const seen: RankProgress[] = [];
+  const emit = throttleProgress(
+    (p) => seen.push(p),
+    () => t,
+    intervalMs,
+  );
+  return { seen, emit, advance: (ms: number) => (t += ms) };
+}
+
+describe('throttleProgress', () => {
+  test('emits the first tick of a phase immediately, then suppresses until the interval elapses', () => {
+    const { seen, emit, advance } = rig();
+    emit({ phase: 'scoring', done: 0, total: 10 });
+    advance(50);
+    emit({ phase: 'scoring', done: 1, total: 10 });
+    expect(seen).toEqual([{ phase: 'scoring', done: 0, total: 10 }]);
+    advance(50);
+    emit({ phase: 'scoring', done: 2, total: 10 });
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toEqual({ phase: 'scoring', done: 2, total: 10 });
+  });
+
+  test('never suppresses a phase change', () => {
+    const { seen, emit } = rig();
+    emit({ phase: 'assembling' });
+    emit({ phase: 'enumerating' });
+    emit({ phase: 'scoring', done: 0, total: 4 });
+    emit({ phase: 'ranking' });
+    expect(seen.map((p) => p.phase)).toEqual(['assembling', 'enumerating', 'scoring', 'ranking']);
+  });
+
+  test('never drops the final tick of a determinate phase — the bar cannot stop short of the end', () => {
+    const { seen, emit, advance } = rig();
+    emit({ phase: 'scoring', done: 0, total: 3 });
+    advance(1);
+    emit({ phase: 'scoring', done: 1, total: 3 });
+    advance(1);
+    emit({ phase: 'scoring', done: 2, total: 3 });
+    advance(1);
+    emit({ phase: 'scoring', done: 3, total: 3 }); // done === total: exempt from the throttle
+    expect(seen.at(-1)).toEqual({ phase: 'scoring', done: 3, total: 3 });
+  });
+});
+
+describe('progressBar', () => {
+  test('an indeterminate phase carries NO total and no fabricated percentage', () => {
+    for (const phase of ['assembling', 'enumerating', 'ranking'] as const) {
+      const bar = progressBar({ phase });
+      expect(bar.determinate).toBe(false);
+      expect(bar.valueNow).toBeUndefined();
+      expect(bar.valueMax).toBeUndefined();
+      expect(bar.label).not.toMatch(/\d/); // no count, no "0%", no invented denominator
+    }
+  });
+
+  test('scoring before the total exists is still indeterminate', () => {
+    expect(progressBar({ phase: 'scoring' }).determinate).toBe(false);
+  });
+
+  test('a determinate bar reports the exact counts and never fills to 100%', () => {
+    const bar = progressBar({ phase: 'scoring', done: 117760, total: 117760 });
+    expect(bar.determinate).toBe(true);
+    expect(bar.valueNow).toBe(117760); // aria-valuenow stays EXACT
+    expect(bar.valueMax).toBe(117760);
+    expect(bar.pct).toBeLessThanOrEqual(99); // the FILL never reads "finished" while work follows
+    expect(bar.label).toBe('scoring 117,760 / 117,760 candidates'); // grouped, not 117760
+  });
+
+  test('a zero total cannot divide by zero', () => {
+    expect(progressBar({ phase: 'scoring', done: 0, total: 0 }).pct).toBe(0);
+  });
+});
+
+describe('progressLabel', () => {
+  test('every phase has a sentence — the badge is never empty', () => {
+    for (const phase of ['assembling', 'enumerating', 'scoring', 'ranking'] as const) {
+      expect(progressLabel({ phase }).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/test/rank-progress.test.ts
+++ b/apps/web/test/rank-progress.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { type RankProgress, progressBar, progressLabel, throttleProgress } from '../src/pages/playground/rank-progress';
+import type { RankMessage } from '../src/pages/playground/score-wasm';
 
 /** A hand-cranked clock: the throttle is keyed on elapsed WALL TIME (per-candidate cost was
  *  measured between 25 ms and 167 ms on one function, so a count-keyed throttle posts at wildly
@@ -95,5 +96,36 @@ describe('progressLabel', () => {
     for (const phase of ['assembling', 'enumerating', 'scoring', 'ranking'] as const) {
       expect(progressLabel({ phase }).length).toBeGreaterThan(0);
     }
+  });
+});
+
+// The worker protocol is now a THREE-shape union, so it is read on an explicit `kind` discriminant
+// rather than by sniffing for a property. A structural sniff is how a fourth message shape later
+// gets silently mis-routed — and mis-routing a progress message into the result branch would land
+// it in `{ status: 'error', error: undefined }`, a loud failure traded for a blank one.
+// (`score-wasm` is imported TYPE-ONLY here: the import is erased, so the `agbcc` package it pulls
+// in at runtime is never loaded.)
+function describeMessage(m: RankMessage): string {
+  switch (m.kind) {
+    case 'progress':
+      return `progress:${m.phase}`;
+    case 'result':
+      return m.ok ? `ok:${m.result.candidates.length}` : `error:${m.error}`;
+    default: {
+      const exhaustive: never = m;
+      return exhaustive;
+    }
+  }
+}
+
+describe('RankMessage', () => {
+  test('a progress message is discriminated by kind, never mistaken for a result', () => {
+    const progress: RankMessage = { kind: 'progress', reqId: 7, phase: 'scoring', done: 1, total: 2 };
+    expect(describeMessage(progress)).toBe('progress:scoring');
+    expect('ok' in progress).toBe(false);
+  });
+
+  test('both result shapes still route to the result branch', () => {
+    expect(describeMessage({ kind: 'result', reqId: 1, ok: false, error: 'boom' })).toBe('error:boom');
   });
 });

--- a/apps/web/test/rank-progress.test.ts
+++ b/apps/web/test/rank-progress.test.ts
@@ -65,7 +65,7 @@ describe('throttleProgress', () => {
 
 describe('progressBar', () => {
   test('an indeterminate phase carries NO total and no fabricated percentage', () => {
-    for (const phase of ['assembling', 'enumerating', 'ranking'] as const) {
+    for (const phase of ['queued', 'assembling', 'enumerating', 'ranking'] as const) {
       const bar = progressBar({ phase });
       expect(bar.determinate).toBe(false);
       expect(bar.valueNow).toBeUndefined();
@@ -93,8 +93,15 @@ describe('progressBar', () => {
 });
 
 describe('progressLabel', () => {
+  test('`queued` is a phase the WORKER never emits — the main thread sets it, and it claims nothing', () => {
+    // The hook cannot observe `assembling`: it only knows it posted. On a busy worker (a superseded
+    // run enumerating for a measured 62.3 s) `assembling` would be false for the whole wait.
+    expect(progressLabel({ phase: 'queued' })).toBe('waiting for the ranking worker…');
+    expect(progressBar({ phase: 'queued' }).determinate).toBe(false);
+  });
+
   test('every phase has a sentence — the badge is never empty', () => {
-    for (const phase of ['assembling', 'enumerating', 'scoring', 'ranking'] as const) {
+    for (const phase of ['queued', 'assembling', 'enumerating', 'scoring', 'ranking'] as const) {
       expect(progressLabel({ phase }).length).toBeGreaterThan(0);
     }
   });

--- a/apps/web/test/rank-progress.test.ts
+++ b/apps/web/test/rank-progress.test.ts
@@ -12,7 +12,13 @@ import { describe, expect, test } from 'vitest';
 
 import { type RankProgress, throttleProgress, whileCurrent } from '../src/pages/playground/rank-progress';
 import type { BrowserRanking, RankMessage } from '../src/pages/playground/score-wasm';
-import { type Ranking, applyRankMessage } from '../src/pages/playground/useRanking';
+import {
+  type Ranking,
+  type RankingInput,
+  applyRankMessage,
+  sameRankingInput,
+  viewRanking,
+} from '../src/pages/playground/useRanking';
 
 /** A hand-cranked clock: the throttle is keyed on elapsed WALL TIME (per-candidate cost was
  *  measured between 25 ms and 167 ms on one function, so a count-keyed throttle posts at wildly
@@ -201,6 +207,65 @@ describe('applyRankMessage (H1)', () => {
     for (const next of [ok, err]) {
       expect(next && 'phase' in next).toBe(false);
       expect(next && 'done' in next).toBe(false);
+    }
+  });
+});
+
+// ── H1 LAYER 1, the window the counts made visible ────────────────────────────────────────────
+// Resetting to `loading` inside the posting effect lands one commit AFTER the render that painted
+// the new input. Measured in the app on 2026-08-30, switching examples mid-run on an 800-candidate
+// fan: the FUNCTION field read the new `half` at t=935 ms while the badge still counted
+// `scoring 52 / 800`; the reset landed at t=962 ms. One commit, 27 ms — and the same window renders
+// a settled VERDICT for an asm no longer on screen. `viewRanking` derives the answer instead, so it
+// cannot lag: re-measured after the change, the first frame naming `half` already reads `queued`.
+const INPUT: RankingInput = {
+  eligible: true,
+  asm: 'push {r4}',
+  name: 'f',
+  targetId: 'agbcc',
+  target: {} as RankingInput['target'],
+};
+
+describe('viewRanking (H1 layer 1)', () => {
+  test('state belonging to ANOTHER input renders as queued, never as that input`s badge', () => {
+    const settled: Ranking = { status: 'ok', result: RESULT };
+    const scoring: Ranking = { status: 'loading', phase: 'scoring', done: 38, total: 800 };
+    const edited = { ...INPUT, asm: 'push {r4,r5}' };
+    for (const ranking of [settled, scoring, { status: 'error', error: 'boom' } as Ranking]) {
+      expect(viewRanking(edited, { input: INPUT, ranking })).toEqual({ status: 'loading', phase: 'queued' });
+    }
+  });
+
+  test('state for the SAME input is shown unchanged — the guard costs nothing when it should not fire', () => {
+    const scoring: Ranking = { status: 'loading', phase: 'scoring', done: 38, total: 800 };
+    expect(viewRanking(INPUT, { input: { ...INPUT }, ranking: scoring })).toBe(scoring);
+  });
+
+  test('an ineligible input is `off`, whatever is stored — no spinner over a non-agbcc target', () => {
+    expect(
+      viewRanking({ ...INPUT, eligible: false }, { input: INPUT, ranking: { status: 'ok', result: RESULT } }),
+    ).toEqual({
+      status: 'off',
+    });
+    expect(
+      viewRanking({ ...INPUT, name: undefined }, { input: INPUT, ranking: { status: 'ok', result: RESULT } }),
+    ).toEqual({
+      status: 'off',
+    });
+  });
+
+  test('every field the posting effect depends on is compared — none may be forgotten', () => {
+    const map = new Map() as NonNullable<RankingInput['symbols']>;
+    expect(sameRankingInput(INPUT, { ...INPUT })).toBe(true);
+    for (const changed of [
+      { eligible: false },
+      { asm: 'other' },
+      { name: 'g' },
+      { targetId: 'ido7.1' },
+      { target: {} as RankingInput['target'] },
+      { symbols: map },
+    ]) {
+      expect(sameRankingInput(INPUT, { ...INPUT, ...changed })).toBe(false);
     }
   });
 });

--- a/apps/web/test/rank-progress.test.ts
+++ b/apps/web/test/rank-progress.test.ts
@@ -10,12 +10,14 @@
 // or sit on a stale phase for a whole tail.
 import { describe, expect, test } from 'vitest';
 
-import { type RankProgress, throttleProgress, whileCurrent } from '../src/pages/playground/rank-progress';
-import type { BrowserRanking, RankMessage } from '../src/pages/playground/score-wasm';
+import { type EmittedProgress, throttleProgress, whileCurrent } from '../src/pages/playground/rank-progress';
+import type { BrowserRanking, RankInbound, RankMessage } from '../src/pages/playground/score-wasm';
 import {
   type Ranking,
   type RankingInput,
+  type StoredRanking,
   applyRankMessage,
+  applyToStored,
   sameRankingInput,
   viewRanking,
 } from '../src/pages/playground/useRanking';
@@ -25,7 +27,7 @@ import {
  *  different rates), and an injected clock is how that is testable without timers. */
 function rig(intervalMs = 100) {
   let t = 0;
-  const seen: RankProgress[] = [];
+  const seen: EmittedProgress[] = [];
   const emit = throttleProgress(
     (p) => seen.push(p),
     () => t,
@@ -75,7 +77,7 @@ describe('whileCurrent', () => {
     // candidate run posted 286 ticks over 78 s after being superseded, every one a main-thread
     // wake-up for a message `applyRankMessage` would discard.
     let current = true;
-    const seen: RankProgress[] = [];
+    const seen: EmittedProgress[] = [];
     const post = whileCurrent(
       () => current,
       (p) => seen.push(p),
@@ -91,7 +93,7 @@ describe('whileCurrent', () => {
 
   test('composed under the throttle it changes nothing while the run IS current', () => {
     let t = 0;
-    const seen: RankProgress[] = [];
+    const seen: EmittedProgress[] = [];
     const emit = throttleProgress(
       whileCurrent(
         () => true,
@@ -137,6 +139,47 @@ describe('RankMessage', () => {
   test('both result shapes still route to the result branch', () => {
     expect(describeMessage({ kind: 'result', reqId: 1, ok: false, error: 'boom' })).toBe('error:boom');
   });
+
+  test('`queued` is not spellable ON THE WIRE — the worker cannot observe it', () => {
+    // The main thread's own phase, set between postMessage and the first tick. It used to be
+    // forbidden only by prose in a comment; the emitter chain is typed on `EmittedProgress`, so
+    // this line is a compile error and the `@ts-expect-error` is what asserts that it still is.
+    // @ts-expect-error queued is the main thread's phase and is not on the worker's wire
+    const impossible: RankMessage = { kind: 'progress', reqId: 1, phase: 'queued' };
+    expect(impossible.kind).toBe('progress');
+  });
+});
+
+// The INBOUND union — what the main thread posts. `supersede` is the second way a run is abandoned:
+// the reqId advances with no new request behind it (the Benchmark tab, a C++ backend, a cleared
+// function name). Before it, the worker learned a new id only from a new REQUEST, so on that route
+// the abandoned run kept posting for its whole life — measured 2026-08-30 against the shipped
+// worker: 108 ticks over 11.9 s at 9.1 Hz, every one discarded by `applyRankMessage`.
+function adopt(msg: RankInbound): { latest: number; runs: boolean } {
+  switch (msg.kind) {
+    case 'request':
+      return { latest: msg.reqId, runs: true };
+    case 'supersede':
+      return { latest: msg.reqId, runs: false };
+    default: {
+      const exhaustive: never = msg;
+      return exhaustive;
+    }
+  }
+}
+
+describe('RankInbound', () => {
+  test('a supersede advances the id and starts NO run — the rate-guard half of an abandonment', () => {
+    expect(adopt({ kind: 'supersede', reqId: 12 })).toEqual({ latest: 12, runs: false });
+  });
+
+  test('a request advances the same id and runs', () => {
+    const target = {} as RankingInput['target'];
+    expect(adopt({ kind: 'request', reqId: 13, name: 'f', asm: 'push {r4}', target })).toEqual({
+      latest: 13,
+      runs: true,
+    });
+  });
 });
 
 // ── H1, the stale-guard, now with progress under it ──────────────────────────────────────────
@@ -147,6 +190,13 @@ describe('RankMessage', () => {
 // "drop this message" so the hook has no second way to settle state.
 //
 // The existing H1 reasoning had no test at all before this file; case (d) pins it.
+const INPUT: RankingInput = {
+  eligible: true,
+  asm: 'push {r4}',
+  name: 'f',
+  targetId: 'agbcc',
+  target: {} as RankingInput['target'],
+};
 const RESULT = {
   best: { label: 'unsigned', source: '', symbolRefs: [], score: { score: 0 } },
   candidates: [],
@@ -211,6 +261,26 @@ describe('applyRankMessage (H1)', () => {
   });
 });
 
+describe('applyToStored (the React updater)', () => {
+  const stored: StoredRanking = { input: INPUT, ranking: { status: 'loading', phase: 'enumerating' } };
+
+  test('a DROPPED message returns the same object — the bail-out, not a fresh one', () => {
+    // React bails out on `Object.is`, so a rebuilt `{ ...stored }` commits a whole Playground
+    // render for a message that changed nothing. Every tick of an abandoned run is such a message.
+    const stale: RankMessage = { kind: 'progress', reqId: 1, phase: 'scoring', done: 5, total: 9 };
+    expect(applyToStored(stored, stale, 2)).toBe(stored);
+    const settled: StoredRanking = { ...stored, ranking: { status: 'error', error: 'boom' } };
+    expect(applyToStored(settled, { kind: 'progress', reqId: 2, phase: 'ranking' }, 2)).toBe(settled);
+  });
+
+  test('an ACCEPTED message keeps the input the state is about and replaces only the ranking', () => {
+    const next = applyToStored(stored, { kind: 'progress', reqId: 2, phase: 'scoring', done: 5, total: 9 }, 2);
+    expect(next).not.toBe(stored);
+    expect(next.input).toBe(stored.input); // H1 layer 1: the pair still names the input it is about
+    expect(next.ranking).toEqual({ status: 'loading', phase: 'scoring', done: 5, total: 9 });
+  });
+});
+
 // ── H1 LAYER 1, the window the counts made visible ────────────────────────────────────────────
 // Resetting to `loading` inside the posting effect lands one commit AFTER the render that painted
 // the new input. Measured in the app on 2026-08-30, switching examples mid-run on an 800-candidate
@@ -218,14 +288,6 @@ describe('applyRankMessage (H1)', () => {
 // `scoring 52 / 800`; the reset landed at t=962 ms. One commit, 27 ms — and the same window renders
 // a settled VERDICT for an asm no longer on screen. `viewRanking` derives the answer instead, so it
 // cannot lag: re-measured after the change, the first frame naming `half` already reads `queued`.
-const INPUT: RankingInput = {
-  eligible: true,
-  asm: 'push {r4}',
-  name: 'f',
-  targetId: 'agbcc',
-  target: {} as RankingInput['target'],
-};
-
 describe('viewRanking (H1 layer 1)', () => {
   test('state belonging to ANOTHER input renders as queued, never as that input`s badge', () => {
     const settled: Ranking = { status: 'ok', result: RESULT };
@@ -254,7 +316,7 @@ describe('viewRanking (H1 layer 1)', () => {
     });
   });
 
-  test('every field the posting effect depends on is compared — none may be forgotten', () => {
+  test('every field of a ranking question is compared — this is the ONE list, so none may be forgotten', () => {
     const map = new Map() as NonNullable<RankingInput['symbols']>;
     expect(sameRankingInput(INPUT, { ...INPUT })).toBe(true);
     for (const changed of [

--- a/apps/web/test/rank-progress.test.ts
+++ b/apps/web/test/rank-progress.test.ts
@@ -164,6 +164,18 @@ describe('applyRankMessage (H1)', () => {
     expect(applyRankMessage(failed, { kind: 'progress', reqId: 3, phase: 'ranking' }, 3)).toBeNull();
   });
 
+  test("(b') rule 2's LIVE case: onerror settles the CURRENT run, whose ticks keep arriving", () => {
+    // postMessage is FIFO per port, so a run's ticks always precede its own result — "its own
+    // result already landed" cannot happen. What CAN: `worker.onerror` sets {status:'error'} for a
+    // run that is still current and still emitting. Without rule 2 the spinner re-opens over the
+    // loud error, which is constraint 4 (a failure path must stay loud) broken by progress.
+    const afterOnError: Ranking = { status: 'error', error: 'the ranking worker failed to load' };
+    expect(applyRankMessage(afterOnError, { kind: 'progress', reqId: 9, phase: 'enumerating' }, 9)).toBeNull();
+    expect(
+      applyRankMessage(afterOnError, { kind: 'progress', reqId: 9, phase: 'scoring', done: 400, total: 800 }, 9),
+    ).toBeNull();
+  });
+
   test('(c) a current-reqId progress message yields loading with the phase and counts', () => {
     const prev: Ranking = { status: 'loading', phase: 'assembling' };
     expect(applyRankMessage(prev, { kind: 'progress', reqId: 4, phase: 'scoring', done: 5, total: 9 }, 4)).toEqual({

--- a/apps/web/test/rank-progress.test.ts
+++ b/apps/web/test/rank-progress.test.ts
@@ -1,16 +1,16 @@
-// The playground's ranking PROGRESS, in the parts a node test can run: the emission throttle and
-// the pure view props the badge/pipeline card render from. They live in
-// src/pages/playground/rank-progress.ts rather than in score-wasm.ts for the reason
-// candidate-compile.test.ts documents: score-wasm.ts pulls in the `agbcc` package, which cannot be
-// imported under vitest's ESM loader.
+// The playground's ranking PROGRESS MODEL: the emission throttle (rank-progress.ts), the worker
+// message union, and the H1 stale-guard the ticks answer to. The SENTENCES and the bar geometry are
+// one altitude up and tested in progress-view.test.ts.
 //
-// The rules under test are the ones a lying bar would break:
-//  • the throttle bounds the postMessage rate but NEVER swallows a phase change or the final tick,
-//    so the bar cannot stop short of the end or sit on a stale phase for a whole tail;
-//  • an indeterminate phase has NO total — no fabricated denominator, no "0%".
+// These live outside score-wasm.ts for the reason candidate-compile.test.ts documents: score-wasm.ts
+// pulls in the `agbcc` package, which cannot be imported under vitest's ESM loader.
+//
+// The rule under test here is the one a lying bar would break: the throttle bounds the postMessage
+// rate but NEVER swallows a phase change or the final tick, so the bar cannot stop short of the end
+// or sit on a stale phase for a whole tail.
 import { describe, expect, test } from 'vitest';
 
-import { type RankProgress, progressBar, progressLabel, throttleProgress } from '../src/pages/playground/rank-progress';
+import { type RankProgress, throttleProgress } from '../src/pages/playground/rank-progress';
 import type { BrowserRanking, RankMessage } from '../src/pages/playground/score-wasm';
 import { type Ranking, applyRankMessage } from '../src/pages/playground/useRanking';
 
@@ -60,60 +60,6 @@ describe('throttleProgress', () => {
     advance(1);
     emit({ phase: 'scoring', done: 3, total: 3 }); // done === total: exempt from the throttle
     expect(seen.at(-1)).toEqual({ phase: 'scoring', done: 3, total: 3 });
-  });
-});
-
-describe('progressBar', () => {
-  test('an indeterminate phase carries NO total and no fabricated percentage', () => {
-    for (const phase of ['queued', 'assembling', 'enumerating', 'ranking'] as const) {
-      const bar = progressBar({ phase });
-      expect(bar.determinate).toBe(false);
-      expect('valueNow' in bar).toBe(false); // the ARIA spelling of indeterminate is OMISSION
-      expect('valueMax' in bar).toBe(false);
-      expect(bar.label).not.toMatch(/\d/); // no count, no "0%", no invented denominator
-    }
-  });
-
-  test('a determinate bar reports the exact counts and never fills to 100%', () => {
-    const bar = progressBar({ phase: 'scoring', done: 117760, total: 117760 });
-    if (!bar.determinate) {
-      throw new Error('a scoring tick with a real total must be determinate');
-    }
-    expect(bar.valueNow).toBe(117760); // aria-valuenow stays EXACT
-    expect(bar.valueMax).toBe(117760);
-    expect(bar.pct).toBeLessThanOrEqual(99); // the FILL never reads "finished" while work follows
-    expect(bar.label).toBe('scoring 117,760 / 117,760 candidates'); // grouped, not 117760
-  });
-
-  test('a zero total is indeterminate — no division by zero, and no equal ARIA bounds', () => {
-    // ARIA requires aria-valuemax > aria-valuemin; `0 / 0` on both would leave the AT-computed
-    // percentage undefined. The enumeration that produces it goes on to throw `no scorable
-    // candidate`, so this is a transient state — but it is a REACHABLE one.
-    const bar = progressBar({ phase: 'scoring', done: 0, total: 0 });
-    expect(bar.determinate).toBe(false);
-    expect('pct' in bar).toBe(false); // no "0 % of an unknown denominator" on the indeterminate arm
-  });
-
-  test('the indeterminate arm carries no pct at all — a number nobody may read', () => {
-    expect('pct' in progressBar({ phase: 'enumerating' })).toBe(false);
-  });
-});
-
-describe('progressLabel', () => {
-  test('`queued` is a phase the WORKER never emits — the main thread sets it, and it claims nothing', () => {
-    // The hook cannot observe `assembling`: it only knows it posted. On a busy worker (a superseded
-    // run enumerating for a measured 62.3 s) `assembling` would be false for the whole wait.
-    expect(progressLabel({ phase: 'queued' })).toBe('waiting for the ranking worker…');
-    expect(progressBar({ phase: 'queued' }).determinate).toBe(false);
-  });
-
-  test('every phase has a sentence — the badge is never empty', () => {
-    for (const phase of ['queued', 'assembling', 'enumerating', 'ranking'] as const) {
-      expect(progressLabel({ phase }).length).toBeGreaterThan(0);
-    }
-    // `scoring` is the one phase that CANNOT be spelled without counts — the union says so, and a
-    // count-less scoring tick is now a compile error rather than a defensive branch.
-    expect(progressLabel({ phase: 'scoring', done: 1, total: 2 })).toBe('scoring 1 / 2 candidates');
   });
 });
 


### PR DESCRIPTION
## The report

Opening a real klonoa function in the playground showed one line and nothing else:

```
scoring candidates with agbcc + objdiff…
```

No count, no percentage, no elapsed time, no ETA, no cancel. Measured live on
`LoadBGTilemapData`: the message sat there for **70+ seconds** and had still not finished when
observation stopped. **A long run and a hung run were indistinguishable from the UI.**

This turns that div into a real progress bar — and, on the way, found that the run behind it was
never going to finish.

## The number nobody had

Measured on this branch, 2026-08-30 (one machine, one day):

| | |
|---|---|
| `LoadBGTilemapData`, map-less, no prototypes | **117,760 candidates** |
| enumeration (synchronous, inside core) | **192,839 ms** |
| total candidate source | **1,162,161,120 chars ≈ 1.16 GB** of strings in one array |
| scoring rate, same rig, 800-candidate fan in the worker | **≈ 6.5 candidates/s** (a lighter day measured 52.8/s) |

**The browser cannot complete this function.** At the rates above, 117,760 candidates is between
37 minutes and 5 hours of agbcc+objdiff — and it never gets that far: enumerating it *on the main
thread* wedged the renderer past five minutes (1.16 GB of candidate sources), and in the app the
run dies before enumeration anyway, because agbcc's `assemble()` hands the `.s` to GNU as AS-IS
and the pret dialect's `thumb_func_start` is not an instruction. That refusal is now **loud and in
milliseconds** instead of a minute of discarded work (see "assemble first" below).

Recommendation left to you, not taken here: a candidate cap and/or a cancel button. Both are
scope changes this round was told not to make.

## The design

Five phases, one of which is determinate:

| phase | who emits it | number |
|---|---|---|
| `queued` | the MAIN THREAD only — between `postMessage` and the first tick | none |
| `assembling` | worker | none |
| `enumerating` | worker | none (synchronous inside core; 192.8 s on the function above) |
| `scoring` | worker, per candidate | `done / total` |
| `ranking` | worker | none |

* **The total does not exist at the start**, so four of five phases are indeterminate and carry no
  number at all — no estimate, no "0 % of an unknown denominator". A union makes a fabricated
  total unspellable rather than merely discouraged, and `queued` exists because "the request is
  posted and nothing has been observed back" is the only honest thing the main thread can say
  (naming `assembling` would be wrong for a measured 62.3 s whenever the worker is still
  enumerating a superseded run).
* **The bar is not allowed to lie.** `aria-valuenow` is the EXACT count; the fill is clamped to
  99 % so the pixels never read "finished" while the sort and a six-figure structured clone still
  run; the scoring phase ends by CHANGING PHASE, never by sitting at `done === total`. `0 / 0`
  renders indeterminate (ARIA requires `valuemax > valuemin`).
* **The throttle lives at the postMessage boundary**, not in the loop: the driver observes every
  candidate (a second driver — a node harness, an ETA estimator — gets every one), and
  `rank.worker.ts` bounds how many observations become main-thread wake-ups (~10/s). A phase
  change and the final tick of a determinate phase are never swallowed.
* **Assemble first, then enumerate.** `enumerateCandidates` does not consume the assembled
  target, so the swap is behaviour-neutral when assembly succeeds and turns a minute of discarded
  work into an error in milliseconds when it does not.
* **Accessibility**: `role="progressbar"` with `aria-label`, `aria-valuetext`, and the sentence as
  a SIBLING (progressbar is children-presentational, so a label inside it is announced by nobody).
  No `aria-live` — a 10 Hz live region is a screen-reader flood. The indeterminate stripe TRAVELS
  or is not drawn: parked, `animate-pulse` was pixel-identical to a determinate 33 % bar. Both
  animations are `motion-safe:` only.

## H1 is preserved, and now tested

`useRanking.ts`'s header is about H1 (an audit CRITICAL): ranking is async, so a score can resolve
AFTER the user edited the asm, and showing it would claim a byte-exact match for the wrong input.

**A progress tick is a message from the worker and answers to exactly the same guard.** Both rules
live in one pure `applyRankMessage`, which returns `null` for "drop this message":

1. any message — progress or result — whose `reqId` is not current;
2. a progress tick into a request that has already SETTLED (the live path is `worker.onerror`, not
   "its own result landed": postMessage is FIFO per port);
3. progress into anything but `loading` — enforced by the type.

Layer 1 is DERIVED, not scheduled: `viewRanking(input, stored)` reads the state's own input, so a
render for a changed input cannot show the previous one's badge. As a `useEffect` reset it landed
one commit late — measured at 27 ms with the new function name beside the old run's counts, and
the same window renders a settled VERDICT for an asm no longer on screen.

Tests (`apps/web/test/rank-progress.test.ts`) pin each: `(a)` a superseded PROGRESS message is
dropped, `(b)`/`(b')` a tick cannot re-open the spinner over a settled verdict, `(d)` a superseded
RESULT is dropped, `(e)` progress does not leak into `ok`/`error`, and `viewRanking` renders
another input's state as `queued`. The existing H1 reasoning had no test at all before this branch.

## Adversarial round 1 → round 2

Round 1 raised 15 findings; 11 fixed, 4 declined with a command. Round 2 re-measured all of them
in a real browser, upheld the declines, and found five more. Fixed here:

* **`whileCurrent` covered only one of the two abandonment routes.** The other — ineligible input:
  the Benchmark tab, a C++ backend, a cleared function name — bumps the reqId and posts NOTHING,
  so the worker never learned and the abandoned run kept talking. The inbound protocol is now a
  union (`RankRequest | RankSupersede`, read on an explicit `kind`) and both kinds advance
  `latestReqId`. Measured on the shipped worker, same 14 s window: **82 progress messages when not
  abandoned, 1 when abandoned** — the single survivor is emitted inside the same synchronous block
  as the enumeration that was already running. The result is still posted; the compiles still run.
* **The "React bail-out" did not exist.** The hook wrapped every message in a fresh
  `{input, ranking}` object, so a DROPPED tick committed a whole Playground render — worse than
  the base version, which returned before touching state. `applyToStored` now returns the SAME
  object for a dropped message, pinned by an identity test (`toBe`).
* **Two lists that could drift.** `sameRankingInput` is now the only one: the posting effect drops
  its dependency array and guards on it. A field reaching one list but not the other is a silent
  permanent spinner, which is the failure this file swears off.
* `queued` was spellable on the wire though no emitter can produce it → `EmittedProgress` makes it
  a compile error (`@ts-expect-error` pins it). Dead `PHASE_TEXT.scoring`, a duplicated first
  scoring tick, an unused export, a verbatim duplicated `describe` block, and a
  `toContain('hidden')` assertion that could not fail — all removed or strengthened.

Declined, with the command: the 250 ms input debounce means the editor's own text leads the WHOLE
pipeline by a measured 269 ms — every pane still describes the previous input, so they agree with
each other and disagree only with the raw editor buffer. That is Playground's debounce, not this
file's; it is now named in the H1 header instead of left implicit.

## Comment audit — two false comments, both written by an earlier remediation pass

* `rank.worker.ts` called an abandoned run's ticks *"the precise load the worker exists to
  prevent"*. Measured: a live run scores **52.8 candidates/s alone and 40.6 alongside one
  abandoned run** — the compiles are the larger load and they keep running. Rewritten to say so,
  and to name cancelling as the follow-up rather than implying it was done.
* `score-wasm.ts` said `onProgress` is optional so *"the existing 4-arg call sites stay valid"*.
  `grep -rn rankCandidatesInBrowser` finds ONE call site, and it passes five arguments. Deleted.

History narration, positional references and a measurement duplicated across three files were
trimmed; the why-nots and the H1 reasoning were kept and rewritten rather than shrunk.

## Verified in a real browser

* **Big fan (`sizebound`, 800 candidates)**: `queued → assembling → enumerating → scoring N / 800`
  with a teal determinate fill, `aria-valuenow` exact, `animationName: none` while determinate;
  screenshot taken at `scoring 231 / 800`.
* **Big function (`LoadBGTilemapData`, the reported one)**: `queued → assembling →` a loud amber
  ``ranking unavailable — could not assemble the target asm: in.s:1: Error: bad instruction
  `thumb_func_start LoadBGTilemapData'`` in milliseconds, against the 62 s of enumeration the old
  ordering burned first.
* **Small function (6 candidates)**: `queued → assembling → enumerating → 0/6 (0 %) → 1/6 (17 %) →
  … → 5/6 (83 %) → verdict`. No flash of a full bar, no 6/6 frame, no bar left standing, no stale
  badge beside a new function name.

## Gates

```
pnpm exec vitest run apps/web/test   Test Files 18 passed (18)    Tests 123 passed (123)
npx vitest run                       Test Files 181 passed (181)  Tests 2589 passed (2589)
pnpm test:matching                   Test Files 38 passed (38)    Tests 327 passed (327)
pnpm typecheck                       clean
apps/web tsc --noEmit -p tsconfig.test.json   clean
apps/web check-deps                  ✔ no dependency violations found (100 modules, 207 dependencies)
VITE_BASE_URL=/asmlift/ pnpm build   ✓ built in 5.35s + dist/index.html present
pnpm lint                            0 errors, 109 warnings (untouched baseline)
pnpm format:check                    All matched files use Prettier code style!
```

**No benchmark run.** `git diff origin/main --name-only` is ten files, all under `apps/web/`;
`@asmlift/core` and `packages/` are untouched, so no benchmark row can move and a 15–29 minute
`pnpm bench run` would be pure waste.

## Not done, on purpose

* **Issue #4** (the Source panel leading with synthesized `struct ElemN` lines) — a separate round.
* **A cancel button.** `supersede` silences an abandoned run's MESSAGES; its agbcc+objdiff compiles
  keep running, because there is no abort seam in the scoring loop. That is the larger cost
  (52.8 → 40.6 candidates/s) and the honest follow-up.
* **A candidate cap.** Named above as the recommendation the 117,760 measurement earns, not taken.
* **Subdividing `enumerating`** into a numbered phase — a core change.
* **The pret-dialect gap**: asmlift's own frontend reads `thumb_func_start`, the in-browser
  scorer's assembler does not.
