### PR TITLE
Run the full bench twice per round, not eleven times

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -173,6 +173,49 @@ attribution line for every decline naming its first blocker. Constraints learned
   a future `/match-function` should build first. Push the branch and open the PR.
 - Then `scripts/pr-wait.sh <pr>` — it polls the PR's real state under a deadline and exits with the ANSWER (0 merged · 1 a check failed · 2 still pending, nothing decided · 3 green and ready to merge). Never ask a human whether CI is green or whether the PR merged; that question was asked six times in one session and the script answers all six.
 
+## Cost discipline — measured, and a rule rather than a preference
+
+Read off this project's own logs, not estimated:
+
+| command | cost |
+| --- | --- |
+| `pnpm bench run` (all tiers) | **~1800 s** — synthetic 182 s + real 1618 s |
+| `pnpm bench run --tier synthetic` | **~182 s** |
+| `pnpm bench run --tier <t> --only <sym>` | 5–15 s |
+| a ranked run at LoadBGTilemapData scale | 1500–8000 s |
+| `npx vitest run` (root config) | ~120 s |
+
+**A full `pnpm bench run` runs EXACTLY TWICE in a round: once at the zero-flip gate, and once at
+ship after the final rebase.** Everything else uses the scoped forms — the synthetic tier for a
+broad sanity check, `--only` for the rows a change can reach. This is not a style note. One round
+ran it **eleven times**, four of them inside a single remediation agent, and spent about four and a
+half hours on nine runs that the scoped forms answer in three minutes. The real tier is ~90% of the
+cost and is dominated by asmlift's own enumeration, which is the thing under test and therefore
+uncacheable — so the saving comes from not repeating it, never from making it faster.
+
+If you believe a third full run is genuinely needed, run it and **say in your report why** — a
+stated reason is fine, a silent extra half hour is not.
+
+### Start the long command, then keep working
+
+A full bench and a ranked run are pure waiting. Launch one in the BACKGROUND at the start of a
+phase whose other work does not depend on its answer, and read the log at the end:
+
+```sh
+( pnpm bench run > /tmp/<round>-bench.log 2>&1; echo "EXIT=$?" >> /tmp/<round>-bench.log ) &
+… meanwhile: read the diff, grep the corpus, run the unit tests, draft the report …
+until grep -q 'EXIT=' /tmp/<round>-bench.log; do sleep 30; done
+```
+
+**Wait on a log marker, never on `pgrep -f "<pattern>"`** when the pattern also matches your own
+waiting shell — five waiter shells once deadlocked on each other for eight hours doing exactly
+that, long after the jobs they watched had finished.
+
+**Two full benches must never overlap on this machine.** It has 10 cores, the run fans 8 shards,
+and a ranked run takes `--jobs 6`; a bench measured **2704 s against a neighbour versus 1800 s
+solo**. Worse than slow: a shard killed by a neighbour writes a partial tier with **no error line**,
+and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line.
+
 ---
 
 ## Hard rules

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -210,6 +210,49 @@ this phase is the only pass they get.
 - Push the branch (this project's convention is commit + push on a finished goal).
 - Then `scripts/pr-wait.sh <pr>` — it polls the PR's real state under a deadline and exits with the ANSWER (0 merged · 1 a check failed · 2 still pending, nothing decided · 3 green and ready to merge). Never ask a human whether CI is green or whether the PR merged; that question was asked six times in one session and the script answers all six.
 
+## Cost discipline — measured, and a rule rather than a preference
+
+Read off this project's own logs, not estimated:
+
+| command | cost |
+| --- | --- |
+| `pnpm bench run` (all tiers) | **~1800 s** — synthetic 182 s + real 1618 s |
+| `pnpm bench run --tier synthetic` | **~182 s** |
+| `pnpm bench run --tier <t> --only <sym>` | 5–15 s |
+| a ranked run at LoadBGTilemapData scale | 1500–8000 s |
+| `npx vitest run` (root config) | ~120 s |
+
+**A full `pnpm bench run` runs EXACTLY TWICE in a round: once at the zero-flip gate, and once at
+ship after the final rebase.** Everything else uses the scoped forms — the synthetic tier for a
+broad sanity check, `--only` for the rows a change can reach. This is not a style note. One round
+ran it **eleven times**, four of them inside a single remediation agent, and spent about four and a
+half hours on nine runs that the scoped forms answer in three minutes. The real tier is ~90% of the
+cost and is dominated by asmlift's own enumeration, which is the thing under test and therefore
+uncacheable — so the saving comes from not repeating it, never from making it faster.
+
+If you believe a third full run is genuinely needed, run it and **say in your report why** — a
+stated reason is fine, a silent extra half hour is not.
+
+### Start the long command, then keep working
+
+A full bench and a ranked run are pure waiting. Launch one in the BACKGROUND at the start of a
+phase whose other work does not depend on its answer, and read the log at the end:
+
+```sh
+( pnpm bench run > /tmp/<round>-bench.log 2>&1; echo "EXIT=$?" >> /tmp/<round>-bench.log ) &
+… meanwhile: read the diff, grep the corpus, run the unit tests, draft the report …
+until grep -q 'EXIT=' /tmp/<round>-bench.log; do sleep 30; done
+```
+
+**Wait on a log marker, never on `pgrep -f "<pattern>"`** when the pattern also matches your own
+waiting shell — five waiter shells once deadlocked on each other for eight hours doing exactly
+that, long after the jobs they watched had finished.
+
+**Two full benches must never overlap on this machine.** It has 10 cores, the run fans 8 shards,
+and a ranked run takes `--jobs 6`; a bench measured **2704 s against a neighbour versus 1800 s
+solo**. Worse than slow: a shard killed by a neighbour writes a partial tier with **no error line**,
+and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line.
+
 ---
 
 ## Hard rules


### PR DESCRIPTION
Both `/match-function` and `/attribute-function` told agents to re-verify after every fix without ever saying what a check costs. So agents reached for the full `pnpm bench run` each time.

## Measured, across three completed rounds

Per-agent attribution of full `pnpm bench run` invocations in one round:

| agent | phase | full runs |
|---|---|---:|
| `remediate1` | Remediate1 | **4** |
| `implement` | Implement | 2 |
| `ship` | Ship | 2 |
| `remediate2` | Remediate2 | 1 |
| `gate` | Gate | 1 |
| | **total** | **11** |

Two are needed: the zero-flip gate, and ship after the final rebase. A full run is **1800 s** (synthetic 182 s + real 1618 s), so **nine avoidable runs cost about four and a half hours** — in a round whose live agent-time was 15.5 h against a 13.6 h wall.

The same rounds are ~88% serial (parallelism 1.13-1.14x), so that time is almost all on the critical path.

## What this adds

A measured cost table, and two rules:

- **The full run happens exactly twice.** Everything else uses `--tier synthetic` (182 s) or `--only <sym>` (5-15 s). A third full run must be justified in the report rather than taken silently.
- **Start the long command, then keep working.** A bench or a ranked run is pure waiting; launch it in the background at the top of a phase that does not depend on its answer and wait on a log marker at the end — never on `pgrep -f` with a pattern that also matches the waiting shell, which once deadlocked five shells against each other for eight hours.

It also records why two full benches must not overlap on this machine: **2704 s against a neighbour versus 1800 s solo** on 10 cores with an 8-shard fan, and a shard a neighbour kills writes a partial tier with **no error line** while `grep -c SKIP` reads 0 either way.

## What it does not claim

The real tier is ~90% of a full run and is dominated by asmlift's own enumeration — the thing under test, and therefore uncacheable by design. The candidate cache was checked and is working (76 of 78 candidates served on a sampled real agbcc row). The saving here is in not repeating the run, never in making it faster.

Docs only: no source, no dataset, no artifact changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016n2UeBtK5qtvs1ezS85Zbw