### PR TITLE
Release 0.6.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asmlift/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "type": "module",
   "description": "The asmlift command line: decompile one function to C/Pascal from the terminal",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asmlift/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "type": "module",
   "description": "Match decompile an assembly function to C or Pascal",


### PR DESCRIPTION
Version bump only — `@asmlift/core` and `@asmlift/cli` to 0.6.0. cli keeps `workspace:^` on core, which publishes as `^0.6.0`. No source, dataset or artifact change.

## Gates (run locally on this commit's content)

| gate | result |
| --- | --- |
| `pnpm bench run` | ✓ synthetic 770 in 619.8s · ✓ real 252 in 5720.4s |
| zero-flip vs `origin/main` | **0 field changes over 1022 rows** — asmlift 581, m2c 407, unchanged |
| `pnpm bench regression --base origin/main` | 0 lost, 0 missing, 0 gained, 0 other flips |
| `pnpm typecheck` | clean |
| `pnpm lint` | 0 errors, 109 pre-existing warnings |
| `pnpm format:check` | clean |
| `pnpm test:offline` | 154 files, 2679 passed |
| **`pnpm test` (full, incl. matching)** | 204 files / 3524 passed · matching 324 passed, 35 skipped |
| `scripts/check-artifact-provenance.sh` | OK |

Gate 5 is the one hosted CI structurally cannot run — it compiles real ARM/MIPS/PPC through toolchains GitHub runners do not have.

## Packaged-artifact check

Both tarballs were built, packed, installed into a clean npm project (no workspace links), and driven from there: all four targets decompile at exit 0 with no `ASMLIFT_ERROR`, and the full scoring path (`--config` + `--score-against`) reaches byte-exact — `4 candidate(s) scored, 0 dropped, best unsigned: 0 (match)`.

## Note on the artifact

`results.json` is deliberately unchanged. The bench was re-run at this content and reproduces every row byte-identically, so the committed artifact still describes this tree; `packages/*/package.json` is not one of the paths `check-artifact-provenance.sh` measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)