### PR TITLE
Let the fuzz sweeps breathe, so the worker can answer the runner

### DIFF
--- a/packages/core/test/carrier-name-fuzz.test.ts
+++ b/packages/core/test/carrier-name-fuzz.test.ts
@@ -22,7 +22,7 @@ import type { SFn } from '../src/l3/ast';
 import { type Gate, without } from '../src/l3/gates';
 import { recoverTypes } from '../src/raise/recover';
 import { CARRIER_NAME_GATES, type CarrierName, structure } from '../src/structure/structure';
-import { type Event, generateSsaFn, traceOf, tracesDiffer } from './helpers';
+import { BREATHE_EVERY, type Event, breathe, generateSsaFn, traceOf, tracesDiffer } from './helpers';
 
 // Same load sensitivity as the sibling fuzz: solo these run in a couple of seconds, and under a
 // full parallel suite the 5 s default times out on machine load rather than on a defect.
@@ -83,10 +83,11 @@ describe.each([
   ['loop-bearing', 1],
   ['nested', 2],
 ] as const)('%s', (_name, depth) => {
-  test('no name the walk adopts changes what the function does', () => {
+  test('no name the walk adopts changes what the function does', async () => {
     const bad: number[] = [];
     let judged = 0;
     for (let seed = 1; seed <= SEEDS; seed++) {
+      if (seed % BREATHE_EVERY === 0) await breathe();
       const r = spellings(seed, depth);
       if (!r) continue;
       judged++;
@@ -106,12 +107,13 @@ describe.each([
 // is the point: exempting a gate is a visible act with a reason attached.
 const OUT_OF_REACH = new Set(['carrier-width', 'carrier-sign', 'carrier-write']);
 
-test('every SOUND gate of CARRIER_NAME_GATES is load-bearing — dropping it changes what some function does', () => {
+test('every SOUND gate of CARRIER_NAME_GATES is load-bearing — dropping it changes what some function does', async () => {
   const inert: string[] = [];
   for (const g of CARRIER_NAME_GATES.filter((x) => x.sound && !OUT_OF_REACH.has(x.id))) {
     let found = false;
     for (const depth of [0, 1, 2] as const) {
       for (let seed = 1; seed <= SEEDS && !found; seed++) {
+        if (seed % BREATHE_EVERY === 0) await breathe();
         const r = spellings(seed, depth, g.id);
         if (r && tracesDiffer(r)) found = true;
       }

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -293,3 +293,23 @@ export const tracesDiffer = (r: { off: Event[]; on: Event[] }): boolean => {
     return e.args.some((a, k) => a !== UNDEF && f.args[k] !== UNDEF && a !== f.args[k]);
   });
 };
+
+/** Hand the worker's event loop a turn, mid-sweep.
+ *
+ *  A fuzz arm here is tens of thousands of seeds of straight-line synchronous work — the
+ *  `narrowlocal` file alone runs ~23 s of it solo, and its own sweeps measured 3.4x that under
+ *  this suite's parallel forks. vitest's worker talks to the runner over birpc with a FIXED 60 s
+ *  timeout (`DEFAULT_TIMEOUT` in vitest's rpc chunk; no config exposes it), so a file that never
+ *  yields lets `onTaskUpdate`'s reply sit unread in the poll queue while the timer that gives up
+ *  on it matures. Node runs the timers phase BEFORE the poll phase, so the timeout then fires
+ *  even though the reply had already arrived — the run dies on
+ *  `[vitest-worker]: Timeout calling "onTaskUpdate"` with every test passing.
+ *
+ *  `setImmediate` rather than a zero `setTimeout`: the check phase runs after poll, so the reply
+ *  is read on the way in. */
+export const breathe = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+/** How many seeds a sweep may run between breaths. Small enough that no stretch approaches the
+ *  60 s RPC timeout even at the 3.4x fork-contention factor these sweeps measured; large enough
+ *  that the yields themselves cost nothing measurable. */
+export const BREATHE_EVERY = 512;

--- a/packages/core/test/namecoalesce-fuzz.test.ts
+++ b/packages/core/test/namecoalesce-fuzz.test.ts
@@ -24,7 +24,7 @@ import { without } from '../src/l3/gates';
 import { recoverTypes } from '../src/raise/recover';
 import { NAME_COALESCE_GATES } from '../src/structure/namecoalesce';
 import { structure } from '../src/structure/structure';
-import { type Event, generateSsaFn, traceOf, tracesDiffer } from './helpers';
+import { BREATHE_EVERY, type Event, breathe, generateSsaFn, traceOf, tracesDiffer } from './helpers';
 
 // CORPUS-SIZED WORK IN A PARALLEL WORKER POOL: the 5 s default is a LOAD sensitivity here, not a
 // budget. Solo these tests run in 0.9-1.7 s; inside a full `pnpm test:offline` at loadavg ~26 this
@@ -77,10 +77,11 @@ describe.each([
   ['loop-bearing', 1, SEEDS],
   ['nested', 2, 250],
 ] as const)('%s', (_name, depth, seeds) => {
-  test('no merge the pass makes changes what the function does', () => {
+  test('no merge the pass makes changes what the function does', async () => {
     const bad: number[] = [];
     let judged = 0;
     for (let seed = 1; seed <= seeds; seed++) {
+      if (seed % BREATHE_EVERY === 0) await breathe();
       const r = spellings(seed, depth);
       if (!r) continue;
       judged++;
@@ -99,7 +100,7 @@ describe.each([
 // attached, so a rule added later is still held to the bar unless someone argues it out.
 const OUT_OF_REACH = new Set(['type']);
 
-test('every SOUND gate is load-bearing: dropping it changes what some function does', () => {
+test('every SOUND gate is load-bearing: dropping it changes what some function does', async () => {
   // Written over the TABLE, not over named gates: a rule added later is held to this without
   // anyone remembering to. A gate whose ablation changes nothing is either subsumed or decorative,
   // and either way it must not claim `sound`.
@@ -108,6 +109,7 @@ test('every SOUND gate is load-bearing: dropping it changes what some function d
     let found = false;
     for (const depth of [0, 1, 2] as const) {
       for (let seed = 1; seed <= SEEDS && !found; seed++) {
+        if (seed % BREATHE_EVERY === 0) await breathe();
         const r = spellings(seed, depth, g.id);
         if (r && tracesDiffer(r)) found = true;
       }

--- a/packages/core/test/narrowlocal-fuzz.test.ts
+++ b/packages/core/test/narrowlocal-fuzz.test.ts
@@ -27,7 +27,7 @@ import { without } from '../src/l3/gates';
 import { NARROW_LOCAL_GATES, narrowBlockLocals } from '../src/raise/narrowlocal';
 import { recoverTypes } from '../src/raise/recover';
 import { structure } from '../src/structure/structure';
-import { mulberry32 } from './helpers';
+import { BREATHE_EVERY, breathe, mulberry32 } from './helpers';
 
 /** A random SSA function whose block parameters are often EXTENDED at their reads — the shape this
  *  pass judges. Definitions dominate uses by construction (entry values plus the reading block's
@@ -348,10 +348,11 @@ describe.each([
   ['acyclic', false],
   ['loop-bearing', true],
 ])('%s', (_name, withLoop) => {
-  test('no narrowing the pass makes changes what the function does', () => {
+  test('no narrowing the pass makes changes what the function does', async () => {
     const bad: number[] = [];
     let judged = 0;
     for (let seed = 1; seed <= SEEDS; seed++) {
+      if (seed % BREATHE_EVERY === 0) await breathe();
       const r = spellings(seed, withLoop);
       if (!r) continue;
       judged++;
@@ -391,11 +392,12 @@ describe.each([
   // shapes is outside it and owes its own evidence — which is why the arm clause's REFUSALS are
   // priced by the `mergeldcast`/`mergepool` rows: both are memory or pool shapes this generator
   // cannot make, and their arms are exactly what it never emits.
-  test('…and neither does the population `edge-extends` masks', () => {
+  test('…and neither does the population `edge-extends` masks', async () => {
     const bad: number[] = [];
     let judged = 0;
     const ablated = without(NARROW_LOCAL_GATES, 'edge-extends');
     for (let seed = 1; seed <= SEEDS; seed++) {
+      if (seed % BREATHE_EVERY === 0) await breathe();
       const r = spellings(seed, withLoop, ablated as never);
       if (!r) continue;
       judged++;
@@ -431,12 +433,13 @@ describe.each([
 //   for `type`. Its guard is the fixture of the same name.
 const OUT_OF_REACH = new Set(['reader-is-extension', 'cast-width', 'entry-param', 'param-typed']);
 
-test('every SOUND gate is load-bearing: dropping it changes what some function does', () => {
+test('every SOUND gate is load-bearing: dropping it changes what some function does', async () => {
   const inert: string[] = [];
   for (const g of NARROW_LOCAL_GATES.filter((x) => x.sound && !OUT_OF_REACH.has(x.id))) {
     let found = false;
     for (const withLoop of [false, true]) {
       for (let seed = 1; seed <= SEEDS && !found; seed++) {
+        if (seed % BREATHE_EVERY === 0) await breathe();
         const r = spellings(seed, withLoop, without(NARROW_LOCAL_GATES, g.id) as never);
         if (r && differs(r)) found = true;
       }


### PR DESCRIPTION
`main`'s `ci` is red, and no test is failing:

```
Test Files  161 passed (161)
     Tests  2780 passed (2780)
    Errors  1 error
Error: [vitest-worker]: Timeout calling "onTaskUpdate"
```

## What is actually happening

The vitest worker talks to the runner over birpc with a **fixed 60 s timeout** — `DEFAULT_TIMEOUT = 6e4` in vitest's rpc chunk, reachable from no config option.

`packages/core/test/narrowlocal-fuzz.test.ts` runs **~23 s of straight-line synchronous work in one file**, measured solo on an idle 10-core machine:

| test | solo |
| --- | ---: |
| `acyclic > no narrowing…` | 4432 ms |
| `acyclic > …edge-extends masks` | 3028 ms |
| `loop-bearing > no narrowing…` | 2746 ms |
| `loop-bearing > …edge-extends masks` | 3095 ms |
| `every SOUND gate is load-bearing` | 10191 ms |

The file's own comment already records the sweeps measuring **3.4× their solo cost** under this suite's parallel forks — about 80 s, against a 60 s budget.

The worker never yields, so the reply to its own `onTaskUpdate` sits unread in the poll queue. **Node runs the timers phase before the poll phase**, so once the worker is blocked past 60 s the expired timeout fires *before* the reply is read — even though the reply had already arrived. Every test passes and the run exits 1.

This is why the failure looked like a flake: it depends on how much CPU the runner has, and the suite has grown 2696 → 2714 → 2768 → 2780 tests over the last four rounds.

## The change

A `breathe()` helper in `packages/core/test/helpers.ts`, awaited every 512 seeds in the five sweeps that run tens of thousands. `setImmediate` rather than a zero `setTimeout`, because the check phase runs after poll — so the reply is read on the way in.

**No seed, assertion, floor or gate changes.** The longest uninterrupted stretch drops from a whole 15,000-seed sweep to ~512 seeds. Cost is inside run-to-run noise (the 10191 ms arm re-measured at 11444 ms on a machine that had been busy all day; the file total moved 24.60 s → 26.60 s).

## Gates

`pnpm run test:offline` **161 files / 2780 passed, 0 errors, EXIT=0** · typecheck clean · lint 0 errors / 126 pre-existing warnings · `prettier --check` clean.

## What this does not do

No `maxForks` cap and no reporter pin. The error is raised by `onTimeoutError` inside the **worker's** rpc, so the worker is the side that could not service its own call — starving the runner is a different failure and there is no evidence of it here. If CI still times out after this, that is the hypothesis to test next.

There is no unit test for "the run does not exit 1", so CI going green on this PR is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)