### PR TITLE
Size the two new naming fuzz arms to the CI budget they have

### DIFF
--- a/packages/core/test/carrier-name-fuzz.test.ts
+++ b/packages/core/test/carrier-name-fuzz.test.ts
@@ -40,7 +40,18 @@ const ADMIT_NOTHING: readonly Gate<CarrierName>[] = [
   },
 ];
 
-const SEEDS = 4000;
+// SIZED, not maximal, and the size is a CI budget rather than a confidence statement. Arm A is the
+// expensive half — it structures every generated function TWICE — and `test:offline` shares a
+// two-core runner with `narrowlocal-fuzz`, which alone takes a minute there. At 4,000 this file
+// plus the nested arm next door put 30% more CPU into that suite than vitest's own reporter could
+// keep up with: two of three runs ended `2696 passed` and an unhandled
+// `[vitest-worker]: Timeout calling "onTaskUpdate"`, which fails the job.
+//
+// 250 still judges an order of magnitude more functions than the vacuity guard below asks for, and
+// arm B is unaffected — it stops at the first seed that proves a gate load-bearing, which every
+// reachable one does within the first handful. RAISE IT LOCALLY when hunting: that is how the
+// `loop-escape` finding next door was taken, at 8,000.
+const SEEDS = 250;
 
 /** Both spellings of one seed, or null when the shape is not one this can judge. */
 function spellings(seed: number, depth: 0 | 1 | 2, drop?: string): { off: Event[]; on: Event[] } | null {

--- a/packages/core/test/namecoalesce-fuzz.test.ts
+++ b/packages/core/test/namecoalesce-fuzz.test.ts
@@ -64,21 +64,29 @@ function spellings(seed: number, depth: 0 | 1 | 2, drop?: string): { off: Event[
   }
 }
 
+// The nested arm sweeps FEWER seeds than the two that predate it, and the reason is budget rather
+// than confidence: its functions are the largest the generator makes, and adding it at 4,000
+// alongside `carrier-name-fuzz` put 30% more CPU into `test:offline` than vitest's own reporter
+// could keep up with — a fully green run reported an unhandled `Timeout calling "onTaskUpdate"`
+// and the job failed. The finding `namecoalesce.ts` credits to this arm — `loop-escape` dropped
+// makes 2 of 7,535 nested functions compute something else — was taken at 8,000 seeds, so its two
+// (5104 and 6437) are outside the range that ships. Reproduce it by raising this number, not by
+// hunting inside it.
 describe.each([
-  ['acyclic', 0],
-  ['loop-bearing', 1],
-  ['nested', 2],
-] as const)('%s', (_name, depth) => {
+  ['acyclic', 0, SEEDS],
+  ['loop-bearing', 1, SEEDS],
+  ['nested', 2, 250],
+] as const)('%s', (_name, depth, seeds) => {
   test('no merge the pass makes changes what the function does', () => {
     const bad: number[] = [];
     let judged = 0;
-    for (let seed = 1; seed <= SEEDS; seed++) {
+    for (let seed = 1; seed <= seeds; seed++) {
       const r = spellings(seed, depth);
       if (!r) continue;
       judged++;
       if (tracesDiffer(r)) bad.push(seed);
     }
-    expect(judged).toBeGreaterThan(SEEDS / 10); // the sweep is not vacuous
+    expect(judged).toBeGreaterThan(seeds / 10); // the sweep is not vacuous
     expect(bad).toEqual([]);
   });
 });


### PR DESCRIPTION
`main` went red on #164 with **2,696 tests passed** and one unhandled
`Error: [vitest-worker]: Timeout calling "onTaskUpdate"`. No test failed; the reporter starved.

#164 added a third `nested` arm to `namecoalesce-fuzz` and a whole new `carrier-name-fuzz`, both
sweeping 4,000 seeds and both structuring every generated function TWICE, onto a two-core runner
that already spends a minute of that suite inside `narrowlocal-fuzz`. Measured off the CI logs:

```
cd3df134 (main, green)          Tests 2684   Duration 64.51s   tests 102.86s
428f5706 (#164, main, red)      Tests 2696   Duration 77.99s   tests 134.18s   reporter RPC
a5e11694 (this branch, green)   Tests 2696   Duration 70.99s   tests 111.53s
```

**#164 was +31s of test CPU, +30%.** Main was green for eleven runs before it and has failed this
way twice in three runs since (the PR's own re-run passed), so it is #164's cost rather than a
pre-existing flake — though `namecoalesce-fuzz`'s own header already documents the same load
sensitivity from an earlier round.

The three arms that predate #164 keep their 4,000 seeds. The two it added drop to **250**, which
still judges an order of magnitude more functions than each sweep's own `judged > seeds / 10`
vacuity guard asks for. Arm B is untouched — it stops at the first seed that proves a gate
load-bearing, and still runs in 80 ms and 91 ms. Locally the pair goes from **7.1s** of arm-A time
to **0.9s**.

An intermediate cut to 1,000 was pushed first and CI stayed red at 133.4s, which is what says the
size had to come down this far rather than a little.

One consequence, recorded in both files where someone will look for it: the `loop-escape` finding
`namecoalesce.ts` credits to the nested arm — dropping that gate makes 2 of 7,535 nested functions
compute something else — was taken at 8,000 seeds, so its two (5104 and 6437) now sit outside the
range that ships. Raise the number when hunting; do not hunt inside it.

Test files only. No decompiler change, no artifact change, no benchmark row moves.

```
npx vitest run packages/core   Test Files 137 passed   Tests 2311 passed
typecheck clean · format:check clean · lint 0 errors (119 pre-existing warnings)
scripts/check-artifact-provenance.sh origin/main → UNKNOWN, not checked (publishes no numbers)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)