### PR TITLE
Give the offline suites a timeout sized for what they wait on

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,22 @@ export default defineConfig({
     //   hand-written pin from a single case writes a fixture into the real store (1 namespace,
     //   1 key). Pinned here, such a case lands in a per-run throwaway instead — see
     //   vitest.candcache-store.ts, which also removes it.
+    // WHY THIS IS NOT vitest's 5000 ms default. These suites are not pure-CPU unit tests: they
+    // fork `sh` stand-in compilers, run `git`, and read vendored blobs off disk, so their cost is
+    // external process time — the thing that degrades non-linearly when the machine is also
+    // running a bench. Twice, `apps/benchmark/test` failed 8-12 tests on an UNMODIFIED tree, every
+    // failure `Test timed out in 5000ms` and never an assertion, in a different set each run, with
+    // a full `bench run` alongside; both times it was clean once the machine was quiet.
+    //
+    // The slowest test here is ~1.7 s idle, so 5 s is barely 3x headroom for work that is mostly
+    // waiting on other processes. Tests that already knew this raised their own (`{ timeout:
+    // 20_000 }` in m2c-setup, `}, 30_000)` in authored-facts, `}, 90_000)` in the fuzz sweeps) —
+    // this is the same judgement applied where it belongs, matching vitest.matching.config.ts,
+    // which sets 240_000 for the same reason: its work is a real compiler.
+    //
+    // It does not hide a hang: a hung test still fails, 15 s later. It does mean a timeout here is
+    // evidence of a hang rather than of a busy laptop, which is what a gate should report.
+    testTimeout: 20_000,
     env: {
       ASMLIFT_CANDCACHE: '0',
       ASMLIFT_CANDCACHE_SAMPLE: '0',


### PR DESCRIPTION
`apps/benchmark/test` has twice failed **8–12 tests on an unmodified tree** — every failure `Test timed out in 5000ms`, never an assertion, **a different set each run**, with a full `bench run` alongside. Both times clean once the machine was quiet. Same class as #171.

## Why 5000 ms is the wrong budget here

`vitest.config.ts` sets no `testTimeout`, so `test:offline` **and** `apps/benchmark/test` both run on vitest's 5000 ms default — a number calibrated for pure-CPU unit tests. These suites fork `sh` stand-in compilers, run `git`, and read vendored blobs off disk, so their cost is *external process time*: the thing that degrades non-linearly when the machine is also running a bench.

The repo already holds this judgement in two places:

| where | value | why |
| --- | ---: | --- |
| `vitest.matching.config.ts` | 240_000 | its work is a real compiler under Docker |
| `m2c-setup.test.ts` | 20_000 | per-test, already |
| `authored-facts.test.ts` ×3 | 30_000 | per-test, already |
| the fuzz sweeps ×3 | 90_000 | per-test, already |
| **`vitest.config.ts`** | **(none)** | ← the gap |

20_000 matches what `m2c-setup` had already chosen for itself.

## It does not hide a hang

Verified rather than assumed — a test that never resolves still fails, 15 s later:

```
Error: Test timed out in 20000ms.
```

What changes is what a timeout *means* in these suites: evidence of a hang rather than of a busy machine.

## Two corrections to the report that prompted this

The originating round said "the affected files all shell out to compilers or docker". Measured: **`m2c-setup.test.ts` is the slowest test in the suite (1032 ms) and has zero spawn calls** — and it was already protected. The tests that actually timed out are ordinary ones with ~773 ms quiet cost, i.e. ~6× headroom, not the shell-out ones.

## NOT REPRODUCED LOCALLY — read this before merging

Four attempts, all passing 745/745 with zero timeouts:

| condition | load avg |
| --- | ---: |
| 20 CPU spinners | 13 |
| spawn-heavy load (short-lived processes + `git`) | 223 |
| a real `pnpm bench run --tier synthetic`, twice | 276 |
| four concurrent copies of the suite itself | — |

So this is a **headroom argument** from the two observed incidents plus the measured durations, not a demonstrated repair. It is cheap and safe, but if you would rather wait for a captured failing log, this PR is the thing to drop.

## Gates

`test:offline` 161 files / 2780 passed · `apps/benchmark/test` 743 passed + 2 skipped · typecheck clean · lint 0 errors / 126 pre-existing warnings · `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)