### PR TITLE
A permalink carrying a whole `.s` file cannot ride in the request line: the URL state moves to the fragment, and the link built at render time was always one view behind (9,508 chars: 414 → 200)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A **matching decompiler**: assembly in, C / C++ / Pascal out, aiming for source 
 **byte-identical** to the original object. Designed for retro game decompilation.
 
 Check the [playground](https://macabeus.github.io/asmlift/) to see it in action or the
-[benchmark](https://macabeus.github.io/asmlift/?view=benchmark) report to see its current performance.
+[benchmark](https://macabeus.github.io/asmlift/#view=benchmark) report to see its current performance.
 
 <img width="1201" height="984" alt="image" src="https://github.com/user-attachments/assets/df5e28ad-90dc-47bb-9ce6-d6c6a76bcc1a" />
 

--- a/apps/web/.dependency-cruiser.cjs
+++ b/apps/web/.dependency-cruiser.cjs
@@ -45,10 +45,10 @@ module.exports = {
       name: 'hash-params-stays-pure',
       comment:
         'src/shared/utils/hash-params.ts is the pure half of the fragment transport: strings in, ' +
-        'strings out, no location, no history, no React. Keeping it import-free is what lets a ' +
-        'pure page lib (benchmark/lib/explorer-url) reuse it without pulling in hash-adapter.ts, ' +
-        'whose module top level builds a React adapter provider. Put anything that needs an ' +
-        'import in hash-adapter.ts instead.',
+        'strings out, no location, no history, no React. Keeping it import-free is what keeps ' +
+        "every decision the transport makes runnable in vitest's node environment, which is the " +
+        'only environment apps/web has. Put anything that needs an import in hash-adapter.ts ' +
+        'instead.',
       severity: 'error',
       from: { path: '^src/shared/utils/hash-params\\.ts$' },
       to: {},

--- a/apps/web/.dependency-cruiser.cjs
+++ b/apps/web/.dependency-cruiser.cjs
@@ -41,6 +41,18 @@ module.exports = {
       from: { path: '^src/shared/' },
       to: { path: '^src/pages/' },
     },
+    {
+      name: 'hash-params-stays-pure',
+      comment:
+        'src/shared/utils/hash-params.ts is the pure half of the fragment transport: strings in, ' +
+        'strings out, no location, no history, no React. Keeping it import-free is what lets a ' +
+        'pure page lib (benchmark/lib/explorer-url) reuse it without pulling in hash-adapter.ts, ' +
+        'whose module top level builds a React adapter provider. Put anything that needs an ' +
+        'import in hash-adapter.ts instead.',
+      severity: 'error',
+      from: { path: '^src/shared/utils/hash-params\\.ts$' },
+      to: {},
+    },
   ],
   options: {
     doNotFollow: {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,8 +3,9 @@
 // ranking worker stays warm) and the Benchmark (lazy — ECharts + the committed results.json are
 // heavy, so a plain playground visit never downloads them; mounted on first visit, then kept alive
 // and hidden). Because the header, tabs, and container are the shell's, toggling views never shifts
-// the page frame. Navigation state lives in the query string via nuqs: `?view=benchmark` selects
-// the Benchmark (absent = playground, the default), `?s=<lz-string>` is the playground permalink.
+// the page frame. Navigation state lives in the URL FRAGMENT via nuqs (see hash-adapter.ts):
+// `#view=benchmark` selects the Benchmark (absent = playground, the default), `#s=<lz-string>` is
+// the playground permalink.
 //
 // The header follows the shared design system (Mizuchi / Transmuter / gba-kit): a rounded-2xl slate
 // gradient panel with the logo (glow behind), a gradient-clip title, subtitle, right-side content,

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,14 +1,14 @@
-import { NuqsAdapter } from 'nuqs/adapters/react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { App } from './App';
 import './index.css';
+import { NuqsHashAdapter } from './shared/utils/hash-adapter';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <NuqsAdapter>
+    <NuqsHashAdapter>
       <App />
-    </NuqsAdapter>
+    </NuqsHashAdapter>
   </StrictMode>,
 );

--- a/apps/web/src/pages/benchmark/components/FeaturePicker.tsx
+++ b/apps/web/src/pages/benchmark/components/FeaturePicker.tsx
@@ -5,6 +5,7 @@ import { FEATURES, FEATURE_GROUP_LABEL, GROUP_ORDER } from '@asmlift/bench-schem
 import { useMemo } from 'react';
 
 import { MultiSelect, type MultiSelectOption } from '../../../shared/components/MultiSelect';
+import { useCurrentHash } from '../../../shared/utils/hash-adapter';
 import { DECLINE_CLASSES, OTHER_CLASS } from '../lib/declines';
 import { FEATURE_TERM_KEY, featureHref } from '../lib/explorer-url';
 
@@ -24,6 +25,9 @@ export function FeaturePicker({
   counts: Map<string, number>;
   onOpenFeature: (id: string) => void;
 }) {
+  // Each option's `href` is a permalink to this view with the drawer open, so it has to be rebuilt
+  // when the URL moves; `counts` alone changes a render before the write lands.
+  const hash = useCurrentHash();
   const options = useMemo<MultiSelectOption[]>(() => {
     const rank = new Map(GROUP_ORDER.map((g, i) => [g, i]));
     return [...FEATURES]
@@ -36,9 +40,9 @@ export function FeaturePicker({
         description: f.summary,
         count: counts.get(f.id) ?? 0,
         disabled: (counts.get(f.id) ?? 0) === 0,
-        href: featureHref(f.id),
+        href: featureHref(f.id, hash),
       }));
-  }, [counts]);
+  }, [counts, hash]);
 
   return (
     <MultiSelect

--- a/apps/web/src/pages/benchmark/lib/explorer-url.ts
+++ b/apps/web/src/pages/benchmark/lib/explorer-url.ts
@@ -3,7 +3,7 @@
 // FunctionDetail — is a shareable link. Defaults are cleared from the URL (nuqs clearOnDefault).
 import { type inferParserType, parseAsArrayOf, parseAsString, parseAsStringLiteral } from 'nuqs';
 
-import { hashToSearchParams } from '../../../shared/utils/hash-adapter';
+import { hashToSearchParams } from '../../../shared/utils/hash-params';
 
 export const TAB_IDS = ['overview', 'explorer', 'gap', 'methodology'] as const;
 export type TabId = (typeof TAB_IDS)[number];

--- a/apps/web/src/pages/benchmark/lib/explorer-url.ts
+++ b/apps/web/src/pages/benchmark/lib/explorer-url.ts
@@ -3,6 +3,8 @@
 // FunctionDetail — is a shareable link. Defaults are cleared from the URL (nuqs clearOnDefault).
 import { type inferParserType, parseAsArrayOf, parseAsString, parseAsStringLiteral } from 'nuqs';
 
+import { hashToSearchParams } from '../../../shared/utils/hash-adapter';
+
 export const TAB_IDS = ['overview', 'explorer', 'gap', 'methodology'] as const;
 export type TabId = (typeof TAB_IDS)[number];
 export const tabParser = parseAsStringLiteral(TAB_IDS).withDefault('overview');
@@ -60,11 +62,11 @@ export const FEATURE_TERM_PARSER = parseAsString.withDefault('');
 export const FEATURE_TERM_KEY = 'about';
 
 /** Link that opens the definition drawer for `id`. A real `href`, so middle-click and copy-link
- *  work; built from the CURRENT query, so opening one never discards the filters already set. */
-export function featureHref(id: string, search = typeof window === 'undefined' ? '' : window.location.search): string {
-  const params = new URLSearchParams(search);
+ *  work; built from the CURRENT fragment, so opening one never discards the filters already set. */
+export function featureHref(id: string, hash = typeof window === 'undefined' ? '' : window.location.hash): string {
+  const params = hashToSearchParams(hash);
   params.set(FEATURE_TERM_KEY, id);
-  return `?${params.toString()}`;
+  return `#${params.toString()}`;
 }
 
 /** A preset deep-link REPLACES the whole filter set: spread this under it to reset the rest. */

--- a/apps/web/src/pages/benchmark/lib/explorer-url.ts
+++ b/apps/web/src/pages/benchmark/lib/explorer-url.ts
@@ -61,9 +61,10 @@ export type ExplorerPreset = Partial<Filters>;
 export const FEATURE_TERM_PARSER = parseAsString.withDefault('');
 export const FEATURE_TERM_KEY = 'about';
 
-/** Link that opens the definition drawer for `id`. A real `href`, so middle-click and copy-link
- *  work; built from the CURRENT fragment, so opening one never discards the filters already set. */
-export function featureHref(id: string, hash = typeof window === 'undefined' ? '' : window.location.hash): string {
+/** Link that opens the definition drawer for `id` over the view `hash` describes: a real `href`,
+ *  so middle-click and copy-link work, carrying the filters already set. `hash` has to come from
+ *  `useCurrentHash` — read from `location` here it would be the view BEFORE the last change. */
+export function featureHref(id: string, hash: string): string {
   const params = hashToSearchParams(hash);
   params.set(FEATURE_TERM_KEY, id);
   return `#${params.toString()}`;

--- a/apps/web/src/pages/playground/Playground.tsx
+++ b/apps/web/src/pages/playground/Playground.tsx
@@ -66,7 +66,7 @@ const IDENT = /^[A-Za-z_$][A-Za-z0-9_$.]*$/;
 export function Playground({
   active,
 }: {
-  /** whether the Playground view is the one on screen — gates the ?s= permalink writes so a
+  /** whether the Playground view is the one on screen — gates the #s= permalink writes so a
    *  hidden Playground never rewrites the Benchmark view's URL */
   active: boolean;
 }) {
@@ -83,7 +83,7 @@ export function Playground({
   const [debounced, setDebounced] = useState({ asm, targetId, backendId, nameOverride, specText, symbolsText });
   const [tab, setTab] = useState<Tab>('source');
   const [copied, setCopied] = useState<'idle' | 'copied' | 'huge' | 'failed'>('idle');
-  // The last ?s= WE wrote, encoded — tells external changes apart from our own writes echoing back.
+  // The last #s= WE wrote, encoded — tells external changes apart from our own writes echoing back.
   const lastWritten = useRef<string | null>(initial ? encodeShare(initial) : null);
 
   useEffect(() => {
@@ -91,7 +91,7 @@ export function Playground({
     return () => clearTimeout(t);
   }, [asm, targetId, backendId, nameOverride, specText, symbolsText]);
 
-  // An EXTERNAL ?s= change (Back/Forward, the Benchmark's "Open in playground") loads into the
+  // An EXTERNAL #s= change (Back/Forward, the Benchmark's "Open in playground") loads into the
   // editor. Own writes are skipped via lastWritten, so a debounced (250ms-old) echo can never
   // clobber newer keystrokes.
   useEffect(() => {
@@ -124,7 +124,7 @@ export function Playground({
     });
   }, [urlShare]);
 
-  // The permalink IS the state: keep ?s= in sync with the debounced editor state (nuqs rate-limits
+  // The permalink IS the state: keep #s= in sync with the debounced editor state (nuqs rate-limits
   // the writes, Safari-aware). Gated on `active`: a hidden Playground must not rewrite the
   // Benchmark view's URL.
   useEffect(() => {

--- a/apps/web/src/shared/utils/hash-adapter.ts
+++ b/apps/web/src/shared/utils/hash-adapter.ts
@@ -2,8 +2,18 @@
 // a whole `.s` file, and a query string is part of the HTTP request line (GitHub Pages answers
 // 414 above ~8 KiB), while a fragment is never sent to the server at all.
 //
-// These are the pure, testable halves of the nuqs adapter below: strings in, strings out, no
-// `location`, no `history`.
+// This is a nuqs adapter, so every parser, `useQueryState`, `useQueryStates`, `urlKeys`,
+// `history: 'push'` and the ~20 params of this app keep working untouched — nuqs hands an adapter
+// a `URLSearchParams` and takes one back, and its contract says nothing about where they live.
+// Modelled on nuqs's own `adapters/react`, minus everything a Vite SPA has no use for: no RSC, no
+// SSR snapshot, no provider props, no full-page-navigation branch, no history monkey-patching.
+//
+// The helpers above the glue are pure and tested (apps/web/test/hash-adapter.test.ts); the glue
+// below touches `location`/`history` and is covered by the browser checks instead.
+import { type unstable_AdapterOptions, unstable_createAdapterProvider } from 'nuqs/adapters/custom';
+import { useRef, useSyncExternalStore } from 'react';
+
+// --- the pure halves: strings in, strings out, no `location`, no `history`.
 
 /** `''` | `'#'` | `'#a=1'` | `'a=1'` -> params. Strips exactly one leading `#` — handing one to
  *  `URLSearchParams` would make an entry keyed `'#'` (and `'#a=1'` has no key `a` at all). */
@@ -40,3 +50,57 @@ export function pickKeys(search: URLSearchParams, keys: string[]): URLSearchPara
   }
   return filtered;
 }
+
+// --- the React glue: the only part that touches `location` and `history`.
+
+/** `history.pushState` fires NEITHER `popstate` NOR `hashchange`, so this adapter's own writes are
+ *  invisible to the DOM. This set is the channel that tells every mounted subscriber about them —
+ *  nuqs keeps a private emitter for exactly this reason. */
+const listeners = new Set<() => void>();
+
+/** Module-level, therefore stable, which is what stops `useSyncExternalStore` resubscribing on
+ *  every render. Three change sources, three disjoint causes: our own writes (the set above),
+ *  Back/Forward (`popstate`), and a hand-edited address bar (`hashchange`). */
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  window.addEventListener('popstate', onStoreChange);
+  window.addEventListener('hashchange', onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+    window.removeEventListener('popstate', onStoreChange);
+    window.removeEventListener('hashchange', onStoreChange);
+  };
+}
+
+/** Closes over nothing, so it is a module-level const rather than a `useMemo`. */
+function updateUrl(search: URLSearchParams, options: Required<unstable_AdapterOptions>): void {
+  const url = hashUrl(window.location.href, search);
+  (options.history === 'push' ? history.pushState : history.replaceState).call(history, history.state, '', url);
+  for (const listener of listeners) {
+    listener();
+  }
+  if (options.scroll) {
+    window.scrollTo({ top: 0 });
+  }
+}
+
+function useHashAdapter(watchKeys: string[]) {
+  const cache = useRef<{ key: string; search: URLSearchParams } | null>(null);
+  // `useSyncExternalStore` compares snapshots with Object.is and throws "The result of getSnapshot
+  // should be cached to avoid an infinite loop" on a fresh object each call, so cache on the
+  // serialised watched keys — which also turns "the watched values did not change" into "the same
+  // object", i.e. no re-render for a component watching `s` when `tab` moves.
+  const snapshot = (): URLSearchParams => {
+    const filtered = pickKeys(hashToSearchParams(window.location.hash), watchKeys);
+    const key = filtered.toString();
+    if (cache.current?.key === key) {
+      return cache.current.search;
+    }
+    cache.current = { key, search: filtered };
+    return filtered;
+  };
+  return { searchParams: useSyncExternalStore(subscribe, snapshot), updateUrl };
+}
+
+/** Drop-in replacement for nuqs's `NuqsAdapter`; wrap the app in it exactly the same way. */
+export const NuqsHashAdapter = unstable_createAdapterProvider(useHashAdapter);

--- a/apps/web/src/shared/utils/hash-adapter.ts
+++ b/apps/web/src/shared/utils/hash-adapter.ts
@@ -18,8 +18,8 @@ const listeners = new Set<() => void>();
  *
  *  A `pushState` from code OUTSIDE this adapter stays invisible until the next event — nuqs's own
  *  React adapter behaves identically, which is what its opt-in `enableHistorySync` is for. Nothing
- *  in this app writes history out of band (`grep -rn 'pushState\|replaceState' src/` finds only
- *  `updateUrl` below), and the next write re-syncs rather than clobbers, because
+ *  in this app writes history out of band (`grep -rn 'history\.\(push\|replace\)State' src/`
+ *  finds one line, in `updateUrl`), and the next write re-syncs rather than clobbers, because
  *  `getSearchParamsSnapshot` re-reads the live hash. */
 function subscribe(onStoreChange: () => void): () => void {
   listeners.add(onStoreChange);
@@ -43,7 +43,8 @@ export function useCurrentHash(): string {
 /** nuqs's own adapter also aborts its write queue on `popstate` (`QueueReset` calling
  *  `resetQueues`), which no entry in nuqs's export map reaches. Without it, a Back pressed while an
  *  update is still queued — at most `defaultRateLimit.timeMs`, 50 ms outside Safari — lands that
- *  update on the entry popped to, as a push, discarding the forward stack. */
+ *  update on the entry popped to, taking the forward stack with it if the queued write was a
+ *  push. */
 function updateUrl(search: URLSearchParams, options: Required<unstable_AdapterOptions>): void {
   const url = hashUrl(window.location.href, search);
   (options.history === 'push' ? history.pushState : history.replaceState).call(history, history.state, '', url);

--- a/apps/web/src/shared/utils/hash-adapter.ts
+++ b/apps/web/src/shared/utils/hash-adapter.ts
@@ -9,7 +9,7 @@
 import { type unstable_AdapterOptions, unstable_createAdapterProvider } from 'nuqs/adapters/custom';
 import { useRef, useSyncExternalStore } from 'react';
 
-import { hashToSearchParams, hashUrl, pickKeys } from './hash-params';
+import { createSnapshotCache, hashToSearchParams, hashUrl } from './hash-params';
 
 /** `history.pushState` fires NEITHER `popstate` NOR `hashchange`, so this adapter's own writes are
  *  invisible to the DOM. This set is the channel that tells every mounted subscriber about them —
@@ -69,22 +69,9 @@ function getSearchParamsSnapshot(): URLSearchParams {
 }
 
 function useHashAdapter(watchKeys: string[]) {
-  const cache = useRef<{ key: string; search: URLSearchParams } | null>(null);
-  // `useSyncExternalStore` compares snapshots with Object.is and throws "The result of getSnapshot
-  // should be cached to avoid an infinite loop" on a fresh object each call, so cache on the
-  // serialised watched keys — which also turns "the watched values did not change" into "the same
-  // object", i.e. no re-render for a component watching `s` when `tab` moves.
-  const snapshot = (): URLSearchParams => {
-    const filtered = pickKeys(getSearchParamsSnapshot(), watchKeys);
-    const key = filtered.toString();
-    if (cache.current?.key === key) {
-      return cache.current.search;
-    }
-    cache.current = { key, search: filtered };
-    return filtered;
-  };
+  const snapshot = useRef(createSnapshotCache());
   return {
-    searchParams: useSyncExternalStore(subscribe, snapshot),
+    searchParams: useSyncExternalStore(subscribe, () => snapshot.current(window.location.hash, watchKeys)),
     updateUrl,
     getSearchParamsSnapshot,
   };

--- a/apps/web/src/shared/utils/hash-adapter.ts
+++ b/apps/web/src/shared/utils/hash-adapter.ts
@@ -84,6 +84,15 @@ function updateUrl(search: URLSearchParams, options: Required<unstable_AdapterOp
   }
 }
 
+/** The BASE every write is merged onto. nuqs's default is
+ *  `new URLSearchParams(location.search)` (its `getSearchParamsSnapshotFromLocation`), which is
+ *  empty under this transport — so without this, a write of one key would drop every OTHER key
+ *  from the URL. Found in the browser, not by a test: clicking an Overview aggregate turned
+ *  `#view=benchmark` into a URL with no `view` at all. */
+function getSearchParamsSnapshot(): URLSearchParams {
+  return hashToSearchParams(window.location.hash);
+}
+
 function useHashAdapter(watchKeys: string[]) {
   const cache = useRef<{ key: string; search: URLSearchParams } | null>(null);
   // `useSyncExternalStore` compares snapshots with Object.is and throws "The result of getSnapshot
@@ -91,7 +100,7 @@ function useHashAdapter(watchKeys: string[]) {
   // serialised watched keys — which also turns "the watched values did not change" into "the same
   // object", i.e. no re-render for a component watching `s` when `tab` moves.
   const snapshot = (): URLSearchParams => {
-    const filtered = pickKeys(hashToSearchParams(window.location.hash), watchKeys);
+    const filtered = pickKeys(getSearchParamsSnapshot(), watchKeys);
     const key = filtered.toString();
     if (cache.current?.key === key) {
       return cache.current.search;
@@ -99,7 +108,11 @@ function useHashAdapter(watchKeys: string[]) {
     cache.current = { key, search: filtered };
     return filtered;
   };
-  return { searchParams: useSyncExternalStore(subscribe, snapshot), updateUrl };
+  return {
+    searchParams: useSyncExternalStore(subscribe, snapshot),
+    updateUrl,
+    getSearchParamsSnapshot,
+  };
 }
 
 /** Drop-in replacement for nuqs's `NuqsAdapter`; wrap the app in it exactly the same way. */

--- a/apps/web/src/shared/utils/hash-adapter.ts
+++ b/apps/web/src/shared/utils/hash-adapter.ts
@@ -23,3 +23,20 @@ export function hashUrl(href: string, search: URLSearchParams): string {
   url.hash = searchParamsToHash(search);
   return url.toString();
 }
+
+/** Key isolation: a COPY of `search` holding only `keys`, so a hook watching `s` does not
+ *  re-render when `tab` moves. nuqs's own `filterSearchParams` is internal (it appears in no
+ *  `.d.ts` it ships), so this is a reimplementation of it with `copy` fixed to true.
+ *  An empty `keys` means "watch everything", which is what nuqs asks for. */
+export function pickKeys(search: URLSearchParams, keys: string[]): URLSearchParams {
+  if (keys.length === 0) {
+    return search;
+  }
+  const filtered = new URLSearchParams(search);
+  for (const key of Array.from(search.keys())) {
+    if (!keys.includes(key)) {
+      filtered.delete(key);
+    }
+  }
+  return filtered;
+}

--- a/apps/web/src/shared/utils/hash-adapter.ts
+++ b/apps/web/src/shared/utils/hash-adapter.ts
@@ -1,30 +1,26 @@
-// The React glue of the fragment transport: the only part that touches `location` and `history`.
-// The pure helpers it is built on live in hash-params.ts and are unit-tested there.
-//
-// This is a nuqs adapter, so every parser, `useQueryState`, `useQueryStates`, `urlKeys`,
-// `history: 'push'` and the ~20 params of this app keep working untouched — nuqs hands an adapter
-// a `URLSearchParams` and takes one back, and its contract says nothing about where they live.
-// Modelled on nuqs's own `adapters/react`, minus everything a Vite SPA has no use for: no RSC, no
-// SSR snapshot, no provider props, no full-page-navigation branch, no history monkey-patching.
+// The React glue of the fragment transport — the only part that touches `location` and `history`;
+// the pure helpers are in hash-params.ts. As a nuqs adapter it changes nothing above it: nuqs hands
+// an adapter a `URLSearchParams` and takes one back, saying nothing about where they live, so every
+// parser, `useQueryStates`, `urlKeys` and `history: 'push'` keeps working. It is nuqs's own
+// `adapters/react` minus what a Vite SPA has no use for: RSC, SSR, provider props, full-page
+// navigation, history monkey-patching.
 import { type unstable_AdapterOptions, unstable_createAdapterProvider } from 'nuqs/adapters/custom';
-import { useRef, useSyncExternalStore } from 'react';
+import { useState, useSyncExternalStore } from 'react';
 
 import { createSnapshotCache, hashToSearchParams, hashUrl } from './hash-params';
 
-/** `history.pushState` fires NEITHER `popstate` NOR `hashchange`, so this adapter's own writes are
- *  invisible to the DOM. This set is the channel that tells every mounted subscriber about them —
- *  nuqs keeps a private emitter for exactly this reason. */
+/** `pushState` fires NEITHER `popstate` NOR `hashchange`, so this adapter's own writes are
+ *  invisible to the DOM; this set is the channel that carries them, as nuqs's own emitter does. */
 const listeners = new Set<() => void>();
 
-/** Module-level, therefore stable, which is what stops `useSyncExternalStore` resubscribing on
- *  every render. Three change sources, three disjoint causes: our own writes (the set above),
- *  Back/Forward (`popstate`), and a hand-edited address bar (`hashchange`).
+/** Module-level, therefore stable, so `useSyncExternalStore` never resubscribes. Three sources,
+ *  three disjoint causes: our own writes, Back/Forward, and a hand-edited address bar.
  *
- *  A `history.pushState` by code OUTSIDE this adapter is therefore invisible until the next
- *  event — nuqs's own React adapter behaves identically, which is what its opt-in
- *  `enableHistorySync`/`patchHistory` exists for, and neither adapter enables it. Nothing in this
- *  app writes history out of band, and the next adapter write re-syncs rather than clobbering,
- *  because `getSearchParamsSnapshot` below re-reads the live hash. */
+ *  A `pushState` from code OUTSIDE this adapter stays invisible until the next event — nuqs's own
+ *  React adapter behaves identically, which is what its opt-in `enableHistorySync` is for. Nothing
+ *  in this app writes history out of band (`grep -rn 'pushState\|replaceState' src/` finds only
+ *  `updateUrl` below), and the next write re-syncs rather than clobbers, because
+ *  `getSearchParamsSnapshot` re-reads the live hash. */
 function subscribe(onStoreChange: () => void): () => void {
   listeners.add(onStoreChange);
   window.addEventListener('popstate', onStoreChange);
@@ -36,12 +32,18 @@ function subscribe(onStoreChange: () => void): () => void {
   };
 }
 
-/** Closes over nothing, so it is a module-level const rather than a `useMemo`.
- *
- *  nuqs's own adapter also resets its write queue on `popstate` (its internal `QueueReset`); that
- *  module is not exported, so this adapter drops it and inherits `autoResetQueueOnUpdate ?? true`
- *  (nuqs's default), i.e. only the popstate-specific abort is lost. Browser check 2 — one Back
- *  across a batched Explorer preset — is the observation that no stale queued write lands. */
+/** The live fragment, for the one `<a href>` outside nuqs that has to carry the reader's current
+ *  view (benchmark's `featureHref`). Reading `location.hash` during render is a step behind: nuqs
+ *  rate-limits its writes, so the hash still holds the value from before the change that caused
+ *  the render — and a memoised href would keep that one. */
+export function useCurrentHash(): string {
+  return useSyncExternalStore(subscribe, () => window.location.hash);
+}
+
+/** nuqs's own adapter also aborts its write queue on `popstate` (`QueueReset` calling
+ *  `resetQueues`), which no entry in nuqs's export map reaches. Without it, a Back pressed while an
+ *  update is still queued — at most `defaultRateLimit.timeMs`, 50 ms outside Safari — lands that
+ *  update on the entry popped to, as a push, discarding the forward stack. */
 function updateUrl(search: URLSearchParams, options: Required<unstable_AdapterOptions>): void {
   const url = hashUrl(window.location.href, search);
   (options.history === 'push' ? history.pushState : history.replaceState).call(history, history.state, '', url);
@@ -53,29 +55,26 @@ function updateUrl(search: URLSearchParams, options: Required<unstable_AdapterOp
   }
 }
 
-/** The BASE every write is merged onto. nuqs's default is
- *  `new URLSearchParams(location.search)` (its `getSearchParamsSnapshotFromLocation`), which is
- *  empty under this transport — so without this, a write of one key would drop every OTHER key
- *  from the URL. Found in the browser, not by a test: clicking an Overview aggregate turned
- *  `#view=benchmark` into a URL with no `view` at all.
+/** The BASE every write is merged onto. nuqs's default reads `location.search`, which is empty
+ *  under this transport — so without this, a write of one key drops every OTHER key from the URL.
  *
- *  Audited on 2.10.1: `dist/index.js:533` is the ONE place nuqs still reads `location.search`
- *  behind an adapter's back (`grep -rn 'location\.search' node_modules/nuqs/dist/*.js`, ignoring
- *  the react-router adapter and the opt-in history patch). It is inert here because it sits in an
- *  `onCommittedPathname ||` short-circuit and we supply no `adapter.pathname`, so nuqs compares
- *  `location.pathname`, which never changes under fragment routing. Re-check on a nuqs upgrade. */
+ *  `dist/index.js:533` is the one place 2.10.1 still reads `location.search` behind an adapter's
+ *  back. It is inert here because its guard `onCommittedPathname` (`:521`) compares the committed
+ *  pathname against `adapter.pathname ?? location.pathname`, which under fragment routing never
+ *  changes. Re-check on an upgrade. */
 function getSearchParamsSnapshot(): URLSearchParams {
   return hashToSearchParams(window.location.hash);
 }
 
 function useHashAdapter(watchKeys: string[]) {
-  const snapshot = useRef(createSnapshotCache());
+  // `useState`'s lazy initialiser, not `useRef(createSnapshotCache())`: a ref's argument is built
+  // on every render and thrown away, and one cache cell per mounted adapter is the point.
+  const [snapshot] = useState(createSnapshotCache);
   return {
-    searchParams: useSyncExternalStore(subscribe, () => snapshot.current(window.location.hash, watchKeys)),
+    searchParams: useSyncExternalStore(subscribe, () => snapshot(window.location.hash, watchKeys)),
     updateUrl,
     getSearchParamsSnapshot,
   };
 }
 
-/** Drop-in replacement for nuqs's `NuqsAdapter`; wrap the app in it exactly the same way. */
 export const NuqsHashAdapter = unstable_createAdapterProvider(useHashAdapter);

--- a/apps/web/src/shared/utils/hash-adapter.ts
+++ b/apps/web/src/shared/utils/hash-adapter.ts
@@ -1,57 +1,15 @@
-// The app's URL state lives in the FRAGMENT, not the query string: a playground permalink carries
-// a whole `.s` file, and a query string is part of the HTTP request line (GitHub Pages answers
-// 414 above ~8 KiB), while a fragment is never sent to the server at all.
+// The React glue of the fragment transport: the only part that touches `location` and `history`.
+// The pure helpers it is built on live in hash-params.ts and are unit-tested there.
 //
 // This is a nuqs adapter, so every parser, `useQueryState`, `useQueryStates`, `urlKeys`,
 // `history: 'push'` and the ~20 params of this app keep working untouched — nuqs hands an adapter
 // a `URLSearchParams` and takes one back, and its contract says nothing about where they live.
 // Modelled on nuqs's own `adapters/react`, minus everything a Vite SPA has no use for: no RSC, no
 // SSR snapshot, no provider props, no full-page-navigation branch, no history monkey-patching.
-//
-// The helpers above the glue are pure and tested (apps/web/test/hash-adapter.test.ts); the glue
-// below touches `location`/`history` and is covered by the browser checks instead.
 import { type unstable_AdapterOptions, unstable_createAdapterProvider } from 'nuqs/adapters/custom';
 import { useRef, useSyncExternalStore } from 'react';
 
-// --- the pure halves: strings in, strings out, no `location`, no `history`.
-
-/** `''` | `'#'` | `'#a=1'` | `'a=1'` -> params. Strips exactly one leading `#` — handing one to
- *  `URLSearchParams` would make an entry keyed `'#'` (and `'#a=1'` has no key `a` at all). */
-export function hashToSearchParams(hash: string): URLSearchParams {
-  return new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
-}
-
-/** params -> the fragment WITHOUT its `#`; `''` for an empty set, which clears the fragment. */
-export function searchParamsToHash(search: URLSearchParams): string {
-  return search.toString();
-}
-
-/** href + params -> the URL to hand to `pushState`. Only the fragment changes; origin, path and
- *  any query survive. Taking the href as an argument is what keeps the write path testable. */
-export function hashUrl(href: string, search: URLSearchParams): string {
-  const url = new URL(href);
-  url.hash = searchParamsToHash(search);
-  return url.toString();
-}
-
-/** Key isolation: a COPY of `search` holding only `keys`, so a hook watching `s` does not
- *  re-render when `tab` moves. nuqs's own `filterSearchParams` is internal (it appears in no
- *  `.d.ts` it ships), so this is a reimplementation of it with `copy` fixed to true.
- *  An empty `keys` means "watch everything", which is what nuqs asks for. */
-export function pickKeys(search: URLSearchParams, keys: string[]): URLSearchParams {
-  if (keys.length === 0) {
-    return search;
-  }
-  const filtered = new URLSearchParams(search);
-  for (const key of Array.from(search.keys())) {
-    if (!keys.includes(key)) {
-      filtered.delete(key);
-    }
-  }
-  return filtered;
-}
-
-// --- the React glue: the only part that touches `location` and `history`.
+import { hashToSearchParams, hashUrl, pickKeys } from './hash-params';
 
 /** `history.pushState` fires NEITHER `popstate` NOR `hashchange`, so this adapter's own writes are
  *  invisible to the DOM. This set is the channel that tells every mounted subscriber about them —
@@ -60,7 +18,13 @@ const listeners = new Set<() => void>();
 
 /** Module-level, therefore stable, which is what stops `useSyncExternalStore` resubscribing on
  *  every render. Three change sources, three disjoint causes: our own writes (the set above),
- *  Back/Forward (`popstate`), and a hand-edited address bar (`hashchange`). */
+ *  Back/Forward (`popstate`), and a hand-edited address bar (`hashchange`).
+ *
+ *  A `history.pushState` by code OUTSIDE this adapter is therefore invisible until the next
+ *  event — nuqs's own React adapter behaves identically, which is what its opt-in
+ *  `enableHistorySync`/`patchHistory` exists for, and neither adapter enables it. Nothing in this
+ *  app writes history out of band, and the next adapter write re-syncs rather than clobbering,
+ *  because `getSearchParamsSnapshot` below re-reads the live hash. */
 function subscribe(onStoreChange: () => void): () => void {
   listeners.add(onStoreChange);
   window.addEventListener('popstate', onStoreChange);
@@ -72,7 +36,12 @@ function subscribe(onStoreChange: () => void): () => void {
   };
 }
 
-/** Closes over nothing, so it is a module-level const rather than a `useMemo`. */
+/** Closes over nothing, so it is a module-level const rather than a `useMemo`.
+ *
+ *  nuqs's own adapter also resets its write queue on `popstate` (its internal `QueueReset`); that
+ *  module is not exported, so this adapter drops it and inherits `autoResetQueueOnUpdate ?? true`
+ *  (nuqs's default), i.e. only the popstate-specific abort is lost. Browser check 2 — one Back
+ *  across a batched Explorer preset — is the observation that no stale queued write lands. */
 function updateUrl(search: URLSearchParams, options: Required<unstable_AdapterOptions>): void {
   const url = hashUrl(window.location.href, search);
   (options.history === 'push' ? history.pushState : history.replaceState).call(history, history.state, '', url);
@@ -88,7 +57,13 @@ function updateUrl(search: URLSearchParams, options: Required<unstable_AdapterOp
  *  `new URLSearchParams(location.search)` (its `getSearchParamsSnapshotFromLocation`), which is
  *  empty under this transport — so without this, a write of one key would drop every OTHER key
  *  from the URL. Found in the browser, not by a test: clicking an Overview aggregate turned
- *  `#view=benchmark` into a URL with no `view` at all. */
+ *  `#view=benchmark` into a URL with no `view` at all.
+ *
+ *  Audited on 2.10.1: `dist/index.js:533` is the ONE place nuqs still reads `location.search`
+ *  behind an adapter's back (`grep -rn 'location\.search' node_modules/nuqs/dist/*.js`, ignoring
+ *  the react-router adapter and the opt-in history patch). It is inert here because it sits in an
+ *  `onCommittedPathname ||` short-circuit and we supply no `adapter.pathname`, so nuqs compares
+ *  `location.pathname`, which never changes under fragment routing. Re-check on a nuqs upgrade. */
 function getSearchParamsSnapshot(): URLSearchParams {
   return hashToSearchParams(window.location.hash);
 }

--- a/apps/web/src/shared/utils/hash-adapter.ts
+++ b/apps/web/src/shared/utils/hash-adapter.ts
@@ -1,0 +1,25 @@
+// The app's URL state lives in the FRAGMENT, not the query string: a playground permalink carries
+// a whole `.s` file, and a query string is part of the HTTP request line (GitHub Pages answers
+// 414 above ~8 KiB), while a fragment is never sent to the server at all.
+//
+// These are the pure, testable halves of the nuqs adapter below: strings in, strings out, no
+// `location`, no `history`.
+
+/** `''` | `'#'` | `'#a=1'` | `'a=1'` -> params. Strips exactly one leading `#` — handing one to
+ *  `URLSearchParams` would make an entry keyed `'#'` (and `'#a=1'` has no key `a` at all). */
+export function hashToSearchParams(hash: string): URLSearchParams {
+  return new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
+}
+
+/** params -> the fragment WITHOUT its `#`; `''` for an empty set, which clears the fragment. */
+export function searchParamsToHash(search: URLSearchParams): string {
+  return search.toString();
+}
+
+/** href + params -> the URL to hand to `pushState`. Only the fragment changes; origin, path and
+ *  any query survive. Taking the href as an argument is what keeps the write path testable. */
+export function hashUrl(href: string, search: URLSearchParams): string {
+  const url = new URL(href);
+  url.hash = searchParamsToHash(search);
+  return url.toString();
+}

--- a/apps/web/src/shared/utils/hash-params.ts
+++ b/apps/web/src/shared/utils/hash-params.ts
@@ -13,8 +13,9 @@ export function hashToSearchParams(hash: string): URLSearchParams {
   return new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
 }
 
-/** href + params -> the URL to hand to `pushState`. Only the fragment changes; origin, path and
- *  any query survive.
+/** href + params -> the URL to hand to `pushState`: same origin and path, the params as the
+ *  fragment, and NO query string — this app reads none, so anything there is dead weight a share
+ *  link would carry forever (a legacy `?s=` permalink kept re-copying its own dead payload).
  *
  *  `search.toString()`, not nuqs's `renderQueryString`: that one returns a `?`-prefixed string
  *  (so the fragment would read `#?view=…`) and calls `warnIfURLIsTooLong`, which measures a
@@ -24,6 +25,7 @@ export function hashToSearchParams(hash: string): URLSearchParams {
  *  Taking the href as an argument is what keeps the write path testable without a DOM. */
 export function hashUrl(href: string, search: URLSearchParams): string {
   const url = new URL(href);
+  url.search = '';
   url.hash = search.toString();
   return url.toString();
 }

--- a/apps/web/src/shared/utils/hash-params.ts
+++ b/apps/web/src/shared/utils/hash-params.ts
@@ -46,3 +46,24 @@ export function pickKeys(search: URLSearchParams, keys: string[]): URLSearchPara
   }
   return filtered;
 }
+
+/** The `useSyncExternalStore` snapshot, extracted from the hook so it can be tested in node.
+ *  It compares snapshots with `Object.is` and throws *"The result of getSnapshot should be cached
+ *  to avoid an infinite loop"* on a fresh object each call, so this caches on the serialised
+ *  WATCHED keys. Two load-bearing properties, both pinned in hash-params.test.ts:
+ *    - identity is PRESERVED when only an unwatched key moves (that is key isolation: no render);
+ *    - identity CHANGES when a watched key moves (or the URL would update and the UI would not).
+ *  The key is derived from the content, so a change of `watchKeys` that yields the same params
+ *  correctly keeps the same object. One cache cell per caller — hence a factory. */
+export function createSnapshotCache(): (hash: string, watchKeys: string[]) => URLSearchParams {
+  let cached: { key: string; search: URLSearchParams } | null = null;
+  return (hash, watchKeys) => {
+    const filtered = pickKeys(hashToSearchParams(hash), watchKeys);
+    const key = filtered.toString();
+    if (cached?.key === key) {
+      return cached.search;
+    }
+    cached = { key, search: filtered };
+    return filtered;
+  };
+}

--- a/apps/web/src/shared/utils/hash-params.ts
+++ b/apps/web/src/shared/utils/hash-params.ts
@@ -1,0 +1,48 @@
+// The pure half of the fragment transport: strings in, strings out. No `location`, no `history`,
+// no React, and — enforced by the `hash-params-stays-pure` rule in .dependency-cruiser.cjs — no
+// imports at all. That is what lets a pure page lib (benchmark/lib/explorer-url) reuse the
+// `#`-strip without pulling in hash-adapter.ts, whose module top level builds a React provider.
+//
+// Why the app's URL state lives in the FRAGMENT: a playground permalink carries a whole `.s` file,
+// and a query string is part of the HTTP request line (GitHub Pages answers 414 above ~8 KiB),
+// while a fragment is never sent to the server at all.
+
+/** `''` | `'#'` | `'#a=1'` | `'a=1'` -> params. Strips exactly one leading `#` — handing one to
+ *  `URLSearchParams` would make an entry keyed `'#'` (and `'#a=1'` has no key `a` at all). */
+export function hashToSearchParams(hash: string): URLSearchParams {
+  return new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
+}
+
+/** href + params -> the URL to hand to `pushState`. Only the fragment changes; origin, path and
+ *  any query survive.
+ *
+ *  `search.toString()`, not nuqs's `renderQueryString`: that one returns a `?`-prefixed string
+ *  (so the fragment would read `#?view=…`) and calls `warnIfURLIsTooLong`, which measures a
+ *  FRAGMENT as a query against `URL_MAX_LENGTH = 2e3` — a permanently false dev warning, firing
+ *  exactly while testing the long links this transport exists to allow.
+ *
+ *  Taking the href as an argument is what keeps the write path testable without a DOM. */
+export function hashUrl(href: string, search: URLSearchParams): string {
+  const url = new URL(href);
+  url.hash = search.toString();
+  return url.toString();
+}
+
+/** Key isolation: a COPY of `search` holding only `keys`, so a hook watching `s` does not
+ *  re-render when `tab` moves. nuqs's own `filterSearchParams` is internal (it appears in no
+ *  `.d.ts` it ships), so this is a reimplementation of it with `copy` fixed to true.
+ *  An empty `keys` means "watch everything": nuqs asks for that, and — as in nuqs — the input is
+ *  then returned ALIASED rather than copied, which is safe only because every caller here passes
+ *  a freshly parsed object. */
+export function pickKeys(search: URLSearchParams, keys: string[]): URLSearchParams {
+  if (keys.length === 0) {
+    return search;
+  }
+  const filtered = new URLSearchParams(search);
+  for (const key of Array.from(search.keys())) {
+    if (!keys.includes(key)) {
+      filtered.delete(key);
+    }
+  }
+  return filtered;
+}

--- a/apps/web/src/shared/utils/hash-params.ts
+++ b/apps/web/src/shared/utils/hash-params.ts
@@ -1,41 +1,35 @@
-// The pure half of the fragment transport: strings in, strings out. No `location`, no `history`,
-// no React, and — enforced by the `hash-params-stays-pure` rule in .dependency-cruiser.cjs — no
-// imports at all. That is what lets a pure page lib (benchmark/lib/explorer-url) reuse the
-// `#`-strip without pulling in hash-adapter.ts, whose module top level builds a React provider.
+// The pure half of the fragment transport: strings in, strings out, and — enforced by the
+// `hash-params-stays-pure` rule in .dependency-cruiser.cjs — no imports at all, so every decision
+// it makes runs in vitest's node environment, the only one apps/web has. React glue: hash-adapter.
 //
-// Why the app's URL state lives in the FRAGMENT: a playground permalink carries a whole `.s` file,
-// and a query string is part of the HTTP request line (GitHub Pages answers 414 above ~8 KiB),
-// while a fragment is never sent to the server at all.
+// Why the FRAGMENT: a playground permalink carries a whole `.s` file, and a query string is part
+// of the HTTP request line — GitHub Pages answers `414 URI Too Long` above ~8,180 characters,
+// while 200,000 characters of fragment come back 200, never having been sent.
 
-/** `''` | `'#'` | `'#a=1'` | `'a=1'` -> params. Strips exactly one leading `#` — handing one to
- *  `URLSearchParams` would make an entry keyed `'#'` (and `'#a=1'` has no key `a` at all). */
+/** Strips exactly one leading `#`: handing one to `URLSearchParams` makes an entry keyed `'#'`,
+ *  and `'#a=1'` then has no key `a` at all. */
 export function hashToSearchParams(hash: string): URLSearchParams {
   return new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
 }
 
-/** href + params -> the URL to hand to `pushState`: same origin and path, the params as the
- *  fragment, and NO query string — this app reads none, so anything there is dead weight a share
- *  link would carry forever (a legacy `?s=` permalink kept re-copying its own dead payload).
+/** The URL to hand to `pushState`: `href` with `search` as its fragment and the rest of it — the
+ *  query string included — untouched. This app reads no query param, and ignoring someone else's
+ *  is not the same as deleting it. `href` is an argument so the write path stays testable.
  *
- *  `search.toString()`, not nuqs's `renderQueryString`: that one returns a `?`-prefixed string
- *  (so the fragment would read `#?view=…`) and calls `warnIfURLIsTooLong`, which measures a
- *  FRAGMENT as a query against `URL_MAX_LENGTH = 2e3` — a permanently false dev warning, firing
- *  exactly while testing the long links this transport exists to allow.
- *
- *  Taking the href as an argument is what keeps the write path testable without a DOM. */
+ *  `search.toString()`, not nuqs's `renderQueryString`: that one returns a `?`-prefixed string (so
+ *  the fragment would read `#?view=…`) and calls `warnIfURLIsTooLong`, which measures a FRAGMENT
+ *  against `URL_MAX_LENGTH = 2e3` — a false dev warning firing on exactly the long links this
+ *  transport exists to allow. */
 export function hashUrl(href: string, search: URLSearchParams): string {
   const url = new URL(href);
-  url.search = '';
   url.hash = search.toString();
   return url.toString();
 }
 
-/** Key isolation: a COPY of `search` holding only `keys`, so a hook watching `s` does not
- *  re-render when `tab` moves. nuqs's own `filterSearchParams` is internal (it appears in no
- *  `.d.ts` it ships), so this is a reimplementation of it with `copy` fixed to true.
- *  An empty `keys` means "watch everything": nuqs asks for that, and — as in nuqs — the input is
- *  then returned ALIASED rather than copied, which is safe only because every caller here passes
- *  a freshly parsed object. */
+/** Key isolation: a COPY of `search` holding only `keys`, so a hook watching `s` does not re-render
+ *  when `tab` moves. nuqs's own `filterSearchParams` is internal (it appears in no `.d.ts` it
+ *  ships), so this reimplements it. Empty `keys` means "watch everything" — nuqs asks for that —
+ *  and then returns the input ALIASED, safe only because every caller passes a fresh parse. */
 export function pickKeys(search: URLSearchParams, keys: string[]): URLSearchParams {
   if (keys.length === 0) {
     return search;
@@ -49,14 +43,11 @@ export function pickKeys(search: URLSearchParams, keys: string[]): URLSearchPara
   return filtered;
 }
 
-/** The `useSyncExternalStore` snapshot, extracted from the hook so it can be tested in node.
- *  It compares snapshots with `Object.is` and throws *"The result of getSnapshot should be cached
- *  to avoid an infinite loop"* on a fresh object each call, so this caches on the serialised
- *  WATCHED keys. Two load-bearing properties, both pinned in hash-params.test.ts:
- *    - identity is PRESERVED when only an unwatched key moves (that is key isolation: no render);
- *    - identity CHANGES when a watched key moves (or the URL would update and the UI would not).
- *  The key is derived from the content, so a change of `watchKeys` that yields the same params
- *  correctly keeps the same object. One cache cell per caller — hence a factory. */
+/** The `useSyncExternalStore` snapshot. That hook compares with `Object.is` and throws *"The result
+ *  of getSnapshot should be cached to avoid an infinite loop"* on a fresh object each call, so this
+ *  caches on the serialised WATCHED keys: identity survives a move of an unwatched key (that is the
+ *  isolation — no render), and changes when a watched one moves (or the URL would update and the UI
+ *  would not). One cell per caller, hence a factory. */
 export function createSnapshotCache(): (hash: string, watchKeys: string[]) => URLSearchParams {
   let cached: { key: string; search: URLSearchParams } | null = null;
   return (hash, watchKeys) => {

--- a/apps/web/src/shared/utils/permalink.ts
+++ b/apps/web/src/shared/utils/permalink.ts
@@ -1,5 +1,5 @@
 // Shareable state-in-URL: the whole playground state lz-string-compressed into one URL param
-// (`?s=`, see url-state.ts), so a permalink IS the repro — no server, nothing stored.
+// (`#s=`, see url-state.ts), so a permalink IS the repro — no server, nothing stored.
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
 
 export interface ShareState {

--- a/apps/web/src/shared/utils/url-state.ts
+++ b/apps/web/src/shared/utils/url-state.ts
@@ -1,13 +1,11 @@
-// URL-state glue for nuqs: the playground ShareState as a single `?s=` query param. The codec
-// itself stays in permalink.ts (dependency-free).
+// URL-state glue for nuqs: the playground ShareState as a single `s=` param in the fragment (see
+// hash-adapter.ts). The codec itself stays in permalink.ts (dependency-free).
 import { createParser } from 'nuqs';
 
 import { type ShareState, decodeShare, encodeShare } from './permalink';
 
-// lz-string's URI alphabet includes '+', which URLSearchParams decodes to a space — restore it
-// before decoding (a space can never legitimately appear in an lz-string payload).
 export const parseAsShareState = createParser<ShareState>({
-  parse: (value) => decodeShare(value.replaceAll(' ', '+')),
+  parse: decodeShare,
   serialize: encodeShare,
   eq: (a, b) => a === b || encodeShare(a) === encodeShare(b),
 });

--- a/apps/web/test/benchmark-link.test.ts
+++ b/apps/web/test/benchmark-link.test.ts
@@ -19,7 +19,7 @@ test("a row's share is the exact playground state and round-trips through the pe
     name: 'add1',
     asm: '00000000 <add1>:\n   0:\tjr\tra\n',
   });
-  // The shell hands `share` to the editor and the editor re-encodes it into the `?s=` param — so it
+  // The shell hands `share` to the editor and the editor re-encodes it into the `s=` param — so it
   // must survive an encode/decode round-trip unchanged.
   expect(decodeShare(encodeShare(share))).toEqual(share);
 });

--- a/apps/web/test/explorer-url.test.ts
+++ b/apps/web/test/explorer-url.test.ts
@@ -48,7 +48,7 @@ test('a feature definition is a link, and opening one PRESERVES the filters alre
 });
 
 test('opening a second definition replaces the first rather than appending', () => {
-  const href = featureHref('magic-div', featureHref('div-const', '#tab=explorer').slice(0));
+  const href = featureHref('magic-div', featureHref('div-const', '#tab=explorer'));
   expect(new URLSearchParams(href.slice(1)).getAll(FEATURE_TERM_KEY)).toEqual(['magic-div']);
 });
 

--- a/apps/web/test/explorer-url.test.ts
+++ b/apps/web/test/explorer-url.test.ts
@@ -37,16 +37,18 @@ test('every filter key has a URL name and a reset entry, so a preset cannot leav
 
 test('a feature definition is a link, and opening one PRESERVES the filters already set', () => {
   // the drawer sits over whatever tab is showing, so its link must not reset the reader's view
-  const href = featureHref('div-const', '?tab=explorer&feature=loop,table&project=kleod');
+  const href = featureHref('div-const', '#tab=explorer&feature=loop,table&project=kleod');
   const params = new URLSearchParams(href.slice(1));
   expect(params.get(FEATURE_TERM_KEY)).toBe('div-const');
   expect(params.get('tab')).toBe('explorer');
   expect(params.get('feature')).toBe('loop,table');
   expect(params.get('project')).toBe('kleod');
+  // The link is a FRAGMENT: a '?' here would be a real navigation that discards the whole state.
+  expect(href.startsWith('#')).toBe(true);
 });
 
 test('opening a second definition replaces the first rather than appending', () => {
-  const href = featureHref('magic-div', featureHref('div-const', '?tab=explorer').slice(0));
+  const href = featureHref('magic-div', featureHref('div-const', '#tab=explorer').slice(0));
   expect(new URLSearchParams(href.slice(1)).getAll(FEATURE_TERM_KEY)).toEqual(['magic-div']);
 });
 

--- a/apps/web/test/hash-adapter.test.ts
+++ b/apps/web/test/hash-adapter.test.ts
@@ -1,0 +1,72 @@
+// The fragment transport: pure string <-> URLSearchParams helpers behind the nuqs hash adapter.
+// Everything here is string-level, so it runs in vitest's node environment with no DOM.
+import { expect, test } from 'vitest';
+
+import { hashToSearchParams, hashUrl, searchParamsToHash } from '../src/shared/utils/hash-adapter';
+import { encodeShare } from '../src/shared/utils/permalink';
+import { parseAsShareState } from '../src/shared/utils/url-state';
+
+test('hashToSearchParams strips exactly one leading #, and tolerates none', () => {
+  expect([...hashToSearchParams('')]).toEqual([]);
+  // `new URLSearchParams('#')` on its own yields one entry keyed '#': the strip must be ours.
+  expect([...hashToSearchParams('#')]).toEqual([]);
+  expect([...hashToSearchParams('#a=1&b=2')]).toEqual([
+    ['a', '1'],
+    ['b', '2'],
+  ]);
+  expect(hashToSearchParams('a=1&b=2').toString()).toBe(hashToSearchParams('#a=1&b=2').toString());
+});
+
+test('a hostile value round-trips through the fragment verbatim', () => {
+  const nasty = 'a b+c&d=e%f#g"h<i>j`k/l:m?n';
+  const params = new URLSearchParams();
+  params.set('x', nasty);
+  expect(hashToSearchParams(searchParamsToHash(params)).get('x')).toBe(nasty);
+});
+
+test('a real lz-string ShareState whose encoding contains + round-trips through the fragment', () => {
+  const base = {
+    target: 'agbcc',
+    backend: 'c',
+    name: 'add1',
+    asm: 'add1:\n\tadd r0, r0, #1\n\tbx lr\n',
+  };
+  // Grow the payload until the lz-string alphabet actually emits a '+' — that character is the
+  // one the query-string transport used to mangle into a space.
+  let state = base;
+  let encoded = encodeShare(state);
+  for (let i = 0; !encoded.includes('+') && i < 500; i++) {
+    state = { ...base, asm: `${base.asm}// pad ${i}\n` };
+    encoded = encodeShare(state);
+  }
+  expect(encoded).toContain('+');
+
+  const params = new URLSearchParams();
+  params.set('s', encoded);
+  const back = hashToSearchParams(searchParamsToHash(params)).get('s');
+  expect(back).toBe(encoded);
+  expect(parseAsShareState.parse(back!)).toEqual(state);
+});
+
+test('an empty param set makes an empty fragment, and hashUrl then writes no #', () => {
+  expect(searchParamsToHash(new URLSearchParams())).toBe('');
+  expect(hashUrl('https://x.test/asmlift/?keep=1#view=benchmark', new URLSearchParams())).toBe(
+    'https://x.test/asmlift/?keep=1',
+  );
+});
+
+test('hashUrl changes only the fragment', () => {
+  const params = new URLSearchParams();
+  params.set('view', 'benchmark');
+  params.set('s', 'a+b');
+  expect(hashUrl('https://x.test/asmlift/?keep=1#old=1', params)).toBe(
+    'https://x.test/asmlift/?keep=1#view=benchmark&s=a%2Bb',
+  );
+});
+
+test('a 200,000-character payload round-trips (the fragment has no transport ceiling)', () => {
+  const huge = 'A'.repeat(200_000);
+  const params = new URLSearchParams();
+  params.set('s', huge);
+  expect(hashToSearchParams(searchParamsToHash(params)).get('s')).toBe(huge);
+});

--- a/apps/web/test/hash-adapter.test.ts
+++ b/apps/web/test/hash-adapter.test.ts
@@ -2,7 +2,7 @@
 // Everything here is string-level, so it runs in vitest's node environment with no DOM.
 import { expect, test } from 'vitest';
 
-import { hashToSearchParams, hashUrl, searchParamsToHash } from '../src/shared/utils/hash-adapter';
+import { hashToSearchParams, hashUrl, pickKeys, searchParamsToHash } from '../src/shared/utils/hash-adapter';
 import { encodeShare } from '../src/shared/utils/permalink';
 import { parseAsShareState } from '../src/shared/utils/url-state';
 
@@ -69,4 +69,36 @@ test('a 200,000-character payload round-trips (the fragment has no transport cei
   const params = new URLSearchParams();
   params.set('s', huge);
   expect(hashToSearchParams(searchParamsToHash(params)).get('s')).toBe(huge);
+});
+
+// --- key isolation: nuqs's own filterSearchParams is internal (no hit in any dist/**/*.d.ts),
+// so this is a reimplementation, and these are its tests.
+
+const explorer = () =>
+  new URLSearchParams('view=benchmark&tab=explorer&project=kleod&feature=loop&feature=table&s=xyz');
+
+test('pickKeys keeps only the watched keys, in their original order', () => {
+  expect(pickKeys(explorer(), ['s', 'view']).toString()).toBe('view=benchmark&s=xyz');
+});
+
+test('pickKeys with no keys watches everything (nuqs asks for that on the empty set)', () => {
+  expect(pickKeys(explorer(), []).toString()).toBe(explorer().toString());
+});
+
+test('pickKeys keeps every value of a repeated key', () => {
+  expect(pickKeys(explorer(), ['feature']).getAll('feature')).toEqual(['loop', 'table']);
+});
+
+test('pickKeys does not mutate its input, and is stable across calls', () => {
+  const source = explorer();
+  const before = source.toString();
+  const a = pickKeys(source, ['view']).toString();
+  const b = pickKeys(source, ['view']).toString();
+  // That string IS the getSnapshot cache key, so equal input must give an equal key.
+  expect(a).toBe(b);
+  expect(source.toString()).toBe(before);
+});
+
+test('pickKeys drops a watched key that is absent rather than inventing it', () => {
+  expect(pickKeys(explorer(), ['nope']).toString()).toBe('');
 });

--- a/apps/web/test/hash-params.test.ts
+++ b/apps/web/test/hash-params.test.ts
@@ -56,17 +56,17 @@ test('a real lz-string ShareState whose encoding contains + round-trips through 
 });
 
 test('an empty param set makes an empty fragment, and hashUrl then writes no #', () => {
-  expect(hashUrl('https://x.test/asmlift/?keep=1#view=benchmark', new URLSearchParams())).toBe(
-    'https://x.test/asmlift/?keep=1',
-  );
+  expect(hashUrl('https://x.test/asmlift/#view=benchmark', new URLSearchParams())).toBe('https://x.test/asmlift/');
 });
 
-test('hashUrl changes only the fragment', () => {
+test('hashUrl replaces the fragment and DROPS the query — this app reads none', () => {
   const params = new URLSearchParams();
   params.set('view', 'benchmark');
   params.set('s', 'a+b');
-  expect(hashUrl('https://x.test/asmlift/?keep=1#old=1', params)).toBe(
-    'https://x.test/asmlift/?keep=1#view=benchmark&s=a%2Bb',
+  // The `?s=` is a dead pre-fragment permalink: without the drop it rides along through every
+  // share, reload and tab switch, and is counted by the Share button's 20k length warning.
+  expect(hashUrl('https://x.test/asmlift/?s=DEAD-LEGACY-PAYLOAD#old=1', params)).toBe(
+    'https://x.test/asmlift/#view=benchmark&s=a%2Bb',
   );
 });
 

--- a/apps/web/test/hash-params.test.ts
+++ b/apps/web/test/hash-params.test.ts
@@ -38,8 +38,8 @@ test('a real lz-string ShareState whose encoding contains + round-trips through 
     name: 'add1',
     asm: 'add1:\n\tadd r0, r0, #1\n\tbx lr\n',
   };
-  // Grow the payload until the lz-string alphabet actually emits a '+' — that character is the
-  // one the query-string transport used to mangle into a space.
+  // Grow the payload until lz-string's alphabet actually emits a '+': the one character a
+  // transport can silently turn into a space (`new URLSearchParams('x=a+b').get('x')` is 'a b').
   let state = base;
   let encoded = encodeShare(state);
   for (let i = 0; !encoded.includes('+') && i < 500; i++) {
@@ -59,14 +59,14 @@ test('an empty param set makes an empty fragment, and hashUrl then writes no #',
   expect(hashUrl('https://x.test/asmlift/#view=benchmark', new URLSearchParams())).toBe('https://x.test/asmlift/');
 });
 
-test('hashUrl replaces the fragment and DROPS the query — this app reads none', () => {
+test('hashUrl replaces the fragment and touches nothing else in the URL', () => {
   const params = new URLSearchParams();
   params.set('view', 'benchmark');
   params.set('s', 'a+b');
-  // The `?s=` is a dead pre-fragment permalink: without the drop it rides along through every
-  // share, reload and tab switch, and is counted by the Share button's 20k length warning.
-  expect(hashUrl('https://x.test/asmlift/?s=DEAD-LEGACY-PAYLOAD#old=1', params)).toBe(
-    'https://x.test/asmlift/#view=benchmark&s=a%2Bb',
+  // The query is someone else's slot — an analytics tag, or a `?s=` this app ignores. Ignoring is
+  // not deleting, and only one of the two is reversible.
+  expect(hashUrl('https://x.test/asmlift/?utm_source=hn#old=1', params)).toBe(
+    'https://x.test/asmlift/?utm_source=hn#view=benchmark&s=a%2Bb',
   );
 });
 

--- a/apps/web/test/hash-params.test.ts
+++ b/apps/web/test/hash-params.test.ts
@@ -2,7 +2,7 @@
 // Everything here is string-level, so it runs in vitest's node environment with no DOM.
 import { expect, test } from 'vitest';
 
-import { hashToSearchParams, hashUrl, pickKeys, searchParamsToHash } from '../src/shared/utils/hash-adapter';
+import { hashToSearchParams, hashUrl, pickKeys } from '../src/shared/utils/hash-params';
 import { encodeShare } from '../src/shared/utils/permalink';
 import { parseAsShareState } from '../src/shared/utils/url-state';
 
@@ -21,7 +21,7 @@ test('a hostile value round-trips through the fragment verbatim', () => {
   const nasty = 'a b+c&d=e%f#g"h<i>j`k/l:m?n';
   const params = new URLSearchParams();
   params.set('x', nasty);
-  expect(hashToSearchParams(searchParamsToHash(params)).get('x')).toBe(nasty);
+  expect(hashToSearchParams(params.toString()).get('x')).toBe(nasty);
 });
 
 test('a real lz-string ShareState whose encoding contains + round-trips through the fragment', () => {
@@ -43,13 +43,12 @@ test('a real lz-string ShareState whose encoding contains + round-trips through 
 
   const params = new URLSearchParams();
   params.set('s', encoded);
-  const back = hashToSearchParams(searchParamsToHash(params)).get('s');
+  const back = hashToSearchParams(params.toString()).get('s');
   expect(back).toBe(encoded);
   expect(parseAsShareState.parse(back!)).toEqual(state);
 });
 
 test('an empty param set makes an empty fragment, and hashUrl then writes no #', () => {
-  expect(searchParamsToHash(new URLSearchParams())).toBe('');
   expect(hashUrl('https://x.test/asmlift/?keep=1#view=benchmark', new URLSearchParams())).toBe(
     'https://x.test/asmlift/?keep=1',
   );
@@ -68,7 +67,7 @@ test('a 200,000-character payload round-trips (the fragment has no transport cei
   const huge = 'A'.repeat(200_000);
   const params = new URLSearchParams();
   params.set('s', huge);
-  expect(hashToSearchParams(searchParamsToHash(params)).get('s')).toBe(huge);
+  expect(hashToSearchParams(params.toString()).get('s')).toBe(huge);
 });
 
 // --- key isolation: nuqs's own filterSearchParams is internal (no hit in any dist/**/*.d.ts),

--- a/apps/web/test/hash-params.test.ts
+++ b/apps/web/test/hash-params.test.ts
@@ -6,6 +6,13 @@ import { createSnapshotCache, hashToSearchParams, hashUrl, pickKeys } from '../s
 import { encodeShare } from '../src/shared/utils/permalink';
 import { parseAsShareState } from '../src/shared/utils/url-state';
 
+/** The WHOLE write-then-read path, not a string-level shortcut: params -> the URL the adapter
+ *  hands to `pushState` -> what `location.hash` gives back -> params. `URL`'s hash setter is the
+ *  one platform component that could re-encode a payload, and only this route touches it. */
+function throughTheFragment(params: URLSearchParams): URLSearchParams {
+  return hashToSearchParams(new URL(hashUrl('https://x.test/asmlift/', params)).hash);
+}
+
 test('hashToSearchParams strips exactly one leading #, and tolerates none', () => {
   expect([...hashToSearchParams('')]).toEqual([]);
   // `new URLSearchParams('#')` on its own yields one entry keyed '#': the strip must be ours.
@@ -21,7 +28,7 @@ test('a hostile value round-trips through the fragment verbatim', () => {
   const nasty = 'a b+c&d=e%f#g"h<i>j`k/l:m?n';
   const params = new URLSearchParams();
   params.set('x', nasty);
-  expect(hashToSearchParams(params.toString()).get('x')).toBe(nasty);
+  expect(throughTheFragment(params).get('x')).toBe(nasty);
 });
 
 test('a real lz-string ShareState whose encoding contains + round-trips through the fragment', () => {
@@ -43,7 +50,7 @@ test('a real lz-string ShareState whose encoding contains + round-trips through 
 
   const params = new URLSearchParams();
   params.set('s', encoded);
-  const back = hashToSearchParams(params.toString()).get('s');
+  const back = throughTheFragment(params).get('s');
   expect(back).toBe(encoded);
   expect(parseAsShareState.parse(back!)).toEqual(state);
 });
@@ -63,11 +70,11 @@ test('hashUrl changes only the fragment', () => {
   );
 });
 
-test('a 200,000-character payload round-trips (the fragment has no transport ceiling)', () => {
+test('a 200,000-character payload round-trips through the fragment (no transport ceiling)', () => {
   const huge = 'A'.repeat(200_000);
   const params = new URLSearchParams();
   params.set('s', huge);
-  expect(hashToSearchParams(params.toString()).get('s')).toBe(huge);
+  expect(throughTheFragment(params).get('s')).toBe(huge);
 });
 
 // --- key isolation: nuqs's own filterSearchParams is internal (no hit in any dist/**/*.d.ts),

--- a/apps/web/test/hash-params.test.ts
+++ b/apps/web/test/hash-params.test.ts
@@ -2,7 +2,7 @@
 // Everything here is string-level, so it runs in vitest's node environment with no DOM.
 import { expect, test } from 'vitest';
 
-import { hashToSearchParams, hashUrl, pickKeys } from '../src/shared/utils/hash-params';
+import { createSnapshotCache, hashToSearchParams, hashUrl, pickKeys } from '../src/shared/utils/hash-params';
 import { encodeShare } from '../src/shared/utils/permalink';
 import { parseAsShareState } from '../src/shared/utils/url-state';
 
@@ -100,4 +100,31 @@ test('pickKeys does not mutate its input, and is stable across calls', () => {
 
 test('pickKeys drops a watched key that is absent rather than inventing it', () => {
   expect(pickKeys(explorer(), ['nope']).toString()).toBe('');
+});
+
+// --- the getSnapshot cache: `useSyncExternalStore` compares with Object.is, so these are
+// IDENTITY assertions, not value assertions. They are the two properties that decide whether the
+// app re-renders too much (isolation) or not at all (liveness).
+
+test('createSnapshotCache preserves object identity when only an UNWATCHED key moves', () => {
+  const snap = createSnapshotCache();
+  expect(snap('#view=a&s=1', ['s'])).toBe(snap('#view=b&s=1', ['s']));
+  // ... and when nothing moves at all, which is what stops the infinite-loop warning.
+  expect(snap('#view=b&s=1', ['s'])).toBe(snap('#view=b&s=1', ['s']));
+});
+
+test('createSnapshotCache returns a NEW object when a watched key moves', () => {
+  const snap = createSnapshotCache();
+  expect(snap('#s=1', ['s'])).not.toBe(snap('#s=2', ['s']));
+  expect(snap('#s=2', ['s']).get('s')).toBe('2');
+  // Watching everything (nuqs's empty-keys case) still tracks every key.
+  const all = createSnapshotCache();
+  expect(all('#view=a', [])).not.toBe(all('#view=b', []));
+});
+
+test('createSnapshotCache gives each caller its own cell, and takes the hash with or without #', () => {
+  const a = createSnapshotCache();
+  const b = createSnapshotCache();
+  expect(a('#s=1', ['s'])).not.toBe(b('#s=1', ['s']));
+  expect(a('#s=1', ['s'])).toBe(a('s=1', ['s']));
 });

--- a/apps/web/test/url-state.test.ts
+++ b/apps/web/test/url-state.test.ts
@@ -1,30 +1,14 @@
 // The nuqs glue: the `s=` ShareState parser. The transport is the FRAGMENT (see hash-adapter.ts),
-// which round-trips a payload verbatim, so the parser does no repair of its own.
+// which round-trips a payload verbatim, so the parser does no repair of its own — the '+'-carrying
+// payload that proves it is exercised end to end in hash-params.test.ts.
 import { expect, test } from 'vitest';
 
-import { encodeShare } from '../src/shared/utils/permalink';
 import { parseAsShareState } from '../src/shared/utils/url-state';
 
 const share = { target: 'agbcc', backend: 'c', name: 'add1', asm: 'add1:\n\tadd r0, r0, #1\n\tbx lr\n' };
 
 test('ShareState round-trips through the s= parser', () => {
   expect(parseAsShareState.parse(parseAsShareState.serialize(share))).toEqual(share);
-});
-
-test('a payload containing + parses as-is: the parser does no repair of its own', () => {
-  // '+' is in lz-string's URI alphabet, and it was the reason url-state.ts used to pre-rewrite
-  // ' ' -> '+'. That rewrite was inert twice over: the fragment transport round-trips '+'
-  // verbatim, and lz-string's own decompressFromEncodedURIComponent already does
-  // `input.replace(/ /g, "+")` (lz-string/libs/lz-string.js:102). So the parser is plain
-  // decodeShare, and this pins that a '+'-carrying payload survives it untouched.
-  let s = share;
-  let encoded = encodeShare(s);
-  for (let i = 0; !encoded.includes('+') && i < 500; i++) {
-    s = { ...share, asm: `${share.asm}// pad ${i}\n` };
-    encoded = encodeShare(s);
-  }
-  expect(encoded).toContain('+');
-  expect(parseAsShareState.parse(encoded)).toEqual(s);
 });
 
 test('garbage s= values parse to null, never throw', () => {

--- a/apps/web/test/url-state.test.ts
+++ b/apps/web/test/url-state.test.ts
@@ -1,4 +1,5 @@
-// The nuqs glue: the ?s= ShareState parser, including the URLSearchParams '+' → space quirk.
+// The nuqs glue: the `s=` ShareState parser. The transport is the FRAGMENT (see hash-adapter.ts),
+// which round-trips a payload verbatim, so the parser does no repair of its own.
 import { expect, test } from 'vitest';
 
 import { encodeShare } from '../src/shared/utils/permalink';
@@ -6,13 +7,16 @@ import { parseAsShareState } from '../src/shared/utils/url-state';
 
 const share = { target: 'agbcc', backend: 'c', name: 'add1', asm: 'add1:\n\tadd r0, r0, #1\n\tbx lr\n' };
 
-test('ShareState round-trips through the ?s= parser', () => {
+test('ShareState round-trips through the s= parser', () => {
   expect(parseAsShareState.parse(parseAsShareState.serialize(share))).toEqual(share);
 });
 
-test("a '+' decoded to a space by URLSearchParams is restored before lz decoding", () => {
-  // Find a state whose encoding actually contains '+' (the lz URI alphabet includes it), then
-  // simulate what URLSearchParams hands the parser: every '+' already turned into a space.
+test('a payload containing + parses as-is: the parser does no repair of its own', () => {
+  // '+' is in lz-string's URI alphabet, and it was the reason url-state.ts used to pre-rewrite
+  // ' ' -> '+'. That rewrite was inert twice over: the fragment transport round-trips '+'
+  // verbatim, and lz-string's own decompressFromEncodedURIComponent already does
+  // `input.replace(/ /g, "+")` (lz-string/libs/lz-string.js:102). So the parser is plain
+  // decodeShare, and this pins that a '+'-carrying payload survives it untouched.
   let s = share;
   let encoded = encodeShare(s);
   for (let i = 0; !encoded.includes('+') && i < 500; i++) {
@@ -20,10 +24,10 @@ test("a '+' decoded to a space by URLSearchParams is restored before lz decoding
     encoded = encodeShare(s);
   }
   expect(encoded).toContain('+');
-  expect(parseAsShareState.parse(encoded.replaceAll('+', ' '))).toEqual(s);
+  expect(parseAsShareState.parse(encoded)).toEqual(s);
 });
 
-test('garbage ?s= values parse to null, never throw', () => {
+test('garbage s= values parse to null, never throw', () => {
   expect(parseAsShareState.parse('not-lz-data-!!!')).toBeNull();
   expect(parseAsShareState.parse('')).toBeNull();
 });


### PR DESCRIPTION
## The ceiling this was measured against

A playground permalink carries a whole `.s` file, and a query string is part of the HTTP request
line. Binary-searched against the live site:

```
query_len=8171 http=200
query_len=8180 http=200
query_len=8187 http=414      <- GitHub Pages: 414 URI Too Long
frag_len=200000 http=200
```

That ceiling is not theoretical for this app. Encoding a real 10,597-character GBA disassembly
(agbcc, C backend) with `encodeShare` gives a **4,754**-character payload; paste a 200-entry symbol
map into the Symbols pane (6,935 JSON characters) and it is **9,508** — already over the line:

```
bare    len=4754 http=200
withmap len=9508 http=414
withmap as FRAGMENT  http=200
```

So the feature was not "nearly broken"; with a symbol map it *was* broken, and compression alone
cannot fix the class — a fragment is never sent to the server at all.

## The change

`apps/web/src/shared/utils/hash-adapter.ts` is a nuqs adapter built on `nuqs/adapters/custom`'s
`unstable_createAdapterProvider`, replacing `nuqs/adapters/react` in `main.tsx`. nuqs hands an
adapter a `URLSearchParams` and takes one back, and its contract says nothing about where they
live, so **every parser, `useQueryState`, `useQueryStates`, `urlKeys`, `clearOnDefault` and
`history: 'push'` in the app keeps working untouched.** It is nuqs's own React adapter minus what a
Vite SPA has no use for (RSC, SSR, provider props, full-page navigation, history monkey-patching),
with the read and the write swapped from `location.search` to `location.hash`, plus `hashchange` as
a third change source so a hand-edited address bar reaches the app. The pure string half is
`hash-params.ts`, which imports nothing — a dependency-cruiser rule (`hash-params-stays-pure`)
keeps it that way, because vitest's node environment is the only one `apps/web` has and that is
where the transport's decisions are tested.

**`search.toString()`, not nuqs's `renderQueryString`.** `renderQueryString` returns a
`?`-prefixed string, so `url.hash = …` would produce `#?view=…`; and it calls `warnIfURLIsTooLong`,
which builds `url.search = queryString` and warns above `URL_MAX_LENGTH = 2e3` — it would measure a
*fragment* payload as a *query*, i.e. a permanently false dev warning firing on exactly the long
links this transport exists to allow.

**The `+` workaround is deleted, and it had become wrong, not merely unnecessary.** `url-state.ts`
called `decodeShare(value.replaceAll(' ', '+'))` because nuqs's query encoder writes a space as
`+`. With `toString()` on both sides the encoding is symmetric, so that rewrite would now corrupt
any payload legitimately carrying a space. A test grows a real `ShareState` until lz-string's
alphabet emits a `+` and round-trips it through `hashUrl` → `new URL(…).hash` → parse.

**Key isolation is reimplemented.** `filterSearchParams(params, watchKeys, false)` is internal to
nuqs and exported from nothing it ships (`grep -rn filterSearchParams node_modules/nuqs/dist
--include='*.d.ts'` → exit 1). `pickKeys` is a five-line equivalent; without it every nuqs hook
re-renders on every param change, which the Explorer's 16 filters would feel. It differs from the
internal one in exactly one way: nuqs's takes a `copy` flag and can alias its input, `pickKeys`
always copies — except on the empty key set, where nuqs's "watch everything" contract makes
aliasing correct and every caller here passes a fresh parse.

**`getSearchParamsSnapshot` is required here and could not be copied from the reference.** nuqs's
default is `new URLSearchParams(location.search)` — empty under this transport — and it is the base
every queued update is written onto. Without it a write of one key drops every *other* key from the
URL; found in a browser, when clicking an Overview aggregate turned `#view=benchmark` into a URL
with no `view` in it.

## The risk

**Every URL this app writes now goes through this adapter** — `view`, `tab`, `fn`, `about`, the
playground `s=` payload and the Explorer's 16 filters — so a bug here breaks navigation everywhere,
not only sharing. There is no jsdom in `apps/web` and adding one for a single file would be a
bigger change than the feature, so everything that touches `location` and `history` was checked by
hand in a real browser, at the shipped commit:

1. **The long permalink.** `#s=<9,508-char payload>` loaded, decompiled `LoadBGTilemapData`,
   recovered `struct Elem0…Elem11` from the 200-entry symbol map that rode in the same fragment
   (Symbols pane: 6,935 characters), `0` `ASMLIFT_ERROR` markers; the app's own rewrite settled at
   a **9,770-character fragment / 9,792-character URL**. The same payload as `?s=` is a 414 on the
   live site. (The screenshot also shows "ranking unavailable — could not assemble the target asm":
   that is the in-browser assembler rejecting `thumb_func_start`, unrelated to this change.)
2. **The batched Back — the property most likely to regress silently.** Clicking an Overview
   aggregate wrote three keys (`view`, `vs`, `tab`) with `pushState` called **once**;
   `history.length` 3 → 4, table `209 / 942`. **One** Back returned to `#view=benchmark` and the
   Overview, with the push counter still 1 afterwards — no stale queued write landed on the popped
   entry. Forward restored all four keys.
3. **Deep links.** `#view=benchmark` loads the Benchmark (942 functions).
4. **A hand-edited fragment.** `location.hash = 'view=benchmark&tab=methodology'` moved the app to
   Methodology with no reload and no new history entry — that is what the `hashchange` source buys.
5. **Playground round trip.** An edit wrote `#s=…`; a reload restored the edited function name, the
   assembly and the C output from the fragment alone.
6. **The definition links.** With the Feature picker open: 80 `read more →` anchors, all
   `#`-prefixed, and each anchor minus its own `about=` **byte-equal to the live fragment** —
   re-checked after two filter changes made with the picker open (anchor `project` = live
   `project` = `pokeemerald`, then `sa3`).
7. **A query string on the way in.** `/?utm_source=hn&ref=article` — after the app's first write,
   `location.search` is still `?utm_source=hn&ref=article` and the state is in `#s=…`.
8. **Console.** After the reload: 2 messages, both `[vite] connecting/connected` DEBUG. Zero
   errors, zero warnings, zero React `getSnapshot` complaints, zero nuqs warnings.

## Old query permalinks die by design

As instructed, no back-compat shim: a `?s=` link now loads the app with no state. What the adapter
does **not** do is delete it. An earlier revision of this branch cleared `url.search` on every
write, which also erased `utm_source`/`ref` from any shared link ~250 ms after load and destroyed
the last readable copy of the dead payload. Ignoring a slot is not the same as destroying it, and
only one of the two is reversible.

## Two adversarial ledgers

**Round 1** (7 findings). Fixed: `hashUrl` unconditionally replaces the fragment; the pure half
split out as `hash-params.ts` with a CI rule that was *falsified* before it was trusted (a
temporary `import type` makes it fail, and it catches type-only imports); `createSnapshotCache`
extracted and unit-tested on its two identities (preserved when an unwatched key moves, new when a
watched one does); the "through the fragment" round-trips actually routed through a fragment;
`searchParamsToHash` inlined into its single caller. Declined with a command: third-party
`pushState` is invisible to nuqs's own React adapter too (that is what its opt-in
`enableHistorySync` is for); the raw-hash short-circuit in the snapshot cache is a real 0.07 ms/call
win that breaks key isolation in its naive form.

**Round 2** (4 new findings + one architecture review). Fixed here:

- **HIGH — a definition link built at render time pointed at the *previous* view.** `featureHref`
  read `window.location.hash` while `FeaturePicker` memoised on `counts`, which moves one write
  earlier, so every `read more →` href kept the previous filter set — silently substituting a
  different project into a copied link. Pre-existing in mechanism (the old version read
  `location.search` under an equally async writer), restated as a false claim by this round's own
  comment and test name. `featureHref` now takes the hash as a required argument, and the picker
  takes it from a new `useCurrentHash` that subscribes to the adapter's own store.
- **MEDIUM — `hashUrl` deleted the query string** (see above); reverted, with the test rewritten to
  pin preservation.
- **LOW — three comments stated mechanisms that are false.** `index.js:533` is inert because its
  `onCommittedPathname` guard (`:521`) compares an invariant `location.pathname`, *not* because of
  the `adapter.pathname` conjunct; the pure/glue split is not justified by "a provider built at
  import" (`createAdapterProvider` returns an arrow — nothing runs at import), it is justified by
  the node-only test environment; and the dropped `QueueReset` is not covered by browser check 2,
  whose clicks cannot enter the 50 ms window the queue lives in.
- **LOW — `useRef(createSnapshotCache())`** built and discarded a closure every render; now
  `useState`'s lazy initialiser.
- **LOW — the `+`-payload growth test existed twice**; the fragment-routed one subsumes the other.

Also from this pass: the comment density of the two new files was measured against its neighbours
(`shared/utils` sits at 0.05–0.29 comment lines per code line, the densest file in `apps/web` at
0.77) and cut from 1.28/1.16 to 0.85/0.81, deleting the history and the review-argument prose; and
every number left in a comment was re-derived from the command that produces it.

## What was NOT done

- No back-compat shim for `?s=` links (instructed).
- No codec change — `permalink.ts`'s lz-string encoding is untouched; deflate/brotli stays a
  separate, now-optional decision.
- No `row=` scheme for benchmark links.
- No jsdom / `@testing-library/react`.
- nuqs's popstate queue abort (`QueueReset` → `resetQueues`) is not reimplemented: no entry in
  nuqs's export map reaches it. The gap is written at the call site — a Back pressed while an
  update is still queued (at most `defaultRateLimit.timeMs`, 50 ms outside Safari) lands that
  update on the entry popped to. It is not reachable by hand in a browser check, and not worth
  reaching into nuqs's internals for.

## Scope and gates

`git diff origin/main --name-only` → **15 files**: `apps/web/**` plus one README link. Nothing
under `packages/` or `apps/benchmark/`, so **no benchmark row can move** and the 15–29 minute
`bench run` is skipped deliberately rather than forgotten.

All run at the shipped commit:

```
pnpm exec vitest run apps/web/test   Test Files  19 passed (19)   Tests  136 passed (136)
npx vitest run                       Test Files 182 passed (182)  Tests 2602 passed (2602)
pnpm test:matching                   Test Files  38 passed (38)   Tests  327 passed (327)
pnpm exec vitest run apps/benchmark/test   Test Files 26 passed (26)  Tests 424 passed (424)
pnpm typecheck                       exit 0
pnpm lint                            0 errors, 109 warnings (all pre-existing)
pnpm format:check                    All matched files use Prettier code style!
apps/web pnpm run check-deps         no dependency violations found (102 modules, 212 dependencies cruised)
VITE_BASE_URL=/asmlift/ pnpm build   built in 6.42s; dist/index.html 832 bytes
```

**Honesty note on the suite.** An earlier `pnpm exec vitest run apps/web/test` on this machine
reported `Test Files 8 failed | 11 passed`, `Tests 68 passed (68)` — every failure was
`[vitest-worker]: Timeout calling "fetch" ... "ssr"`, a module-transform timeout at load average
371 with two other rounds' suites running, and zero of them an assertion. The same command on a
quiet machine is the 19/136 above. This is vitest's default timeout losing to machine load, it is
not this branch, and CI will meet it the same way regardless of this PR.
