### PR TITLE
Print every score with the denominator it was measured against

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -19,7 +19,7 @@ one) is an unfinished finding.
 ## Phase 0 — Resolve and baseline (never skip)
 
 1. Resolve the row: `pnpm bench run --tier real --only $1`. Record the outcome verbatim for both
-   decompilers.
+   decompilers — **the whole `diff:N/M`, never the `N` alone** (see "the denominator moves" below).
 2. Reproduce outside the harness with **the command in
    [`docs/ranked-repro.md`](../../docs/ranked-repro.md), verbatim** — its flags (`--proto` when a
    callee's arity matters, `--jobs 6 --progress`) are part of the number, and its `grep -F
@@ -27,6 +27,35 @@ one) is an unfinished finding.
    `/match-function`; correct it there, never here. The best `[score]` line is the number every
    later claim is measured against, and it goes into your report verbatim, flags included.
 3. State the baseline in your first user-facing message.
+
+## The denominator moves — so a residual is never a "partition"
+
+`maxScore` is not a property of the target function. It is the objdiff row count of the **winning
+candidate's** alignment, so a different candidate is scored against a different scale. Across two
+committed artifacts (`eb6dec7d` → `2fed1e42`) twelve of 1013 rows moved their denominator, and
+`kleod:CountCollectedGems:agbcc` moved 290/404 → **171/387** — 17 points of scale inside a
+119-point "improvement".
+
+This is not a footnote; it is the most expensive mistake this workflow has made. Read as a
+subtraction on a fixed 404, that row's residual was decomposed into six gaps said to **PARTITION
+the 290**; the gaps then predicted 297 points and delivered 119, and an entire extra attribution
+round was spent explaining a shortfall that was partly the scale.
+
+Rules, and they are not optional:
+
+- **Never write "partition", "accounts for all of", "the N decomposes into", or any other
+  exhaustive-decomposition word about a residual** unless you have shown the denominator is fixed
+  across every measurement you are comparing. Write "these gaps cover X of the N *measured at
+  maxScore M*" and give M.
+- **A delta is a pair of fractions, not a difference.** Quote `before N₁/M₁ → after N₂/M₂` in the
+  report, the PR body and the row comment. If M moved, say so in the same sentence and say by how
+  much; if you do not know M, you do not have the delta.
+- **The tools now tell you.** `pnpm bench run` prints `diff:<score>/<maxScore>` per row, and
+  `pnpm bench diff` prints `asmlift.score: 290/404 → 171/387` plus a separate
+  `asmlift.maxScore: 404 → 387` line when the denominator moves on its own. You do not have to
+  open `results.json` to see this, and there is no excuse for a report that does not.
+- **Gap arithmetic is a prediction until measured.** Sum-of-parts vs. whole is a claim about a
+  moving scale; state it as a prediction with the ablation that falsifies it.
 
 ## Phase 1 — Capture what was actually compiled
 
@@ -93,8 +122,9 @@ pattern:
 - **MATCH** → the capability exists; the shape is a CONTROL. Then find where it stops: add the
   aggravation from the real function (a read-back, a second block, a fixed-index access) until
   the score moves. The minimal failing shape is the row; the passing one may be its control.
-- **diff:N** → a gap row. Attribute the N by diffing the probe's candidate asm the Phase-2 way —
-  a small N can still be a distinct capability (operand order) or can be noise.
+- **diff:N/M** → a gap row. Attribute the N by diffing the probe's candidate asm the Phase-2 way —
+  a small N can still be a distinct capability (operand order) or can be noise. Quote `M` too:
+  two probes' Ns are comparable only when their Ms agree.
 - **declined** → name the FIRST blocker from the decline message. If it is a pre-existing link
   (branch-likely on MIPS is the usual one), the row still measures something on that toolchain —
   but say which link, and never credit the decline to this family.

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -52,7 +52,9 @@ Rules, and they are not optional:
   much; if you do not know M, you do not have the delta.
 - **The tools now tell you.** `pnpm bench run` prints `diff:<score>/<maxScore>` per row, and
   `pnpm bench diff` prints `asmlift.score: 290/404 → 171/387` plus a separate
-  `asmlift.maxScore: 404 → 387` line when the denominator moves on its own. You do not have to
+  `asmlift.maxScore: 404 → 387` line **whenever** the denominator moves — alone or beside a moving
+  score. All twelve asmlift-side denominator moves between `eb6dec7d` and `2fed1e42` printed both
+  lines, so a `maxScore` line is never evidence that the score held still. You do not have to
   open `results.json` to see this, and there is no excuse for a report that does not.
 - **Gap arithmetic is a prediction until measured.** Sum-of-parts vs. whole is a claim about a
   moving scale; state it as a prediction with the ablation that falsifies it.

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -32,14 +32,12 @@ one) is an unfinished finding.
 
 `maxScore` is not a property of the target function. It is the objdiff row count of the **winning
 candidate's** alignment, so a different candidate is scored against a different scale. Across two
-committed artifacts (`eb6dec7d` → `2fed1e42`) twelve of 1013 rows moved their denominator, and
-`kleod:CountCollectedGems:agbcc` moved 290/404 → **171/387** — 17 points of scale inside a
-119-point "improvement".
-
-This is not a footnote; it is the most expensive mistake this workflow has made. Read as a
-subtraction on a fixed 404, that row's residual was decomposed into six gaps said to **PARTITION
-the 290**; the gaps then predicted 297 points and delivered 119, and an entire extra attribution
-round was spent explaining a shortfall that was partly the scale.
+committed artifacts (`eb6dec7d` → `2fed1e42`) fourteen of 1013 rows moved their denominator (twelve
+on the asmlift side), and `kleod:CountCollectedGems:agbcc` moved 290/404 → **171/387** — 17 points
+of scale inside a 119-point "improvement". Read as a subtraction on a fixed 404, that row's
+residual was decomposed into six gaps said to **PARTITION the 290**; the gaps then predicted 297
+points and delivered 119, and an extra attribution round was spent explaining a shortfall that was
+partly the scale.
 
 Rules, and they are not optional:
 
@@ -50,12 +48,12 @@ Rules, and they are not optional:
 - **A delta is a pair of fractions, not a difference.** Quote `before N₁/M₁ → after N₂/M₂` in the
   report, the PR body and the row comment. If M moved, say so in the same sentence and say by how
   much; if you do not know M, you do not have the delta.
-- **The tools now tell you.** `pnpm bench run` prints `diff:<score>/<maxScore>` per row, and
+- **The tools tell you.** `pnpm bench run` prints `diff:<score>/<maxScore>` per row, and
   `pnpm bench diff` prints `asmlift.score: 290/404 → 171/387` plus a separate
   `asmlift.maxScore: 404 → 387` line **whenever** the denominator moves — alone or beside a moving
-  score. All twelve asmlift-side denominator moves between `eb6dec7d` and `2fed1e42` printed both
-  lines, so a `maxScore` line is never evidence that the score held still. You do not have to
-  open `results.json` to see this, and there is no excuse for a report that does not.
+  score. Every denominator move between `eb6dec7d` and `2fed1e42` printed both lines, so a
+  `maxScore` line is never evidence that the score held still. You do not have to open
+  `results.json` to see this.
 - **Gap arithmetic is a prediction until measured.** Sum-of-parts vs. whole is a claim about a
   moving scale; state it as a prediction with the ablation that falsifies it.
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -22,9 +22,8 @@ you looked at this function's diff is a failure, even if the row flips to MATCH.
    `declined(k gap(s))` / `failed`) and m2c's for the same row. Every later claim of improvement is
    measured against this exact number, produced by this exact command. **Record the whole `N/M`,
    never the `N` alone**: `M` is `maxScore`, the objdiff row count of the *winning candidate's*
-   alignment, so it moves when the candidate does. A `diff:290/404 → diff:171/387` is 119 points
-   on a scale that also lost 17, and quoting it as `290 → 171` is what makes the next reader
-   subtract.
+   alignment, so it moves when the candidate does. `diff:290/404 → diff:171/387` is 119 points on a
+   scale that also lost 17; quoted as `290 → 171` it makes the next reader subtract.
 3. Read the asm and the current asmlift output side by side. Get the target `.o` and a working dir
    with `pnpm bench target <row-id> --out <dir>` so you can iterate without the full harness.
 4. State the baseline in your first user-facing message. Never report progress without a
@@ -100,14 +99,12 @@ Keep the order too: `diff` exits **2**, "nothing was compared", if `results.json
 base's `generatedAt` — run before `run`+`merge` it compares the base with itself in a second and
 prints a green line. `regression` answers "did a match break"; `diff` names every row and field that
 moved — that list is the PR body's inventory of what the round did, and for a commit claiming to
-move nothing it is the gate. The fields it watches live in `report/diff.ts`'s `FIELDS` and are wider
-than the score: both sides' `outcome, score, maxScore, compileErrors, errorMarkers, breakdown,
-source, quality`, plus asmlift's `candidateLabel` and the `droppedCandidates` /
-`withheldCandidates` counts. Expect lines you did not predict from `maxScore` and `breakdown` — the
-denominator and the shape of the gap moving — and from the dropped count, which moves when the FAN
-changed even though every score held. If a match is lost, either tighten the gate on your lever or
-drop the lever — do not rationalize a trade unless the user explicitly approves it. Report the totals (asmlift vs m2c)
-before and after.
+move nothing it is the gate. The fields it watches are `report/diff.ts`'s `FIELDS`; read them there
+rather than from memory, they are wider than the score. Expect lines you did not predict: from
+`maxScore` and `breakdown` (the denominator and the shape of the gap moving), and from the dropped
+count, which moves when the FAN changed even though every score held. If a match is lost, either
+tighten the gate on your lever or drop the lever — do not rationalize a trade unless the user
+explicitly approves it. Report the totals (asmlift vs m2c) before and after.
 
 Four things this gate does not catch by itself:
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -98,11 +98,15 @@ match blocks the branch.** Pass the base ref: both gates read the COMMITTED arti
 branch that has already committed its own they compare it against itself and pass vacuously.
 Keep the order too: `diff` exits **2**, "nothing was compared", if `results.json` still carries the
 base's `generatedAt` — run before `run`+`merge` it compares the base with itself in a second and
-prints a green line. `regression` answers "did a match break"; `diff` names every row and field that moved
-(`asmlift.{outcome,score,candidateLabel,source}`, `m2c.{outcome,score,source}`) — that list is the
-PR body's inventory of what the round did, and for a commit claiming to move nothing it is the
-gate. If a match is lost, either tighten the gate on your lever or drop the lever — do not
-rationalize a trade unless the user explicitly approves it. Report the totals (asmlift vs m2c)
+prints a green line. `regression` answers "did a match break"; `diff` names every row and field that
+moved — that list is the PR body's inventory of what the round did, and for a commit claiming to
+move nothing it is the gate. The fields it watches live in `report/diff.ts`'s `FIELDS` and are wider
+than the score: both sides' `outcome, score, maxScore, compileErrors, errorMarkers, breakdown,
+source, quality`, plus asmlift's `candidateLabel` and the `droppedCandidates` /
+`withheldCandidates` counts. Expect lines you did not predict from `maxScore` and `breakdown` — the
+denominator and the shape of the gap moving — and from the dropped count, which moves when the FAN
+changed even though every score held. If a match is lost, either tighten the gate on your lever or
+drop the lever — do not rationalize a trade unless the user explicitly approves it. Report the totals (asmlift vs m2c)
 before and after.
 
 Four things this gate does not catch by itself:

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -18,9 +18,13 @@ you looked at this function's diff is a failure, even if the row flips to MATCH.
 1. Resolve the row: `pnpm bench run --tier real --only $1` (`--only` is a substring match on the
    symbol; row ids are `project:sym:toolchain`). If it hits more than one row, list them and pick
    the one the user meant — say which you picked.
-2. Record the **baseline** verbatim: asmlift outcome (`MATCH` / `diff:N` / `noncompile(k)` /
+2. Record the **baseline** verbatim: asmlift outcome (`MATCH` / `diff:N/M` / `noncompile(k)` /
    `declined(k gap(s))` / `failed`) and m2c's for the same row. Every later claim of improvement is
-   measured against this exact number, produced by this exact command.
+   measured against this exact number, produced by this exact command. **Record the whole `N/M`,
+   never the `N` alone**: `M` is `maxScore`, the objdiff row count of the *winning candidate's*
+   alignment, so it moves when the candidate does. A `diff:290/404 → diff:171/387` is 119 points
+   on a scale that also lost 17, and quoting it as `290 → 171` is what makes the next reader
+   subtract.
 3. Read the asm and the current asmlift output side by side. Get the target `.o` and a working dir
    with `pnpm bench target <row-id> --out <dir>` so you can iterate without the full harness.
 4. State the baseline in your first user-facing message. Never report progress without a

--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -20,9 +20,11 @@ paths. Three agents per iteration, looped:
 `args: {since: "<sha>"}` starts the incremental window at a specific commit.
 
 **The hard invariant** is that nothing it ships may change a measurement: a full bench run, then a
-per-row diff of the regenerated `results.json` against `origin/main`'s, comparing
-`asmlift.{outcome,score,candidateLabel,source}` and `m2c.{outcome,score,source}`. Every row
-identical, or it does not ship. The reviewer re-proves this rather than trusting the implementer —
+per-row diff of the regenerated `results.json` against `origin/main`'s (`pnpm bench diff --base
+origin/main`), comparing every field `report/diff.ts`'s `FIELDS` watches — read the list there, it is
+wider than the score: both sides' `outcome, score, maxScore, compileErrors, errorMarkers, breakdown,
+source, quality`, plus asmlift's `candidateLabel` and the `droppedCandidates` / `withheldCandidates`
+counts. Every row identical, or it does not ship. The reviewer re-proves this rather than trusting the implementer —
 a "harmless" speedup that silently moved one row would poison every measurement in the project.
 
 **`meta-optimizer-ledger.md` is load-bearing.** It records what has already shipped, which harness

--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -21,10 +21,9 @@ paths. Three agents per iteration, looped:
 
 **The hard invariant** is that nothing it ships may change a measurement: a full bench run, then a
 per-row diff of the regenerated `results.json` against `origin/main`'s (`pnpm bench diff --base
-origin/main`), comparing every field `report/diff.ts`'s `FIELDS` watches — read the list there, it is
-wider than the score: both sides' `outcome, score, maxScore, compileErrors, errorMarkers, breakdown,
-source, quality`, plus asmlift's `candidateLabel` and the `droppedCandidates` / `withheldCandidates`
-counts. Every row identical, or it does not ship. The reviewer re-proves this rather than trusting the implementer —
+origin/main`), comparing every field `report/diff.ts`'s `FIELDS` watches — read the list there, it
+is wider than the score. Every row identical, or it does not ship. The reviewer re-proves this
+rather than trusting the implementer —
 a "harmless" speedup that silently moved one row would poison every measurement in the project.
 
 **`meta-optimizer-ledger.md` is load-bearing.** It records what has already shipped, which harness

--- a/.claude/workflows/meta-optimizer-loop.js
+++ b/.claude/workflows/meta-optimizer-loop.js
@@ -65,12 +65,10 @@ const SCOPE = `
 
 Run the full bench on your branch and diff the regenerated \`results.json\` against \`origin/main\`'s
 committed one on every field \`report/diff.ts\`'s \`FIELDS\` watches — read the list THERE rather
-than from memory, it is wider than the score: both sides' \`outcome, score, maxScore, compileErrors,
-errorMarkers, breakdown, source, quality\`, plus asmlift's \`candidateLabel\` and the
-\`droppedCandidates\` / \`withheldCandidates\` COUNTS. **Every one must be identical.** Timings and
-the provenance stamp are the only permitted differences, and you must name which differed.
-(\`droppedCandidates\` ORDER is still free; its COUNT is not — a reordered fan is a scheduling
-detail, a fan that grew or shrank is a different measurement.)
+than from memory, it is wider than the score. **Every one must be identical.** Timings and the
+provenance stamp are the only permitted differences, and you must name which differed.
+(\`droppedCandidates\` ORDER is free; its COUNT is not — a reordered fan is a scheduling detail, a
+fan that grew or shrank is a different measurement.)
 A change you cannot prove neutral this way does not ship, however obviously safe it looks.
 
 **OUT of scope — propose in the PR body, never implement:**
@@ -228,11 +226,9 @@ ${implReport}
    (\`packages/core/**\`, \`apps/benchmark/dataset/**\`, \`bench-schema\`, \`cases/features.ts\`).
 3. **RE-PROVE OUTPUT NEUTRALITY YOURSELF** — do not take the implementer's word. Full bench on the
    branch, then \`pnpm bench diff --base origin/main\`: it IS the per-row comparison, over every
-   field \`report/diff.ts\`'s \`FIELDS\` watches (wider than the score — \`maxScore\`,
-   \`errorMarkers\`, \`breakdown\`, \`quality\` and the dropped/withheld counts are all in it). Do
-   not hand-roll a narrower one. Any difference is blocking. This is the most important thing you
-   do: a "harmless" speedup that silently moved one row would poison every measurement the project
-   has.
+   field \`report/diff.ts\`'s \`FIELDS\` watches (wider than the score). Do not hand-roll a narrower
+   one. Any difference is blocking. This is the most important thing you do: a "harmless" speedup
+   that silently moved one row would poison every measurement the project has.
 4. **Soundness.** General or a patch shaped like one incident? Does a cache key have a correct
    invalidation story? Does added parallelism introduce output-order nondeterminism something
    downstream depends on?

--- a/.claude/workflows/meta-optimizer-loop.js
+++ b/.claude/workflows/meta-optimizer-loop.js
@@ -64,9 +64,13 @@ const SCOPE = `
 **THE HARD INVARIANT — output neutrality, proved mechanically.**
 
 Run the full bench on your branch and diff the regenerated \`results.json\` against \`origin/main\`'s
-committed one, comparing for EVERY row: \`asmlift.{outcome, score, candidateLabel, source}\` and
-\`m2c.{outcome, score, source}\`. **Every one must be identical.** Timings, the provenance stamp and
-\`droppedCandidates\` ordering are the only permitted differences, and you must name which differed.
+committed one on every field \`report/diff.ts\`'s \`FIELDS\` watches — read the list THERE rather
+than from memory, it is wider than the score: both sides' \`outcome, score, maxScore, compileErrors,
+errorMarkers, breakdown, source, quality\`, plus asmlift's \`candidateLabel\` and the
+\`droppedCandidates\` / \`withheldCandidates\` COUNTS. **Every one must be identical.** Timings and
+the provenance stamp are the only permitted differences, and you must name which differed.
+(\`droppedCandidates\` ORDER is still free; its COUNT is not — a reordered fan is a scheduling
+detail, a fan that grew or shrank is a different measurement.)
 A change you cannot prove neutral this way does not ship, however obviously safe it looks.
 
 **OUT of scope — propose in the PR body, never implement:**
@@ -223,10 +227,12 @@ ${implReport}
 2. **Scope audit — BLOCKING.** Confirm the diff touches nothing owned by the live tracks
    (\`packages/core/**\`, \`apps/benchmark/dataset/**\`, \`bench-schema\`, \`cases/features.ts\`).
 3. **RE-PROVE OUTPUT NEUTRALITY YOURSELF** — do not take the implementer's word. Full bench on the
-   branch, per-row diff against \`origin/main\`'s committed \`results.json\` on
-   \`asmlift.{outcome,score,candidateLabel,source}\` and \`m2c.{outcome,score,source}\`. Any
-   difference is blocking. This is the most important thing you do: a "harmless" speedup that
-   silently moved one row would poison every measurement the project has.
+   branch, then \`pnpm bench diff --base origin/main\`: it IS the per-row comparison, over every
+   field \`report/diff.ts\`'s \`FIELDS\` watches (wider than the score — \`maxScore\`,
+   \`errorMarkers\`, \`breakdown\`, \`quality\` and the dropped/withheld counts are all in it). Do
+   not hand-roll a narrower one. Any difference is blocking. This is the most important thing you
+   do: a "harmless" speedup that silently moved one row would poison every measurement the project
+   has.
 4. **Soundness.** General or a patch shaped like one incident? Does a cache key have a correct
    invalidation story? Does added parallelism introduce output-order nondeterminism something
    downstream depends on?

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ s32 ReadUnalignedU16(u8 * a0) {
     return *a0 | a0[1] << 8;
 }
 asmlift: [config] target agbcc (platform 'gba' in ./decomp.yaml)
-asmlift: [score] unsigned: 0 (match)
+asmlift: [score] unsigned: 0/<rows> (match)
 ```
 
 > 📚 Check [`packages/cli`](./packages/cli/README.md#cli-reference) to learn about all the configuration options and flags of `asmlift`.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ s32 ReadUnalignedU16(u8 * a0) {
     return *a0 | a0[1] << 8;
 }
 asmlift: [config] target agbcc (platform 'gba' in ./decomp.yaml)
-asmlift: [score] unsigned: 0/<rows> (match)
+asmlift: [score] unsigned: 0/6 (match)
 ```
 
 > 📚 Check [`packages/cli`](./packages/cli/README.md#cli-reference) to learn about all the configuration options and flags of `asmlift`.

--- a/apps/benchmark/src/cache.ts
+++ b/apps/benchmark/src/cache.ts
@@ -192,10 +192,9 @@ export function cachedM2cResult(inputs: M2cKeyInputs, compute: () => DecompilerR
   //      the source AS EMITTED (rung 2 where there are declarations) rather than rung 0's. The
   //      whole difference is the `errorMarkers` this function's own value carries, so a v16 entry
   //      replays ``gPacked' undeclared`` for a row whose deciding rung declares the symbol — the
-  //      exact wrong answer the change removes, served out of a warm store and — at the time —
-  //      invisible to every artifact comparison, `errorMarkers` being outside `FIELDS.m2c`. That
-  //      incident is why it is inside that list now. Caught by reading this list before publishing
-  //      a run, which is what it is for.
+  //      exact wrong answer the change removes, served out of a warm store and invisible to every
+  //      artifact comparison of the day — the incident that put `errorMarkers` into `FIELDS.m2c`.
+  //      Caught by reading this list before publishing a run, which is what it is for.
   // The scorer is the one such input that is DERIVED rather than bumped by hand: the value cached
   // here holds `score`, which objdiff computes, and two objdiff versions can score one pair
   // differently. Off the key, a scorer bump replays the old engine's numbers out of a warm cache

--- a/apps/benchmark/src/cache.ts
+++ b/apps/benchmark/src/cache.ts
@@ -192,9 +192,10 @@ export function cachedM2cResult(inputs: M2cKeyInputs, compute: () => DecompilerR
   //      the source AS EMITTED (rung 2 where there are declarations) rather than rung 0's. The
   //      whole difference is the `errorMarkers` this function's own value carries, so a v16 entry
   //      replays ``gPacked' undeclared`` for a row whose deciding rung declares the symbol — the
-  //      exact wrong answer the change removes, served out of a warm store and invisible to every
-  //      artifact comparison, `errorMarkers` being outside `FIELDS.m2c`. Caught by reading this
-  //      list before publishing a run, which is what it is for.
+  //      exact wrong answer the change removes, served out of a warm store and — at the time —
+  //      invisible to every artifact comparison, `errorMarkers` being outside `FIELDS.m2c`. That
+  //      incident is why it is inside that list now. Caught by reading this list before publishing
+  //      a run, which is what it is for.
   // The scorer is the one such input that is DERIVED rather than bumped by hand: the value cached
   // here holds `score`, which objdiff computes, and two objdiff versions can score one pair
   // differently. Off the key, a scorer bump replays the old engine's numbers out of a warm cache

--- a/apps/benchmark/src/eval/evaluate.ts
+++ b/apps/benchmark/src/eval/evaluate.ts
@@ -54,8 +54,8 @@ const M2C_DIALECT_TYPEDEFS = 'typedef float f32;typedef double f64;\n#define NUL
  *  ``gPacked' undeclared`` for a symbol the deciding rung DOES declare, while that rung's own
  *  failure is `invalid operands to binary <<` / `invalid operands to binary &`. A published error
  *  naming a cause the run does not have is a silent wrong answer wearing a measurement's clothes,
- *  and until `errorMarkers` joined `FIELDS.m2c` in report/diff.ts no artifact comparison
- *  reported it at all. The dialect rungs stay unreported for the original reason: they prepend typedefs,
+ *  and an artifact comparison names the field that moved without saying which rung is right. The
+ *  dialect rungs stay unreported for the original reason: they prepend typedefs,
  *  so their failure can be their own. Pinned by `m2c-rungs.test.ts`, which is why this function
  *  is exported. */
 export function scoreM2c(

--- a/apps/benchmark/src/eval/evaluate.ts
+++ b/apps/benchmark/src/eval/evaluate.ts
@@ -54,8 +54,8 @@ const M2C_DIALECT_TYPEDEFS = 'typedef float f32;typedef double f64;\n#define NUL
  *  ``gPacked' undeclared`` for a symbol the deciding rung DOES declare, while that rung's own
  *  failure is `invalid operands to binary <<` / `invalid operands to binary &`. A published error
  *  naming a cause the run does not have is a silent wrong answer wearing a measurement's clothes,
- *  and `errorMarkers` is not among `FIELDS.m2c` in report/diff.ts, so no artifact comparison
- *  reports it. The dialect rungs stay unreported for the original reason: they prepend typedefs,
+ *  and until `errorMarkers` joined `FIELDS.m2c` in report/diff.ts no artifact comparison
+ *  reported it at all. The dialect rungs stay unreported for the original reason: they prepend typedefs,
  *  so their failure can be their own. Pinned by `m2c-rungs.test.ts`, which is why this function
  *  is exported. */
 export function scoreM2c(

--- a/apps/benchmark/src/report/diff.ts
+++ b/apps/benchmark/src/report/diff.ts
@@ -17,12 +17,22 @@ import { RESULTS_DIR } from '../config';
 import { RESULTS_PATH, byId, headContains, readCommitted, sameRun, scrub, shortSha } from './committed';
 import { rowsAddedSince } from './regression';
 
-/** The fields a published claim is made of — every one the report shows, or the count this gate
- *  prints is the truth about the LIST and not about the row. `source` is here because a change
- *  that moves no score can still rewrite what the report shows, `candidateLabel` because the
- *  ranked WINNER can change identity at an unchanged score (a tie-break moving is a real change),
- *  and `quality` because the report publishes it — a row can move `quality.casts` 0 → 1 with
- *  score, outcome and label all unchanged.
+/** The fields a published claim is made of, named individually when they move.
+ *
+ *  THIS LIST IS NOT "every field the report shows" — it was written as that rule and the rule was
+ *  false in its own file: `droppedCandidates` is published (`[ranked] N dropped, M withheld`) and
+ *  is 51,840 entries long on one row of the current artifact, so watching it raw emits a
+ *  multi-megabyte diff line. The honest rule is: every published claim SMALL ENOUGH TO PRINT, and
+ *  for the big ones the published COUNT rather than the list. A rule stated as universal and
+ *  applied selectively is worse than a narrow rule stated plainly — `errorMarkers` was missed
+ *  twice under the universal wording.
+ *
+ *  `source` is here because a change that moves no score can still rewrite what the report shows,
+ *  `candidateLabel` because the ranked WINNER can change identity at an unchanged score (a
+ *  tie-break moving is a real change), `quality` because the report publishes it — a row can move
+ *  `quality.casts` 0 → 1 with score, outcome and label all unchanged — and `breakdown` for the
+ *  same reason (the web FunctionDetail renders its five numbers; 17 sides moved it over
+ *  `eb6dec7d`→`2fed1e42`, none of them a row no other field already named).
  *
  *  `maxScore` is here because it is NOT a constant of the row, and the whole project read it as
  *  one. It is the objdiff row count of the winning candidate's alignment, so a different
@@ -32,20 +42,61 @@ import { rowsAddedSince } from './regression';
  *  "partition of the 290", a 297-predicted / 119-delivered shortfall, and a whole extra
  *  attribution round to explain the difference. The report publishes `score/maxScore` (the
  *  Explorer and the gap badge both render it), so by this list's own rule a denominator-only move
- *  is a published claim moving and must be named.
+ *  is a published claim moving and must be named. It has never moved ALONE — all 12 printed a
+ *  `score` line on the same row and side, and that line now renders both denominators — so the
+ *  entry buys 0 unique rows today and is kept for the constructible case it alone catches: an
+ *  alignment whose length moves while the diff count holds. Do not re-litigate it as a duplicate.
  *
  *  `compileErrors` is here for the same reason and no other: the report publishes it (the run line
  *  prints `noncompile(k)`, the web FunctionDetail prints `compile errors {n}`), so a row sliding
  *  `noncompile(3) → noncompile(7)` is a published claim moving. It was previously this gate's
  *  own stand-in for an UNCOMPARED field, which asserted the opposite of this list's rule. Cost,
- *  measured over `eb6dec7d`→`2fed1e42`: 0 extra lines — no row in that pair moved it. */
+ *  measured over `eb6dec7d`→`2fed1e42`: 0 extra lines — no row in that pair moved it.
+ *
+ *  `errorMarkers` is here because this repo has already PAID for its absence, in writing: the
+ *  `v17:` note in `cache.ts` records a warm-store entry replaying ``gPacked' undeclared`` for a row
+ *  whose deciding rung declares the symbol — "invisible to every artifact comparison,
+ *  `errorMarkers` being outside `FIELDS.m2c`". The run line prints `declined(k gap(s))` from it and
+ *  the web report derives its whole declined/failed taxonomy column from it. Cost over the same
+ *  pair: 2 lines, 0 rows no other field named. Max 6 entries / 491 chars, so it prints as itself.
+ *
+ *  The two `.length` entries are the exception the first paragraph describes: `droppedCandidates`
+ *  and `withheldCandidates` are published as COUNTS by the `[ranked]` line, and the count is what
+ *  is watched. This is not a cosmetic saving — over `eb6dec7d`→`2fed1e42` the dropped count moved
+ *  on 2 rows (`kleod:ProcessInputAndUpdateEntities:agbcc`, `kleod:UpdateHUDCounterDisplay:agbcc`)
+ *  that NO other watched field moves on: identical source, identical score, identical label, a fan
+ *  that demonstrably changed, and a gate that answered "nothing moved". `symbolsUsed` is left out
+ *  for size and for nothing else. */
 const FIELDS = {
-  asmlift: ['outcome', 'score', 'maxScore', 'compileErrors', 'candidateLabel', 'source', 'quality'],
-  m2c: ['outcome', 'score', 'maxScore', 'compileErrors', 'source', 'quality'],
+  asmlift: [
+    'outcome',
+    'score',
+    'maxScore',
+    'compileErrors',
+    'errorMarkers',
+    'breakdown',
+    'candidateLabel',
+    'source',
+    'quality',
+    'droppedCandidates.length',
+    'withheldCandidates.length',
+  ],
+  m2c: ['outcome', 'score', 'maxScore', 'compileErrors', 'errorMarkers', 'breakdown', 'source', 'quality'],
 } as const;
 
-/** Compared by VALUE with a stable key order — `quality` is an object, and comparing two of those
- *  with `!==` reports every row as changed. */
+/** One side's value for a watched field. A `<key>.length` entry reads the COUNT of a published
+ *  list — absent list = 0, because "no fan recorded" and "an empty fan" are the same published
+ *  claim (`[ranked] 0 dropped`). */
+const read = (res: Record<string, unknown>, field: string): unknown => {
+  if (field.endsWith('.length')) {
+    const list = res[field.slice(0, -'.length'.length)];
+    return Array.isArray(list) ? list.length : 0;
+  }
+  return res[field];
+};
+
+/** Compared by VALUE with a stable key order — `quality`, `breakdown` and `errorMarkers` are
+ *  objects and arrays, and comparing two of those with `!==` reports every row as changed. */
 const stable = (v: unknown): string =>
   JSON.stringify(v, (_k, x: unknown) =>
     x && typeof x === 'object' && !Array.isArray(x)
@@ -74,17 +125,24 @@ export interface DiffReport {
 // `res` is the whole side-result the value came from, because a score alone is not readable: it
 // is a numerator over a denominator that moves with the winning candidate. `290 → 171` invites a
 // subtraction; `290/404 → 171/387` shows that 17 of those 119 points are the scale, not the row.
-const show = (field: string, v: unknown, res?: Record<string, unknown>): string => {
+const show = (field: string, v: unknown, res: Record<string, unknown>): string => {
   if (v === undefined || v === null) {
     return String(v);
   }
   if (field.endsWith('source')) {
     return `${String(v).length} bytes`;
   }
+  // Rendered the way it is COMPARED: a compiler error carries the scratch path a cold run
+  // re-mints, and a rendering that shows a difference the comparison ignored is a false line.
+  if (field === 'errorMarkers') {
+    return scrub(stable(v));
+  }
   // A scored side ALWAYS renders a denominator, `?` included: `show` is called once per side, so
   // a fresh side that lost its `maxScore` would otherwise print `290/404 → 171` and be read as
-  // `171/404` — the fixed-scale misreading this whole rendering exists to stop.
-  if (field === 'score' && res !== undefined && 'maxScore' in res) {
+  // `171/404` — the fixed-scale misreading this whole rendering exists to stop. `res` is REQUIRED
+  // rather than optional so this cannot be re-opened by a call site that forgets it: the bare
+  // numerator would come back silently, on a path no test can reach.
+  if (field === 'score' && 'maxScore' in res) {
     return `${String(v)}/${typeof res.maxScore === 'number' ? res.maxScore : '?'}`;
   }
   return typeof v === 'string' ? v : JSON.stringify(v);
@@ -105,17 +163,22 @@ export function compareMeasurements(base: BenchOutput, fresh: BenchOutput): Diff
     for (const side of ['asmlift', 'm2c'] as const) {
       const wasSide = was[side] as unknown as Record<string, unknown>;
       const nowSide = now[side] as unknown as Record<string, unknown>;
-      for (const f of FIELDS[side]) {
-        const a = wasSide[f];
-        const b = nowSide[f];
-        // sources are compared SCRUBBED, the same measurement-level equality stale-check uses:
-        // a cold run re-mints scratch-dir names inside embedded asm comments
-        const [x, y] =
+      for (const f of FIELDS[side] as readonly string[]) {
+        const a = read(wasSide, f);
+        const b = read(nowSide, f);
+        // sources and compiler errors are compared SCRUBBED, the same measurement-level equality
+        // stale-check uses: a cold run re-mints scratch-dir names inside embedded asm comments and
+        // inside the paths a compiler quotes back. Objects and arrays are compared by VALUE.
+        const norm = (v: unknown): unknown =>
           f === 'source'
-            ? [scrub(String(a ?? '')), scrub(String(b ?? ''))]
-            : f === 'quality'
-              ? [stable(a), stable(b)]
-              : [a, b];
+            ? scrub(String(v ?? ''))
+            : f === 'errorMarkers'
+              ? // `stable(undefined)` is `undefined`, not a string — most sides carry no markers
+                scrub(stable(v) ?? 'absent')
+              : v !== null && typeof v === 'object'
+                ? stable(v)
+                : v;
+        const [x, y] = [norm(a), norm(b)];
         if (x !== y) {
           changed.push({ id: was.id, field: `${side}.${f}`, from: show(f, a, wasSide), to: show(f, b, nowSide) });
         }

--- a/apps/benchmark/src/report/diff.ts
+++ b/apps/benchmark/src/report/diff.ts
@@ -22,10 +22,20 @@ import { rowsAddedSince } from './regression';
  *  that moves no score can still rewrite what the report shows, `candidateLabel` because the
  *  ranked WINNER can change identity at an unchanged score (a tie-break moving is a real change),
  *  and `quality` because the report publishes it — a row can move `quality.casts` 0 → 1 with
- *  score, outcome and label all unchanged. */
+ *  score, outcome and label all unchanged.
+ *
+ *  `maxScore` is here because it is NOT a constant of the row, and the whole project read it as
+ *  one. It is the objdiff row count of the winning candidate's alignment, so a different
+ *  candidate gives a different denominator: twelve rows moved theirs between `eb6dec7d` and
+ *  `2fed1e42`, `kleod:CountCollectedGems:agbcc` by 17 (404 → 387). Its `290 → 171` was therefore
+ *  never a subtraction on a fixed scale, and reading it as one is what produced a six-way
+ *  "partition of the 290", a 297-predicted / 119-delivered shortfall, and a whole extra
+ *  attribution round to explain the difference. The report publishes `score/maxScore` (the
+ *  Explorer and the gap badge both render it), so by this list's own rule a denominator-only move
+ *  is a published claim moving and must be named. */
 const FIELDS = {
-  asmlift: ['outcome', 'score', 'candidateLabel', 'source', 'quality'],
-  m2c: ['outcome', 'score', 'source', 'quality'],
+  asmlift: ['outcome', 'score', 'maxScore', 'candidateLabel', 'source', 'quality'],
+  m2c: ['outcome', 'score', 'maxScore', 'source', 'quality'],
 } as const;
 
 /** Compared by VALUE with a stable key order — `quality` is an object, and comparing two of those
@@ -54,12 +64,19 @@ export interface DiffReport {
 
 // Long text is reported by its shape, not pasted: a 40-line C body in a gate's output buries the
 // one line that says which row moved.
-const show = (field: string, v: unknown): string => {
+//
+// `res` is the whole side-result the value came from, because a score alone is not readable: it
+// is a numerator over a denominator that moves with the winning candidate. `290 → 171` invites a
+// subtraction; `290/404 → 171/387` shows that 17 of those 119 points are the scale, not the row.
+const show = (field: string, v: unknown, res?: Record<string, unknown>): string => {
   if (v === undefined || v === null) {
     return String(v);
   }
   if (field.endsWith('source')) {
     return `${String(v).length} bytes`;
+  }
+  if (field === 'score' && typeof res?.maxScore === 'number') {
+    return `${String(v)}/${res.maxScore}`;
   }
   return typeof v === 'string' ? v : JSON.stringify(v);
 };
@@ -77,9 +94,11 @@ export function compareMeasurements(base: BenchOutput, fresh: BenchOutput): Diff
       continue;
     }
     for (const side of ['asmlift', 'm2c'] as const) {
+      const wasSide = was[side] as unknown as Record<string, unknown>;
+      const nowSide = now[side] as unknown as Record<string, unknown>;
       for (const f of FIELDS[side]) {
-        const a = (was[side] as unknown as Record<string, unknown>)[f];
-        const b = (now[side] as unknown as Record<string, unknown>)[f];
+        const a = wasSide[f];
+        const b = nowSide[f];
         // sources are compared SCRUBBED, the same measurement-level equality stale-check uses:
         // a cold run re-mints scratch-dir names inside embedded asm comments
         const [x, y] =
@@ -89,7 +108,7 @@ export function compareMeasurements(base: BenchOutput, fresh: BenchOutput): Diff
               ? [stable(a), stable(b)]
               : [a, b];
         if (x !== y) {
-          changed.push({ id: was.id, field: `${side}.${f}`, from: show(f, a), to: show(f, b) });
+          changed.push({ id: was.id, field: `${side}.${f}`, from: show(f, a, wasSide), to: show(f, b, nowSide) });
         }
       }
     }

--- a/apps/benchmark/src/report/diff.ts
+++ b/apps/benchmark/src/report/diff.ts
@@ -32,10 +32,16 @@ import { rowsAddedSince } from './regression';
  *  "partition of the 290", a 297-predicted / 119-delivered shortfall, and a whole extra
  *  attribution round to explain the difference. The report publishes `score/maxScore` (the
  *  Explorer and the gap badge both render it), so by this list's own rule a denominator-only move
- *  is a published claim moving and must be named. */
+ *  is a published claim moving and must be named.
+ *
+ *  `compileErrors` is here for the same reason and no other: the report publishes it (the run line
+ *  prints `noncompile(k)`, the web FunctionDetail prints `compile errors {n}`), so a row sliding
+ *  `noncompile(3) → noncompile(7)` is a published claim moving. It was previously this gate's
+ *  own stand-in for an UNCOMPARED field, which asserted the opposite of this list's rule. Cost,
+ *  measured over `eb6dec7d`→`2fed1e42`: 0 extra lines — no row in that pair moved it. */
 const FIELDS = {
-  asmlift: ['outcome', 'score', 'maxScore', 'candidateLabel', 'source', 'quality'],
-  m2c: ['outcome', 'score', 'maxScore', 'source', 'quality'],
+  asmlift: ['outcome', 'score', 'maxScore', 'compileErrors', 'candidateLabel', 'source', 'quality'],
+  m2c: ['outcome', 'score', 'maxScore', 'compileErrors', 'source', 'quality'],
 } as const;
 
 /** Compared by VALUE with a stable key order — `quality` is an object, and comparing two of those
@@ -75,8 +81,11 @@ const show = (field: string, v: unknown, res?: Record<string, unknown>): string 
   if (field.endsWith('source')) {
     return `${String(v).length} bytes`;
   }
-  if (field === 'score' && typeof res?.maxScore === 'number') {
-    return `${String(v)}/${res.maxScore}`;
+  // A scored side ALWAYS renders a denominator, `?` included: `show` is called once per side, so
+  // a fresh side that lost its `maxScore` would otherwise print `290/404 → 171` and be read as
+  // `171/404` — the fixed-scale misreading this whole rendering exists to stop.
+  if (field === 'score' && res !== undefined && 'maxScore' in res) {
+    return `${String(v)}/${typeof res.maxScore === 'number' ? res.maxScore : '?'}`;
   }
   return typeof v === 'string' ? v : JSON.stringify(v);
 };

--- a/apps/benchmark/src/report/diff.ts
+++ b/apps/benchmark/src/report/diff.ts
@@ -19,54 +19,53 @@ import { rowsAddedSince } from './regression';
 
 /** The fields a published claim is made of, named individually when they move.
  *
- *  THIS LIST IS NOT "every field the report shows" — it was written as that rule and the rule was
- *  false in its own file: `droppedCandidates` is published (`[ranked] N dropped, M withheld`) and
- *  is 51,840 entries long on one row of the current artifact, so watching it raw emits a
- *  multi-megabyte diff line. The honest rule is: every published claim SMALL ENOUGH TO PRINT, and
- *  for the big ones the published COUNT rather than the list. A rule stated as universal and
- *  applied selectively is worse than a narrow rule stated plainly — `errorMarkers` was missed
- *  twice under the universal wording.
+ *  The rule is: every published claim SMALL ENOUGH TO PRINT, and for the big ones the published
+ *  COUNT rather than the list. Stated as "every field the report shows" it would be false in this
+ *  file — `droppedCandidates` is published (`[ranked] N dropped, M withheld`) and runs to 51,840
+ *  entries on one row of the current artifact, so watching it raw emits a multi-megabyte diff
+ *  line.
  *
  *  `source` is here because a change that moves no score can still rewrite what the report shows,
  *  `candidateLabel` because the ranked WINNER can change identity at an unchanged score (a
  *  tie-break moving is a real change), `quality` because the report publishes it — a row can move
  *  `quality.casts` 0 → 1 with score, outcome and label all unchanged — and `breakdown` for the
- *  same reason (the web FunctionDetail renders its five numbers; 17 sides moved it over
+ *  same reason (the web FunctionDetail renders its five numbers; it moved 17 lines over
  *  `eb6dec7d`→`2fed1e42`, none of them a row no other field already named).
  *
- *  `maxScore` is here because it is NOT a constant of the row, and the whole project read it as
- *  one. It is the objdiff row count of the winning candidate's alignment, so a different
- *  candidate gives a different denominator: twelve rows moved theirs between `eb6dec7d` and
- *  `2fed1e42`, `kleod:CountCollectedGems:agbcc` by 17 (404 → 387). Its `290 → 171` was therefore
- *  never a subtraction on a fixed scale, and reading it as one is what produced a six-way
- *  "partition of the 290", a 297-predicted / 119-delivered shortfall, and a whole extra
- *  attribution round to explain the difference. The report publishes `score/maxScore` (the
- *  Explorer and the gap badge both render it), so by this list's own rule a denominator-only move
- *  is a published claim moving and must be named. It has never moved ALONE — all 12 printed a
- *  `score` line on the same row and side, and that line now renders both denominators — so the
- *  entry buys 0 unique rows today and is kept for the constructible case it alone catches: an
- *  alignment whose length moves while the diff count holds. Do not re-litigate it as a duplicate.
+ *  `maxScore` is here because it is NOT a constant of the row. It is the objdiff row count of the
+ *  winning candidate's alignment, so a different candidate gives a different denominator: 14 lines
+ *  moved theirs between `eb6dec7d` and `2fed1e42` (12 asmlift, 2 m2c), and
+ *  `kleod:CountCollectedGems:agbcc` by 17 (404 → 387). Its `290 → 171` was therefore never a
+ *  subtraction on a fixed scale, and reading it as one produced a six-way "partition of the 290",
+ *  a 297-predicted / 119-delivered shortfall, and a whole extra attribution round. The report
+ *  publishes `score/maxScore` (the Explorer table and the detail view's objdiff badge), so a
+ *  denominator-only move is a published claim moving. It has never moved without its `score` moving too — all 14
+ *  printed a `score` line on the same row and side, and that line renders both denominators — so
+ *  the entry buys 0 unique rows today and is kept for the case it alone catches: an alignment
+ *  whose length moves while the diff count holds.
  *
- *  `compileErrors` is here for the same reason and no other: the report publishes it (the run line
- *  prints `noncompile(k)`, the web FunctionDetail prints `compile errors {n}`), so a row sliding
- *  `noncompile(3) → noncompile(7)` is a published claim moving. It was previously this gate's
- *  own stand-in for an UNCOMPARED field, which asserted the opposite of this list's rule. Cost,
- *  measured over `eb6dec7d`→`2fed1e42`: 0 extra lines — no row in that pair moved it.
+ *  `compileErrors` is here because the report publishes it (the run line prints `noncompile(k)`,
+ *  the web FunctionDetail prints `compile errors {n}`), so a row sliding `noncompile(3) →
+ *  noncompile(7)` is a published claim moving. Cost over `eb6dec7d`→`2fed1e42`: 0 extra lines.
  *
- *  `errorMarkers` is here because this repo has already PAID for its absence, in writing: the
- *  `v17:` note in `cache.ts` records a warm-store entry replaying ``gPacked' undeclared`` for a row
- *  whose deciding rung declares the symbol — "invisible to every artifact comparison,
- *  `errorMarkers` being outside `FIELDS.m2c`". The run line prints `declined(k gap(s))` from it and
- *  the web report derives its whole declined/failed taxonomy column from it. Cost over the same
- *  pair: 2 lines, 0 rows no other field named. Max 6 entries / 491 chars, so it prints as itself.
+ *  `errorMarkers` is here because this repo has already PAID for its absence: the `v17:` note in
+ *  `cache.ts` records a warm-store entry replaying ``gPacked' undeclared`` for a row whose deciding
+ *  rung declares the symbol, with no artifact comparison to catch it. The run line prints
+ *  `declined(k gap(s))` from it and the web report derives its whole declined/failed taxonomy
+ *  column from it. Cost over the same pair: 2 lines, 0 rows no other field named. Max 6 entries /
+ *  491 chars, so it prints as itself.
  *
- *  The two `.length` entries are the exception the first paragraph describes: `droppedCandidates`
- *  and `withheldCandidates` are published as COUNTS by the `[ranked]` line, and the count is what
- *  is watched. This is not a cosmetic saving — over `eb6dec7d`→`2fed1e42` the dropped count moved
- *  on 2 rows (`kleod:ProcessInputAndUpdateEntities:agbcc`, `kleod:UpdateHUDCounterDisplay:agbcc`)
- *  that NO other watched field moves on: identical source, identical score, identical label, a fan
- *  that demonstrably changed, and a gate that answered "nothing moved". `symbolsUsed` is left out
- *  for size and for nothing else. */
+ *  The two `.length` entries are the exception the rule above describes: `droppedCandidates` and
+ *  `withheldCandidates` are published as COUNTS by the `[ranked]` line, and the count is what is
+ *  watched. Not a cosmetic saving — over `eb6dec7d`→`2fed1e42` the dropped count moved on 2 rows
+ *  (`kleod:ProcessInputAndUpdateEntities:agbcc`, `kleod:UpdateHUDCounterDisplay:agbcc`) that NO
+ *  other watched field moves on: identical source, identical score, identical label, a fan that
+ *  demonstrably changed, and a gate that answered "nothing moved".
+ *
+ *  `symbolsUsed` is the one published field still left out, and NOT for size — it is at most 1,108
+ *  chars on any row of the current artifact. It is derived from the winning candidate, which
+ *  `source` and `candidateLabel` already name, and it moved on 0 rows over `eb6dec7d`→`2fed1e42`;
+ *  a run where a symbol's declared SHAPE moves under an unchanged winner would slip past. */
 const FIELDS = {
   asmlift: [
     'outcome',
@@ -122,8 +121,8 @@ export interface DiffReport {
 // Long text is reported by its shape, not pasted: a 40-line C body in a gate's output buries the
 // one line that says which row moved.
 //
-// `res` is the whole side-result the value came from, because a score alone is not readable: it
-// is a numerator over a denominator that moves with the winning candidate. `290 → 171` invites a
+// `res` is the whole side-result the value came from, because a score alone is not readable: it is
+// a numerator over a denominator that moves with the winning candidate. `290 → 171` invites a
 // subtraction; `290/404 → 171/387` shows that 17 of those 119 points are the scale, not the row.
 const show = (field: string, v: unknown, res: Record<string, unknown>): string => {
   if (v === undefined || v === null) {
@@ -137,11 +136,11 @@ const show = (field: string, v: unknown, res: Record<string, unknown>): string =
   if (field === 'errorMarkers') {
     return scrub(stable(v));
   }
-  // A scored side ALWAYS renders a denominator, `?` included: `show` is called once per side, so
-  // a fresh side that lost its `maxScore` would otherwise print `290/404 → 171` and be read as
-  // `171/404` — the fixed-scale misreading this whole rendering exists to stop. `res` is REQUIRED
-  // rather than optional so this cannot be re-opened by a call site that forgets it: the bare
-  // numerator would come back silently, on a path no test can reach.
+  // A side carrying the key renders a denominator, `?` included: `show` is called once per side,
+  // so a fresh side whose `maxScore` went null would otherwise print `290/404 → 171` and be read
+  // as `171/404` — the fixed-scale misreading this rendering exists to stop. A side with no
+  // `maxScore` key at all (hand-built objects; artifacts predating the field) keeps the bare
+  // numerator, since `290/404 → 171/undefined` says less than `171`.
   if (field === 'score' && 'maxScore' in res) {
     return `${String(v)}/${typeof res.maxScore === 'number' ? res.maxScore : '?'}`;
   }

--- a/apps/benchmark/src/run/runner.ts
+++ b/apps/benchmark/src/run/runner.ts
@@ -41,22 +41,19 @@ export function benchMeta(results: FunctionResult[]): BenchMeta {
 /** The per-row log line's rendering of one decompiler's outcome.
  *
  *  A gap prints `diff:<score>/<maxScore>`, NOT `diff:<score>`, because `maxScore` is not a
- *  constant of the row. It is the objdiff row count of the winning candidate's alignment, so it
- *  moves whenever the candidate does: between `eb6dec7d` and `2fed1e42`,
- *  `kleod:CountCollectedGems:agbcc` went 290/404 → 171/387 and twelve rows moved their
- *  denominator. Printing the numerator alone invites reading two runs' scores as a subtraction on
- *  a fixed scale, which is how a 17-point denominator move got attributed to capability gaps. */
+ *  constant of the row: it is the objdiff row count of the winning candidate's alignment, so it
+ *  moves whenever the candidate does (`kleod:CountCollectedGems:agbcc` went 290/404 → 171/387
+ *  between two committed artifacts). A bare numerator invites reading two runs' scores as a
+ *  subtraction on a fixed scale, which is how a 17-point denominator move got attributed to
+ *  capability gaps. */
 export function fmt(d: DecompilerResult): string {
   if (d.outcome === 'match') {
     return 'MATCH';
   }
   if (d.outcome === 'nonmatch') {
-    // THE SAME PREDICATE `bench diff`'s renderer uses (`typeof res.maxScore === 'number'`), and
-    // deliberately not `=== null`: the artifact types it `number | null`, but this renderer also
-    // runs over hand-built and older objects where the key is simply ABSENT, and `diff:12/undefined`
-    // is a worse answer than `diff:12`. Two defences written for one fact is how they come to
-    // disagree — this one degrades to the bare numerator, that one to `?`, and both must degrade
-    // on the same condition.
+    // `typeof`, deliberately not `=== null`: the artifact types it `number | null`, but this
+    // renderer also runs over hand-built and older objects where the key is simply ABSENT, and
+    // `diff:12/undefined` is a worse answer than `diff:12`.
     return typeof d.maxScore === 'number' ? `diff:${d.score}/${d.maxScore}` : `diff:${d.score}`;
   }
   if (d.outcome === 'noncompile') {

--- a/apps/benchmark/src/run/runner.ts
+++ b/apps/benchmark/src/run/runner.ts
@@ -51,7 +51,13 @@ export function fmt(d: DecompilerResult): string {
     return 'MATCH';
   }
   if (d.outcome === 'nonmatch') {
-    return d.maxScore === null ? `diff:${d.score}` : `diff:${d.score}/${d.maxScore}`;
+    // THE SAME PREDICATE `bench diff`'s renderer uses (`typeof res.maxScore === 'number'`), and
+    // deliberately not `=== null`: the artifact types it `number | null`, but this renderer also
+    // runs over hand-built and older objects where the key is simply ABSENT, and `diff:12/undefined`
+    // is a worse answer than `diff:12`. Two defences written for one fact is how they come to
+    // disagree — this one degrades to the bare numerator, that one to `?`, and both must degrade
+    // on the same condition.
+    return typeof d.maxScore === 'number' ? `diff:${d.score}/${d.maxScore}` : `diff:${d.score}`;
   }
   if (d.outcome === 'noncompile') {
     return `noncompile(${d.compileErrors})`;

--- a/apps/benchmark/src/run/runner.ts
+++ b/apps/benchmark/src/run/runner.ts
@@ -38,12 +38,20 @@ export function benchMeta(results: FunctionResult[]): BenchMeta {
   };
 }
 
-function fmt(d: DecompilerResult): string {
+/** The per-row log line's rendering of one decompiler's outcome.
+ *
+ *  A gap prints `diff:<score>/<maxScore>`, NOT `diff:<score>`, because `maxScore` is not a
+ *  constant of the row. It is the objdiff row count of the winning candidate's alignment, so it
+ *  moves whenever the candidate does: between `eb6dec7d` and `2fed1e42`,
+ *  `kleod:CountCollectedGems:agbcc` went 290/404 → 171/387 and twelve rows moved their
+ *  denominator. Printing the numerator alone invites reading two runs' scores as a subtraction on
+ *  a fixed scale, which is how a 17-point denominator move got attributed to capability gaps. */
+export function fmt(d: DecompilerResult): string {
   if (d.outcome === 'match') {
     return 'MATCH';
   }
   if (d.outcome === 'nonmatch') {
-    return `diff:${d.score}`;
+    return d.maxScore === null ? `diff:${d.score}` : `diff:${d.score}/${d.maxScore}`;
   }
   if (d.outcome === 'noncompile') {
     return `noncompile(${d.compileErrors})`;

--- a/apps/benchmark/src/run/smoke.ts
+++ b/apps/benchmark/src/run/smoke.ts
@@ -13,7 +13,7 @@ export function smoke(): void {
       const { obj, asm } = tc.buildTarget(REF, SYM);
       const r = decompile(SYM, asm, tc.targetDesc);
       const s = tc.score(r.source, SYM, obj);
-      console.log(`[${tc.id}] asmlift → score=${s.score} match=${s.match}`);
+      console.log(`[${tc.id}] asmlift → score=${s.score}/${s.rows} match=${s.match}`);
       console.log(
         r.source
           .trimEnd()

--- a/apps/benchmark/test/diff.test.ts
+++ b/apps/benchmark/test/diff.test.ts
@@ -38,6 +38,33 @@ describe('compareMeasurements', () => {
   test('a score that moves without changing the outcome is caught — the case `regression` misses', () => {
     const r = compareMeasurements(out(row('a', { score: 12 })), out(row('a', { score: 14 })));
     expect(r.ok).toBe(false);
+    expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.score', from: '12/40', to: '14/40' }]);
+  });
+
+  // THE DENOMINATOR MOVES. `maxScore` is the objdiff row count of the winning candidate's
+  // alignment, so a different candidate scores against a different scale: twelve rows moved theirs
+  // between `eb6dec7d` and `2fed1e42`, `kleod:CountCollectedGems:agbcc` by 17. Read as a
+  // subtraction on a fixed scale, its `290 → 171` bought a six-way "partition of the 290", a
+  // 297-predicted / 119-delivered shortfall, and an extra attribution round.
+  test('a moving score is shown over its own denominator, not as a bare numerator', () => {
+    const r = compareMeasurements(
+      out(row('a', { score: 290, maxScore: 404 })),
+      out(row('a', { score: 171, maxScore: 387 })),
+    );
+    expect(r.changed).toContainEqual({ id: 'a', field: 'asmlift.score', from: '290/404', to: '171/387' });
+  });
+
+  test('a denominator that moves ALONE is a change, and is named', () => {
+    const r = compareMeasurements(out(row('a', { maxScore: 404 })), out(row('a', { maxScore: 387 })));
+    expect(r.ok).toBe(false);
+    expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.maxScore', from: '404', to: '387' }]);
+  });
+
+  test('an unscored row still renders its score without a denominator', () => {
+    const r = compareMeasurements(
+      out(row('a', { score: 12, maxScore: null })),
+      out(row('a', { score: 14, maxScore: null })),
+    );
     expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.score', from: '12', to: '14' }]);
   });
 
@@ -78,11 +105,11 @@ describe('compareMeasurements', () => {
     expect(r.ok).toBe(false);
   });
 
-  test('provenance and timings are not compared — only the six fields', () => {
+  test('provenance and timings are not compared — only the listed fields', () => {
     const base = out(row('a'));
     const fresh = out(row('a'));
     (fresh.meta as unknown as Record<string, unknown>).generatedAt = 'much later';
-    (fresh.results[0].asmlift as unknown as Record<string, unknown>).maxScore = 999;
+    (fresh.results[0].asmlift as unknown as Record<string, unknown>).compileErrors = 7;
     expect(compareMeasurements(base, fresh).ok).toBe(true);
   });
 });

--- a/apps/benchmark/test/diff.test.ts
+++ b/apps/benchmark/test/diff.test.ts
@@ -60,12 +60,21 @@ describe('compareMeasurements', () => {
     expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.maxScore', from: '404', to: '387' }]);
   });
 
-  test('an unscored row still renders its score without a denominator', () => {
+  // `show` renders one SIDE at a time, so a denominator missing on one side only would print
+  // `290/404 → 171` and be read as `171/404` — the fixed-scale misreading this rendering exists to
+  // stop. A scored side with no `maxScore` therefore prints `?`, never a bare numerator.
+  test('a score whose denominator is missing renders `?`, on either side', () => {
     const r = compareMeasurements(
       out(row('a', { score: 12, maxScore: null })),
       out(row('a', { score: 14, maxScore: null })),
     );
-    expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.score', from: '12', to: '14' }]);
+    expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.score', from: '12/?', to: '14/?' }]);
+
+    const oneSided = compareMeasurements(
+      out(row('b', { score: 290, maxScore: 404 })),
+      out(row('b', { score: 171, maxScore: null })),
+    );
+    expect(oneSided.changed).toContainEqual({ id: 'b', field: 'asmlift.score', from: '290/404', to: '171/?' });
   });
 
   test('the ranked WINNER changing identity at an equal score is a change', () => {
@@ -105,12 +114,25 @@ describe('compareMeasurements', () => {
     expect(r.ok).toBe(false);
   });
 
-  test('provenance and timings are not compared — only the listed fields', () => {
+  // `compileErrors` used to be this test's stand-in for an uncompared field, which asserted the
+  // opposite of the FIELDS rule: the run line prints `noncompile(k)` and the web detail prints
+  // `compile errors {n}`, so it IS a published claim. It is now watched, and the sentinel here is
+  // provenance alone — the thing the title actually names.
+  test('provenance is not compared — only the listed fields', () => {
     const base = out(row('a'));
     const fresh = out(row('a'));
     (fresh.meta as unknown as Record<string, unknown>).generatedAt = 'much later';
-    (fresh.results[0].asmlift as unknown as Record<string, unknown>).compileErrors = 7;
+    (fresh.results[0] as unknown as Record<string, unknown>).note = 'a re-run on another machine';
     expect(compareMeasurements(base, fresh).ok).toBe(true);
+  });
+
+  test('a compiler-error count that moves is a published claim moving', () => {
+    const r = compareMeasurements(
+      out(row('a', { outcome: 'noncompile' as Outcome, compileErrors: 3 })),
+      out(row('a', { outcome: 'noncompile' as Outcome, compileErrors: 7 })),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.compileErrors', from: '3', to: '7' }]);
   });
 });
 

--- a/apps/benchmark/test/diff.test.ts
+++ b/apps/benchmark/test/diff.test.ts
@@ -43,11 +43,9 @@ describe('compareMeasurements', () => {
     expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.score', from: '12/40', to: '14/40' }]);
   });
 
-  // THE DENOMINATOR MOVES. `maxScore` is the objdiff row count of the winning candidate's
-  // alignment, so a different candidate scores against a different scale: twelve rows moved theirs
-  // between `eb6dec7d` and `2fed1e42`, `kleod:CountCollectedGems:agbcc` by 17. Read as a
-  // subtraction on a fixed scale, its `290 → 171` bought a six-way "partition of the 290", a
-  // 297-predicted / 119-delivered shortfall, and an extra attribution round.
+  // THE DENOMINATOR MOVES: `maxScore` is the objdiff row count of the winning candidate's
+  // alignment, so a different candidate scores against a different scale (`290 → 171` is 119
+  // points on a scale that also lost 17).
   test('a moving score is shown over its own denominator, not as a bare numerator', () => {
     const r = compareMeasurements(
       out(row('a', { score: 290, maxScore: 404 })),
@@ -62,9 +60,8 @@ describe('compareMeasurements', () => {
     expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.maxScore', from: '404', to: '387' }]);
   });
 
-  // `show` renders one SIDE at a time, so a denominator missing on one side only would print
-  // `290/404 → 171` and be read as `171/404` — the fixed-scale misreading this rendering exists to
-  // stop. A scored side with no `maxScore` therefore prints `?`, never a bare numerator.
+  // `show` renders one SIDE at a time, so a denominator that went null on one side only would
+  // print `290/404 → 171` and be read as `171/404`. It prints `?` instead.
   test('a score whose denominator is missing renders `?`, on either side', () => {
     const r = compareMeasurements(
       out(row('a', { score: 12, maxScore: null })),
@@ -116,10 +113,6 @@ describe('compareMeasurements', () => {
     expect(r.ok).toBe(false);
   });
 
-  // `compileErrors` used to be this test's stand-in for an uncompared field, which asserted the
-  // opposite of the FIELDS rule: the run line prints `noncompile(k)` and the web detail prints
-  // `compile errors {n}`, so it IS a published claim. It is now watched, and the sentinel here is
-  // provenance alone — the thing the title actually names.
   test('provenance is not compared — only the listed fields', () => {
     const base = out(row('a'));
     const fresh = out(row('a'));
@@ -139,7 +132,7 @@ describe('compareMeasurements', () => {
 
   // `errorMarkers` is the field this repo has already paid for leaving unwatched: `cache.ts`'s
   // `v17:` note records a warm-store entry replaying a compiler error naming a cause the run does
-  // not have, "invisible to every artifact comparison, `errorMarkers` being outside `FIELDS.m2c`".
+  // not have, with no artifact comparison to catch it.
   test('a declined row that changes WHICH gap it names is a published claim moving', () => {
     const r = compareMeasurements(
       out(row('a', {}, { outcome: 'declined' as Outcome, errorMarkers: ['no frontend for `bl @far`'] })),
@@ -179,8 +172,8 @@ describe('compareMeasurements', () => {
   // THE FAN MOVED AND NOTHING ELSE DID. Over `eb6dec7d`→`2fed1e42` this is 2 real rows
   // (`kleod:ProcessInputAndUpdateEntities:agbcc`, `kleod:UpdateHUDCounterDisplay:agbcc`): identical
   // source, identical score, identical label, a different number of spellings that failed to build.
-  // The COUNT is watched and the LIST is not, because the list runs to 51,840 entries on one row of
-  // the current artifact and a gate that pastes it is a gate nobody reads.
+  // The COUNT is watched and the LIST is not — the list runs to 51,840 entries on one row of the
+  // current artifact.
   test('a fan that grew is caught, by its count and not by pasting it', () => {
     const many = (n: number) => Array.from({ length: n }, (_, i) => ({ label: `cand${i}`, error: 'did not build' }));
     const r = compareMeasurements(

--- a/apps/benchmark/test/diff.test.ts
+++ b/apps/benchmark/test/diff.test.ts
@@ -26,6 +26,8 @@ const row = (
 const out = (...results: FunctionResult[]): BenchOutput =>
   ({ meta: { generatedAt: 'whenever' }, results }) as unknown as BenchOutput;
 
+const drop = (label: string) => ({ label, error: 'did not build' });
+
 const at = (generatedAt: string): BenchOutput => ({ meta: { generatedAt }, results: [] }) as unknown as BenchOutput;
 
 describe('compareMeasurements', () => {
@@ -133,6 +135,79 @@ describe('compareMeasurements', () => {
     );
     expect(r.ok).toBe(false);
     expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.compileErrors', from: '3', to: '7' }]);
+  });
+
+  // `errorMarkers` is the field this repo has already paid for leaving unwatched: `cache.ts`'s
+  // `v17:` note records a warm-store entry replaying a compiler error naming a cause the run does
+  // not have, "invisible to every artifact comparison, `errorMarkers` being outside `FIELDS.m2c`".
+  test('a declined row that changes WHICH gap it names is a published claim moving', () => {
+    const r = compareMeasurements(
+      out(row('a', {}, { outcome: 'declined' as Outcome, errorMarkers: ['no frontend for `bl @far`'] })),
+      out(row('a', {}, { outcome: 'declined' as Outcome, errorMarkers: ['unhandled switch fall-through'] })),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.changed).toEqual([
+      {
+        id: 'a',
+        field: 'm2c.errorMarkers',
+        from: '["no frontend for `bl @far`"]',
+        to: '["unhandled switch fall-through"]',
+      },
+    ]);
+  });
+
+  // …but a marker differing ONLY in the scratch dir a cold run re-mints is not a moved measurement,
+  // the same equality `source` already gets.
+  test('a marker quoting a run-local scratch path is not a difference', () => {
+    const r = compareMeasurements(
+      out(row('a', { errorMarkers: ['/var/folders/x9/bench-run-a1b2c3/t.c:3: parse error'] })),
+      out(row('a', { errorMarkers: ['/var/folders/q1/bench-run-z9y8x7/t.c:3: parse error'] })),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('the gap SHAPE moving at an unchanged score is caught', () => {
+    const bd = { insert: 1, delete: 1, replace: 2, opMismatch: 4, argMismatch: 4 };
+    const r = compareMeasurements(
+      out(row('a', { breakdown: bd })),
+      out(row('a', { breakdown: { ...bd, opMismatch: 5, argMismatch: 3 } })),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.changed.map((c) => c.field)).toEqual(['asmlift.breakdown']);
+  });
+
+  // THE FAN MOVED AND NOTHING ELSE DID. Over `eb6dec7d`→`2fed1e42` this is 2 real rows
+  // (`kleod:ProcessInputAndUpdateEntities:agbcc`, `kleod:UpdateHUDCounterDisplay:agbcc`): identical
+  // source, identical score, identical label, a different number of spellings that failed to build.
+  // The COUNT is watched and the LIST is not, because the list runs to 51,840 entries on one row of
+  // the current artifact and a gate that pastes it is a gate nobody reads.
+  test('a fan that grew is caught, by its count and not by pasting it', () => {
+    const many = (n: number) => Array.from({ length: n }, (_, i) => ({ label: `cand${i}`, error: 'did not build' }));
+    const r = compareMeasurements(
+      out(row('a', { droppedCandidates: many(41472) })),
+      out(row('a', { droppedCandidates: many(51840) })),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.changed).toEqual([{ id: 'a', field: 'asmlift.droppedCandidates.length', from: '41472', to: '51840' }]);
+  });
+
+  // The count, not the order: a scheduling change that reorders one row's fan moved no measurement.
+  //
+  // NOTE this is the one watched field whose ORDER is deliberately free — every other one is
+  // compared by value, order included.
+  test('a fan that only REORDERED is not a difference', () => {
+    const r = compareMeasurements(
+      out(row('a', { droppedCandidates: [drop('x'), drop('y')] })),
+      out(row('a', { droppedCandidates: [drop('y'), drop('x')] })),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  // An ABSENT list and an empty one are the same published claim (`[ranked] 0 dropped`), so a row
+  // that grows the key without growing the fan must not read as a move.
+  test('an absent fan counts as 0, not as a difference from an empty one', () => {
+    const r = compareMeasurements(out(row('a')), out(row('a', { droppedCandidates: [] })));
+    expect(r.ok).toBe(true);
   });
 });
 

--- a/apps/benchmark/test/m2c-rungs.test.ts
+++ b/apps/benchmark/test/m2c-rungs.test.ts
@@ -11,8 +11,7 @@
 // the plain one. It breaks the moment a rung adds the DECLARATIONS the row is compiled against:
 // under that rule `bfwordread` and `bfwordwrite` publish ``gPacked' undeclared`` while the rung
 // that decides them DOES declare `gPacked` and fails with `invalid operands to binary <<`.
-// `errorMarkers` was for a long time outside `FIELDS.m2c` in report/diff.ts, so no artifact
-// comparison caught it; it is watched now, but a gate that names a moved field still does not say
+// `report/diff.ts` watches `errorMarkers`, but a gate that names a moved field still does not say
 // WHICH rung is right — which is why the pin is here, on the function, and toolchain-free.
 import { describe, expect, test } from 'vitest';
 

--- a/apps/benchmark/test/m2c-rungs.test.ts
+++ b/apps/benchmark/test/m2c-rungs.test.ts
@@ -11,8 +11,9 @@
 // the plain one. It breaks the moment a rung adds the DECLARATIONS the row is compiled against:
 // under that rule `bfwordread` and `bfwordwrite` publish ``gPacked' undeclared`` while the rung
 // that decides them DOES declare `gPacked` and fails with `invalid operands to binary <<`.
-// `errorMarkers` is not among `FIELDS.m2c` in report/diff.ts, so no artifact comparison catches
-// it — which is why the pin is here, on the function, and toolchain-free.
+// `errorMarkers` was for a long time outside `FIELDS.m2c` in report/diff.ts, so no artifact
+// comparison caught it; it is watched now, but a gate that names a moved field still does not say
+// WHICH rung is right — which is why the pin is here, on the function, and toolchain-free.
 import { describe, expect, test } from 'vitest';
 
 import { scoreM2c } from '../src/eval/evaluate';

--- a/apps/benchmark/test/runner.test.ts
+++ b/apps/benchmark/test/runner.test.ts
@@ -144,6 +144,14 @@ describe('fmt renders a gap over its denominator', () => {
     expect(fmt(d({ score: 12, maxScore: null }))).toBe('diff:12');
   });
 
+  // The artifact types it `number | null`, but this renderer also runs over hand-built and older
+  // objects where the key is simply ABSENT, and `diff:12/undefined` is a worse answer than
+  // `diff:12`. `bench diff`'s renderer degrades the same case (to `?`); two defences for one fact
+  // is how they come to disagree.
+  test('an ABSENT denominator degrades the same way a null one does', () => {
+    expect(fmt(d({ score: 12, maxScore: undefined as unknown as null }))).toBe('diff:12');
+  });
+
   test('the other outcomes are untouched', () => {
     expect(fmt(d({ outcome: 'match' }))).toBe('MATCH');
     expect(fmt(d({ outcome: 'noncompile', compileErrors: 3 }))).toBe('noncompile(3)');

--- a/apps/benchmark/test/runner.test.ts
+++ b/apps/benchmark/test/runner.test.ts
@@ -126,11 +126,11 @@ describe('benchMeta (pinned)', () => {
   });
 });
 
-// A gap's score is a numerator over a denominator that MOVES. `maxScore` is the objdiff row count
-// of the winning candidate's alignment, so a better candidate changes it: twelve rows moved theirs
-// between `eb6dec7d` and `2fed1e42`, `kleod:CountCollectedGems:agbcc` by 17 (404 → 387). A line
-// that prints only the numerator reads as a subtraction on a fixed scale, and that reading is what
-// sent an attribution round hunting for capability gaps to explain a denominator move.
+// A gap's score is a numerator over a denominator that MOVES: `maxScore` is the objdiff row count
+// of the winning candidate's alignment, so a better candidate changes it (404 → 387 on
+// `kleod:CountCollectedGems:agbcc`). A line printing only the numerator reads as a subtraction on
+// a fixed scale, and that reading sent an attribution round hunting for capability gaps to explain
+// a denominator move.
 describe('fmt renders a gap over its denominator', () => {
   const d = (over: Partial<DecompilerResult>): DecompilerResult =>
     ({ outcome: 'nonmatch', ...over }) as DecompilerResult;
@@ -146,8 +146,7 @@ describe('fmt renders a gap over its denominator', () => {
 
   // The artifact types it `number | null`, but this renderer also runs over hand-built and older
   // objects where the key is simply ABSENT, and `diff:12/undefined` is a worse answer than
-  // `diff:12`. `bench diff`'s renderer degrades the same case (to `?`); two defences for one fact
-  // is how they come to disagree.
+  // `diff:12`.
   test('an ABSENT denominator degrades the same way a null one does', () => {
     expect(fmt(d({ score: 12, maxScore: undefined as unknown as null }))).toBe('diff:12');
   });

--- a/apps/benchmark/test/runner.test.ts
+++ b/apps/benchmark/test/runner.test.ts
@@ -1,13 +1,13 @@
 // Pin tests for the runner's pure pieces: the shard math the orchestrator's parent/child
 // contract rides on, the ONE meta builder, and the no-silent-row-loss build-fail contract.
-import type { FunctionResult } from '@asmlift/bench-schema';
+import type { DecompilerResult, FunctionResult } from '@asmlift/bench-schema';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, test } from 'vitest';
 
 import type { Case } from '../src/cases/types';
-import { benchMeta, inShard, parseShard, runCases } from '../src/run/runner';
+import { benchMeta, fmt, inShard, parseShard, runCases } from '../src/run/runner';
 
 describe('parseShard (pinned)', () => {
   test('parses i/N', () => {
@@ -123,5 +123,31 @@ describe('benchMeta (pinned)', () => {
     expect(m.toolchains).toEqual(['agbcc', 'ido7.1']);
     // no machine identity in published artifacts (meta must never carry a hostname)
     expect(m).not.toHaveProperty('host');
+  });
+});
+
+// A gap's score is a numerator over a denominator that MOVES. `maxScore` is the objdiff row count
+// of the winning candidate's alignment, so a better candidate changes it: twelve rows moved theirs
+// between `eb6dec7d` and `2fed1e42`, `kleod:CountCollectedGems:agbcc` by 17 (404 → 387). A line
+// that prints only the numerator reads as a subtraction on a fixed scale, and that reading is what
+// sent an attribution round hunting for capability gaps to explain a denominator move.
+describe('fmt renders a gap over its denominator', () => {
+  const d = (over: Partial<DecompilerResult>): DecompilerResult =>
+    ({ outcome: 'nonmatch', ...over }) as DecompilerResult;
+
+  test('a scored gap prints score/maxScore', () => {
+    expect(fmt(d({ score: 171, maxScore: 387 }))).toBe('diff:171/387');
+    expect(fmt(d({ score: 290, maxScore: 404 }))).toBe('diff:290/404');
+  });
+
+  test('an unscored denominator degrades to the bare numerator rather than printing null', () => {
+    expect(fmt(d({ score: 12, maxScore: null }))).toBe('diff:12');
+  });
+
+  test('the other outcomes are untouched', () => {
+    expect(fmt(d({ outcome: 'match' }))).toBe('MATCH');
+    expect(fmt(d({ outcome: 'noncompile', compileErrors: 3 }))).toBe('noncompile(3)');
+    expect(fmt(d({ outcome: 'declined', errorMarkers: ['a', 'b'] }))).toBe('declined(2 gap(s))');
+    expect(fmt(d({ outcome: 'failed' }))).toBe('failed');
   });
 });

--- a/apps/web/src/data/summary.json
+++ b/apps/web/src/data/summary.json
@@ -4,7 +4,7 @@
     "asmlift": 598,
     "m2c": 412
   },
-  "commit": "87f76d99e71009ed25a5c526cb0c8102adaadc20",
+  "commit": "13eeb96bbc17b5e2b4ca41bbe4f9ac3226cea1c3",
   "m2cCommit": "ad5c529a65ca1e5191b00a4a7b4cbfe79a7b45a0",
   "dirty": false
 }

--- a/apps/web/src/pages/benchmark/components/Explorer.tsx
+++ b/apps/web/src/pages/benchmark/components/Explorer.tsx
@@ -53,9 +53,9 @@ function Select({
 }
 
 function ScoreCell({ result }: { result: FunctionResult['asmlift'] }) {
-  // A SCORED row always shows a denominator, `?` included. `maxScore` is objdiff's row count for
-  // the winning candidate's alignment, so it moves with the winner; a bare numerator in a column
-  // two runs get compared in is the fixed-scale misreading that cost an attribution round.
+  // A SCORED row always shows a denominator, `?` included: `maxScore` is objdiff's row count for
+  // the winning candidate's alignment, so it moves with the winner, and a bare numerator in a
+  // column two runs get compared in reads as a score on a fixed scale.
   const score = result.score === null ? '' : `${result.score}/${result.maxScore ?? '?'}`;
   return (
     <div className="flex items-center gap-2">

--- a/apps/web/src/pages/benchmark/components/Explorer.tsx
+++ b/apps/web/src/pages/benchmark/components/Explorer.tsx
@@ -53,7 +53,10 @@ function Select({
 }
 
 function ScoreCell({ result }: { result: FunctionResult['asmlift'] }) {
-  const score = result.score === null ? '' : result.maxScore ? `${result.score}/${result.maxScore}` : `${result.score}`;
+  // A SCORED row always shows a denominator, `?` included. `maxScore` is objdiff's row count for
+  // the winning candidate's alignment, so it moves with the winner; a bare numerator in a column
+  // two runs get compared in is the fixed-scale misreading that cost an attribution round.
+  const score = result.score === null ? '' : `${result.score}/${result.maxScore ?? '?'}`;
   return (
     <div className="flex items-center gap-2">
       <OutcomeBadge outcome={result.outcome} />

--- a/apps/web/src/pages/benchmark/components/FunctionDetail.tsx
+++ b/apps/web/src/pages/benchmark/components/FunctionDetail.tsx
@@ -20,12 +20,11 @@ function Code({ text, language }: { text: string; language: CodeLanguage }) {
   return <CodeBlock code={text} language={language} className={CODE_PRE} />;
 }
 
+/** A scored row's `<score>/<maxScore>`, never a bare numerator — `?` when the denominator is
+ *  missing. `maxScore` is the winning candidate's alignment length and moves with the winner, so a
+ *  numerator alone invites reading two runs as a subtraction on a fixed scale. */
 function scoreLabel(r: DecompilerResult): string {
-  if (r.score === null) {
-    return '—';
-  }
-  const max = r.maxScore ? `/${r.maxScore}` : '';
-  return `${r.score}${max}`;
+  return r.score === null ? '—' : `${r.score}/${r.maxScore ?? '?'}`;
 }
 
 /** The nonzero readability penalties, spelled out (nothing shown for clean output). */

--- a/apps/web/src/pages/playground/score-wasm.ts
+++ b/apps/web/src/pages/playground/score-wasm.ts
@@ -308,7 +308,7 @@ export async function rankCandidatesInBrowser(
       // it would be the playground showing a source the CLI refuses to stand behind.
       const why = withheldReason(c, score);
       if (why !== null) {
-        withheld.push({ label: c.label, score: score.score, why });
+        withheld.push({ label: c.label, score: score.score, rows: score.rows, why });
         continue;
       }
       results.push({ ...c, order, score });

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -578,6 +578,17 @@ diff <(grep -F '[score]' a.err) <(grep -F '[score]' b.err)
 passes having compared nothing. A neutrality check that filters away what it is comparing is
 worse than none.
 
+**Every `[score]` line, and the `best …` on the `[ranked]` line, reads `<score>/<rows>`.** `rows`
+is objdiff's total row count for _that candidate's_ alignment against the target, so it belongs to
+the candidate and not to the target: a different spelling aligns differently and is scored against
+a different scale. **A run-to-run delta is therefore a pair of fractions, never a subtraction.**
+`kleod:CountCollectedGems:agbcc` moved 290/404 → 171/387 between two committed artifacts, and
+reading its `290 → 171` as 119 points on a fixed scale cost an attribution round. Quote both
+numbers; if the denominators differ, say so in the same sentence.
+
+(Runs recorded in this file from before that change print a bare numerator. Their `[score]` md5s
+and stdout md5s are therefore not comparable with a run made today; the line _counts_ still are.)
+
 ## Write it down
 
 Whatever you run, paste it verbatim, flags included, into your report. Every later measurement —

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -588,7 +588,8 @@ numbers; if the denominators differ, say so in the same sentence.
 
 (Runs recorded in this file from before that change print a bare numerator, so their `[score]` md5s
 are not comparable with a run made today; the line _counts_ still are. **Their stdout md5s are
-untouched** — the denominator is rendered by `scoreOf`, whose only consumer is `rankedStderr`, and
+untouched** — every score this CLI prints is rendered by `scoreOf`, and all of its consumers write
+to stderr (`rankedStderr`, and the `[progress]` line through the process entry point's stderr sink);
 the generated C on stdout is byte-identical across the change.)
 
 ## Write it down

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -586,11 +586,9 @@ a different scale. **A run-to-run delta is therefore a pair of fractions, never 
 reading its `290 → 171` as 119 points on a fixed scale cost an attribution round. Quote both
 numbers; if the denominators differ, say so in the same sentence.
 
-(Runs recorded in this file from before that change print a bare numerator, so their `[score]` md5s
-are not comparable with a run made today; the line _counts_ still are. **Their stdout md5s are
-untouched** — every score this CLI prints is rendered by `scoreOf`, and all of its consumers write
-to stderr (`rankedStderr`, and the `[progress]` line through the process entry point's stderr sink);
-the generated C on stdout is byte-identical across the change.)
+(The runs recorded in this file predate that format, so their `[score]` md5s do not compare with a
+run made today; their line _counts_ and their **stdout** md5s do — every score the CLI prints goes
+to stderr, and the generated C on stdout is untouched.)
 
 ## Write it down
 

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -525,7 +525,7 @@ find nothing to disagree with and go green having audited nothing.
   writes:
 
   ```
-  asmlift: [ranked] 20608 candidate(s) scored, 0 dropped, 0 withheld, 0 synthesized, best <label>: 531 [asmlift source 7362050]
+  asmlift: [ranked] 20608 candidate(s) scored, 0 dropped, 0 withheld, 0 synthesized, best <label>: 531/<rows> [asmlift source 7362050]
   ```
 
   A score from a run that dropped candidates is not comparable to one that dropped none — and
@@ -586,8 +586,10 @@ a different scale. **A run-to-run delta is therefore a pair of fractions, never 
 reading its `290 → 171` as 119 points on a fixed scale cost an attribution round. Quote both
 numbers; if the denominators differ, say so in the same sentence.
 
-(Runs recorded in this file from before that change print a bare numerator. Their `[score]` md5s
-and stdout md5s are therefore not comparable with a run made today; the line _counts_ still are.)
+(Runs recorded in this file from before that change print a bare numerator, so their `[score]` md5s
+are not comparable with a run made today; the line _counts_ still are. **Their stdout md5s are
+untouched** — the denominator is rendered by `scoreOf`, whose only consumer is `rankedStderr`, and
+the generated C on stdout is byte-identical across the change.)
 
 ## Write it down
 

--- a/packages/bench-schema/src/index.ts
+++ b/packages/bench-schema/src/index.ts
@@ -77,7 +77,7 @@ export interface DecompilerResult {
    *  needed one. A different fact from `droppedCandidates` — nothing failed — and recorded for the
    *  same reason: a row whose winner outranks a withheld sibling, or whose own winner is published
    *  only because it matched, says none of that anywhere else. Absent ⇒ nothing was withheld. */
-  withheldCandidates?: { label: string; score: number; why: string }[];
+  withheldCandidates?: { label: string; score: number; rows?: number; why: string }[];
 }
 
 /** MEASURED size of the remaining gap (merge-time): the best compiling candidate's absolute

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -174,8 +174,12 @@ export interface ObjInput {
   asmData: typeof asmDataForObject;
 }
 
-/** One candidate's score as `<score>/<rows>` — the numerator over the denominator it was measured
- *  against, on both the `[score]` table and the `[ranked]` line readers are told to quote.
+/** A score as `<score>/<rows>` — the numerator over the denominator it was measured against.
+ *
+ *  THE ONE RENDERER FOR EVERY SCORE THIS CLI PRINTS: the `[score]` table, the `[ranked]` line's
+ *  `best …`, the `[withheld]` line and the `[progress]` line. It was three renderings in this one
+ *  file for a while, which is the failure the shape exists to stop wearing a different hat — a
+ *  reader comparing two runs cannot be asked to know which lines carry a denominator.
  *
  *  `rows` is objdiff's total row count for THIS candidate's alignment against the target, so it is
  *  a property of the candidate and not of the target: a different spelling aligns differently and
@@ -183,19 +187,15 @@ export interface ObjInput {
  *  before/after comparison, and printing the numerator alone makes that comparison read as a
  *  subtraction on a fixed scale. It is not one — `kleod:CountCollectedGems:agbcc` went 290/404 →
  *  171/387 across two committed artifacts, 17 points of which were the scale, and an attribution
- *  round was spent explaining the difference. */
-export function scoreOf(s: { score: number; rows: number; match: boolean }): string {
-  return `${s.score}/${s.rows}${s.match ? ' (match)' : ''}`;
+ *  round was spent explaining the difference.
+ *
+ *  Both fields are OPTIONAL, and each absence means one thing. No `rows`: the scorer that produced
+ *  this score supplied none (core rank.ts's `WithheldCandidate` types it optional for exactly
+ *  that), so the numerator prints alone rather than against an invented denominator — never a `0`,
+ *  which would read as a real scale. No `match`: the caller does not know, so nothing is claimed. */
+export function scoreOf(s: { score: number; rows?: number; match?: boolean }): string {
+  return `${s.score}${s.rows === undefined ? '' : `/${s.rows}`}${s.match === true ? ' (match)' : ''}`;
 }
-
-/** A WITHHELD candidate's score, in the same `<score>/<rows>` shape as a published one. Its
- *  numerator is read across runs exactly like the `[score]` table's — a withheld sibling's score
- *  is the evidence that a proof-gated spelling was close — so it must not be the one line in this
- *  log that invites a subtraction on a fixed scale. `rows` is optional at the type level
- *  (core rank.ts `WithheldCandidate`) because the scorer that produced it need not supply one;
- *  absent, the numerator prints alone rather than against an invented denominator. */
-const withheldScore = (w: { score: number; rows?: number }): string =>
-  w.rows === undefined ? String(w.score) : `${w.score}/${w.rows}`;
 
 export interface CliResult {
   code: number;
@@ -239,7 +239,7 @@ function rankedStderr(a: {
   // them out entirely would make `candidates scored` under-count the fan with no trace.
   const held = ranked.withheld.length
     ? `asmlift: [withheld] ${ranked.withheld.length} candidate(s) scored but unpublishable; first: ` +
-      `${ranked.withheld[0].label} at ${withheldScore(ranked.withheld[0])}: ${ranked.withheld[0].why}\n`
+      `${ranked.withheld[0].label} at ${scoreOf(ranked.withheld[0])}: ${ranked.withheld[0].why}\n`
     : '';
   // THE ASSUMPTIONS THE SCORE RESTS ON. A candidate names globals the asm's own literal pool
   // named, and where no symbol map knows them asmlift synthesizes their declarations — width
@@ -643,7 +643,10 @@ export async function runCli(
             return;
           }
           lastTick = now;
-          const best = bestSoFar === undefined ? '' : `, best so far ${bestSoFar.score}/${bestSoFar.rows}`;
+          // Same renderer as the `[score]` table, `(match)` included: a reader watching a
+          // six-figure fan wants "the best so far is already a match" from this line, and a score
+          // spelled one way here and another there is what this item exists to stop.
+          const best = bestSoFar === undefined ? '' : `, best so far ${scoreOf(bestSoFar)}`;
           progressSink(`asmlift: [progress] ${doneN}/${total} candidates scored${best}\n`);
         }
       : undefined;

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -185,6 +185,20 @@ export interface CliResult {
  *  A TIMING VALUE, never a timing call: `phaseReport` and `stamp` are computed by the caller at
  *  the moment the run ended, because both measure the run and neither may be re-measured by the
  *  act of rendering it. */
+/** One candidate's score as `<score>/<rows>` — the numerator over the denominator it was measured
+ *  against, on both the `[score]` table and the `[ranked]` line readers are told to quote.
+ *
+ *  `rows` is objdiff's total row count for THIS candidate's alignment against the target, so it is
+ *  a property of the candidate and not of the target: a different spelling aligns differently and
+ *  is scored on a different scale. Two runs' `[score]` lines are the project's standard
+ *  before/after comparison, and printing the numerator alone makes that comparison read as a
+ *  subtraction on a fixed scale. It is not one — `kleod:CountCollectedGems:agbcc` went 290/404 →
+ *  171/387 across two committed artifacts, 17 points of which were the scale, and an attribution
+ *  round was spent explaining the difference. */
+export function scoreOf(s: { score: number; rows: number; match: boolean }): string {
+  return `${s.score}/${s.rows}${s.match ? ' (match)' : ''}`;
+}
+
 function rankedStderr(a: {
   targetTrace: string;
   warn: string;
@@ -197,9 +211,7 @@ function rankedStderr(a: {
   protoNote: string;
 }): string {
   const { ranked } = a;
-  const table = ranked.candidates
-    .map((c) => `asmlift: [score] ${c.label}: ${c.score.score}${c.score.match ? ' (match)' : ''}\n`)
-    .join('');
+  const table = ranked.candidates.map((c) => `asmlift: [score] ${c.label}: ${scoreOf(c.score)}\n`).join('');
   // Spellings the scorer refused are recorded, not silent: a lever whose every candidate
   // fails to build looks identical to one that declined unless the drops are visible.
   // …and the same idea one stage EARLIER: `[dropped]` reports a spelling the SCORER refused,
@@ -253,7 +265,7 @@ function rankedStderr(a: {
   const summary =
     `asmlift: [ranked] ${ranked.candidates.length} candidate(s) scored, ${ranked.dropped.length} dropped, ` +
     `${ranked.withheld.length} withheld, ${synthesized} synthesized, ` +
-    `best ${ranked.best.label}: ${ranked.best.score.score}${ranked.best.score.match ? ' (match)' : ''} ` +
+    `best ${ranked.best.label}: ${scoreOf(ranked.best.score)} ` +
     `[${a.stamp}]\n`;
   // …and where the time went, ABOVE the line readers paste, so `[ranked]` and its `[proto]`
   // tail stay adjacent.

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -177,17 +177,16 @@ export interface ObjInput {
 /** A score as `<score>/<rows>` — the numerator over the denominator it was measured against.
  *
  *  THE ONE RENDERER FOR EVERY SCORE THIS CLI PRINTS: the `[score]` table, the `[ranked]` line's
- *  `best …`, the `[withheld]` line and the `[progress]` line. It was three renderings in this one
- *  file for a while, which is the failure the shape exists to stop wearing a different hat — a
- *  reader comparing two runs cannot be asked to know which lines carry a denominator.
+ *  `best …`, the `[withheld]` line and the `[progress]` line. A reader comparing two runs cannot
+ *  be asked to know which lines carry a denominator.
  *
  *  `rows` is objdiff's total row count for THIS candidate's alignment against the target, so it is
  *  a property of the candidate and not of the target: a different spelling aligns differently and
  *  is scored on a different scale. Two runs' `[score]` lines are the project's standard
- *  before/after comparison, and printing the numerator alone makes that comparison read as a
- *  subtraction on a fixed scale. It is not one — `kleod:CountCollectedGems:agbcc` went 290/404 →
- *  171/387 across two committed artifacts, 17 points of which were the scale, and an attribution
- *  round was spent explaining the difference.
+ *  before/after comparison (docs/ranked-repro.md), and printing the numerator alone makes that
+ *  comparison read as a subtraction on a fixed scale. It is not one — `kleod:CountCollectedGems`
+ *  went 290/404 → 171/387 across two committed artifacts, 17 points of which were the scale, and
+ *  an attribution round was spent explaining the difference.
  *
  *  Both fields are OPTIONAL, and each absence means one thing. No `rows`: the scorer that produced
  *  this score supplied none (core rank.ts's `WithheldCandidate` types it optional for exactly
@@ -644,8 +643,7 @@ export async function runCli(
           }
           lastTick = now;
           // Same renderer as the `[score]` table, `(match)` included: a reader watching a
-          // six-figure fan wants "the best so far is already a match" from this line, and a score
-          // spelled one way here and another there is what this item exists to stop.
+          // six-figure fan wants "the best so far is already a match" from this line.
           const best = bestSoFar === undefined ? '' : `, best so far ${scoreOf(bestSoFar)}`;
           progressSink(`asmlift: [progress] ${doneN}/${total} candidates scored${best}\n`);
         }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -174,17 +174,6 @@ export interface ObjInput {
   asmData: typeof asmDataForObject;
 }
 
-export interface CliResult {
-  code: number;
-  stdout: string;
-  stderr: string;
-}
-
-/** Everything a ranked run writes to stderr, in the order a reader reads it.
- *
- *  A TIMING VALUE, never a timing call: `phaseReport` and `stamp` are computed by the caller at
- *  the moment the run ended, because both measure the run and neither may be re-measured by the
- *  act of rendering it. */
 /** One candidate's score as `<score>/<rows>` — the numerator over the denominator it was measured
  *  against, on both the `[score]` table and the `[ranked]` line readers are told to quote.
  *
@@ -199,6 +188,26 @@ export function scoreOf(s: { score: number; rows: number; match: boolean }): str
   return `${s.score}/${s.rows}${s.match ? ' (match)' : ''}`;
 }
 
+/** A WITHHELD candidate's score, in the same `<score>/<rows>` shape as a published one. Its
+ *  numerator is read across runs exactly like the `[score]` table's — a withheld sibling's score
+ *  is the evidence that a proof-gated spelling was close — so it must not be the one line in this
+ *  log that invites a subtraction on a fixed scale. `rows` is optional at the type level
+ *  (core rank.ts `WithheldCandidate`) because the scorer that produced it need not supply one;
+ *  absent, the numerator prints alone rather than against an invented denominator. */
+const withheldScore = (w: { score: number; rows?: number }): string =>
+  w.rows === undefined ? String(w.score) : `${w.score}/${w.rows}`;
+
+export interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Everything a ranked run writes to stderr, in the order a reader reads it.
+ *
+ *  A TIMING VALUE, never a timing call: `phaseReport` and `stamp` are computed by the caller at
+ *  the moment the run ended, because both measure the run and neither may be re-measured by the
+ *  act of rendering it. */
 function rankedStderr(a: {
   targetTrace: string;
   warn: string;
@@ -230,7 +239,7 @@ function rankedStderr(a: {
   // them out entirely would make `candidates scored` under-count the fan with no trace.
   const held = ranked.withheld.length
     ? `asmlift: [withheld] ${ranked.withheld.length} candidate(s) scored but unpublishable; first: ` +
-      `${ranked.withheld[0].label} at ${ranked.withheld[0].score}: ${ranked.withheld[0].why}\n`
+      `${ranked.withheld[0].label} at ${withheldScore(ranked.withheld[0])}: ${ranked.withheld[0].why}\n`
     : '';
   // THE ASSUMPTIONS THE SCORE RESTS ON. A candidate names globals the asm's own literal pool
   // named, and where no symbol map knows them asmlift synthesizes their declarations — width
@@ -628,13 +637,13 @@ export async function runCli(
   let lastTick = 0;
   const onProgress =
     flags.has('progress') && progressSink
-      ? (doneN: number, total: number, bestSoFar: number | undefined) => {
+      ? (doneN: number, total: number, bestSoFar: { score: number; rows: number } | undefined) => {
           const now = Date.now();
           if (doneN < total && now - lastTick < 5000) {
             return;
           }
           lastTick = now;
-          const best = bestSoFar === undefined ? '' : `, best so far ${bestSoFar}`;
+          const best = bestSoFar === undefined ? '' : `, best so far ${bestSoFar.score}/${bestSoFar.rows}`;
           progressSink(`asmlift: [progress] ${doneN}/${total} candidates scored${best}\n`);
         }
       : undefined;

--- a/packages/cli/src/rank.ts
+++ b/packages/cli/src/rank.ts
@@ -37,9 +37,13 @@ export interface RankOptions {
   /** a project's own toolchain — overrides the compiler registry */
   compile?: CandidateCompiler;
   /** Liveness only, never a measurement: called once per candidate as it is scored, carrying the
-   *  best score seen SO FAR — the whole `MatchScore`, not its numerator, because the denominator
-   *  belongs to that candidate's alignment and two candidates' numerators are not on one scale.
-   *  The ranking below is what decides the winner. */
+   *  best score seen SO FAR — the whole `MatchScore`, not its numerator, so the line can PRINT the
+   *  denominator that numerator was measured against. This is not a claim that the ranking is
+   *  wrong to compare bare numerators: core rank.ts's `compareScored` ranks one target's candidates
+   *  by `score` alone and that is right — every candidate is scored against the same target, and
+   *  fewer differing rows is a better candidate whatever the alignment length. What is not a
+   *  subtraction is TWO RUNS' scores, where the winner and therefore the alignment changed
+   *  underneath (290/404 → 171/387). The ranking below is what decides the winner. */
   onProgress?: (done: number, total: number, bestSoFar: MatchScore | undefined) => void;
   /** Where this run's phase timings accumulate (phase.ts). Absent = no timing taken. The serial
    *  driver can only separate the compile from the score when `compile` is supplied; reached

--- a/packages/cli/src/rank.ts
+++ b/packages/cli/src/rank.ts
@@ -38,12 +38,9 @@ export interface RankOptions {
   compile?: CandidateCompiler;
   /** Liveness only, never a measurement: called once per candidate as it is scored, carrying the
    *  best score seen SO FAR — the whole `MatchScore`, not its numerator, so the line can PRINT the
-   *  denominator that numerator was measured against. This is not a claim that the ranking is
-   *  wrong to compare bare numerators: core rank.ts's `compareScored` ranks one target's candidates
-   *  by `score` alone and that is right — every candidate is scored against the same target, and
-   *  fewer differing rows is a better candidate whatever the alignment length. What is not a
-   *  subtraction is TWO RUNS' scores, where the winner and therefore the alignment changed
-   *  underneath (290/404 → 171/387). The ranking below is what decides the winner. */
+   *  denominator that numerator was measured against. Ranking itself compares bare numerators and
+   *  is right to: every candidate here is scored against the same target, so fewer differing rows
+   *  is a better candidate whatever the alignment length. The ranking below decides the winner. */
   onProgress?: (done: number, total: number, bestSoFar: MatchScore | undefined) => void;
   /** Where this run's phase timings accumulate (phase.ts). Absent = no timing taken. The serial
    *  driver can only separate the compile from the score when `compile` is supplied; reached

--- a/packages/cli/src/rank.ts
+++ b/packages/cli/src/rank.ts
@@ -37,8 +37,10 @@ export interface RankOptions {
   /** a project's own toolchain — overrides the compiler registry */
   compile?: CandidateCompiler;
   /** Liveness only, never a measurement: called once per candidate as it is scored, carrying the
-   *  lowest score seen SO FAR. The ranking below is what decides the winner. */
-  onProgress?: (done: number, total: number, bestSoFar: number | undefined) => void;
+   *  best score seen SO FAR — the whole `MatchScore`, not its numerator, because the denominator
+   *  belongs to that candidate's alignment and two candidates' numerators are not on one scale.
+   *  The ranking below is what decides the winner. */
+  onProgress?: (done: number, total: number, bestSoFar: MatchScore | undefined) => void;
   /** Where this run's phase timings accumulate (phase.ts). Absent = no timing taken. The serial
    *  driver can only separate the compile from the score when `compile` is supplied; reached
    *  through the registry instead, the compile is charged to `score`. */
@@ -114,13 +116,13 @@ export function decompileRanked(
           timed(opts.clock, 'compile', () => opts.compile!(source, symbol, backendId, declarations))
       : opts.compile;
   let done = 0;
-  let best: number | undefined;
+  let best: MatchScore | undefined;
   return rankBy(candidates, name, (source, symbol, cand) => {
     try {
       const s = timed(opts.clock, 'score', () =>
         scoreSource(source, symbol, targetObj, target, backend.id, compile, declarationsOf(cand)),
       );
-      best = best === undefined || s.score < best ? s.score : best;
+      best = best === undefined || s.score < best.score ? s : best;
       return s;
     } finally {
       // a candidate the scorer REFUSED still counts as processed: progress must not stall on a
@@ -167,7 +169,7 @@ export async function decompileRankedParallel(
   const scored = new Map<string, MatchScore | Error>();
   let next = 0;
   let done = 0;
-  let best: number | undefined;
+  let best: MatchScore | undefined;
   await Promise.all(
     Array.from({ length: Math.max(1, opts.jobs) }, async () => {
       const compile = opts.worker();
@@ -183,7 +185,7 @@ export async function decompileRankedParallel(
             compile(cand.source, name, backend.id, declarationsOf(cand)),
           );
           result = timed(clock, 'score', () => scoreObjects(targetObj, obj, name));
-          best = best === undefined || result.score < best ? result.score : best;
+          best = best === undefined || result.score < best.score ? result : best;
         } catch (e) {
           // recorded, not thrown: `rankBy` below is what decides whether a refused candidate is
           // survivable (a sibling scored) or fatal (every one failed)

--- a/packages/cli/test/offline/cli.test.ts
+++ b/packages/cli/test/offline/cli.test.ts
@@ -248,3 +248,17 @@ test('a score is rendered over the row count it was measured against', () => {
 test('a match still says so, and still shows the scale it matched on', () => {
   expect(scoreOf({ score: 0, rows: 387, match: true })).toBe('0/387 (match)');
 });
+
+// ONE RENDERER FOR ALL FOUR LINES. `scoreOf` also spells the `[withheld]` and `[progress]` scores,
+// which were two separate renderings in the same file — the divergence this shape exists to stop.
+// A withheld candidate's `rows` is optional at the type level (core `WithheldCandidate`) because
+// the scorer that produced it need not supply one, and `match` is absent there entirely.
+test('an absent row count prints the numerator alone, never against an invented scale', () => {
+  expect(scoreOf({ score: 35 })).toBe('35');
+  expect(scoreOf({ score: 35, rows: 47 })).toBe('35/47');
+});
+
+test('nothing is claimed about matching when the caller does not know', () => {
+  expect(scoreOf({ score: 0, rows: 47 })).toBe('0/47');
+  expect(scoreOf({ score: 0, rows: 47, match: false })).toBe('0/47');
+});

--- a/packages/cli/test/offline/cli.test.ts
+++ b/packages/cli/test/offline/cli.test.ts
@@ -236,10 +236,8 @@ test('a DERIVED shape the source never spells prints no `[assumed]` line either'
 // candidate, not of the target: a different spelling aligns differently and is scored against a
 // different scale. `docs/ranked-repro.md` makes two runs' `[score]` lines the project's standard
 // before/after comparison and `/match-function` makes the `[ranked]` line the number every claim
-// is measured against — printed as a bare numerator, both read as a subtraction on a fixed scale.
-// They are not: `kleod:CountCollectedGems:agbcc` went 290/404 → 171/387 across two committed
-// artifacts, 17 of those 119 points being the scale, and an attribution round was spent on the
-// difference.
+// is measured against — printed as a bare numerator, both read as a subtraction on a fixed scale
+// that in fact moved (290/404 → 171/387 on one row of two committed artifacts).
 test('a score is rendered over the row count it was measured against', () => {
   expect(scoreOf({ score: 290, rows: 404, match: false })).toBe('290/404');
   expect(scoreOf({ score: 171, rows: 387, match: false })).toBe('171/387');
@@ -249,8 +247,7 @@ test('a match still says so, and still shows the scale it matched on', () => {
   expect(scoreOf({ score: 0, rows: 387, match: true })).toBe('0/387 (match)');
 });
 
-// ONE RENDERER FOR ALL FOUR LINES. `scoreOf` also spells the `[withheld]` and `[progress]` scores,
-// which were two separate renderings in the same file — the divergence this shape exists to stop.
+// ONE RENDERER FOR ALL FOUR LINES: `scoreOf` also spells the `[withheld]` and `[progress]` scores.
 // A withheld candidate's `rows` is optional at the type level (core `WithheldCandidate`) because
 // the scorer that produced it need not supply one, and `match` is absent there entirely.
 test('an absent row count prints the numerator alone, never against an invented scale', () => {

--- a/packages/cli/test/offline/cli.test.ts
+++ b/packages/cli/test/offline/cli.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'vitest';
 
-import { detectName, runCli } from '../../src/main';
+import { detectName, runCli, scoreOf } from '../../src/main';
 
 const corpus = (f: string) => readFileSync(join(import.meta.dirname, '../../../core/test/corpus', f), 'utf8');
 const run = (file: string, ...flags: string[]) => runCli([file, ...flags], corpus);
@@ -228,4 +228,23 @@ test('a DERIVED shape the source never spells prints no `[assumed]` line either'
   expect(r.code).toBe(0);
   expect(r.stdout).toContain('((struct Elem0 *)&gBgInfo)[a0].field_0');
   expect(r.stderr).not.toContain('[assumed]');
+});
+
+// THE `[score]`/`[ranked]` LINES CARRY THEIR DENOMINATOR.
+//
+// `rows` is objdiff's total row count for THIS candidate's alignment, so it is a property of the
+// candidate, not of the target: a different spelling aligns differently and is scored against a
+// different scale. `docs/ranked-repro.md` makes two runs' `[score]` lines the project's standard
+// before/after comparison and `/match-function` makes the `[ranked]` line the number every claim
+// is measured against — printed as a bare numerator, both read as a subtraction on a fixed scale.
+// They are not: `kleod:CountCollectedGems:agbcc` went 290/404 → 171/387 across two committed
+// artifacts, 17 of those 119 points being the scale, and an attribution round was spent on the
+// difference.
+test('a score is rendered over the row count it was measured against', () => {
+  expect(scoreOf({ score: 290, rows: 404, match: false })).toBe('290/404');
+  expect(scoreOf({ score: 171, rows: 387, match: false })).toBe('171/387');
+});
+
+test('a match still says so, and still shows the scale it matched on', () => {
+  expect(scoreOf({ score: 0, rows: 387, match: true })).toBe('0/387 (match)');
 });

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -229,6 +229,13 @@ export interface DroppedCandidate {
 export interface WithheldCandidate {
   label: string;
   score: number;
+  /** the denominator that score was measured against — objdiff's row count for THIS candidate's
+   *  alignment, so it moves with the spelling. Present whenever the injected scorer supplies one
+   *  (the cli and webapp objdiff scorers both do); a scorer whose result carries no `rows` leaves
+   *  it absent rather than inventing a scale. A withheld score is compared across runs exactly
+   *  like a published one, and a bare numerator invites the subtraction on a fixed scale that
+   *  `kleod:CountCollectedGems:agbcc` (290/404 → 171/387) cost an attribution round. */
+  rows?: number;
   /** one line: why publication needed a proof this score did not supply */
   why: string;
 }
@@ -1873,7 +1880,7 @@ export function enumerateCandidates(
  *  the scorer must be sync (the cli/Node objdiff path). The webapp scores asynchronously and does
  *  its own await-loop over `enumerateCandidates`, reusing this module's `Candidate`/`RankedResult`
  *  types but not this driver. */
-export function rankBy<S extends { score: number }>(
+export function rankBy<S extends { score: number; rows?: number }>(
   candidates: Candidate[],
   symbol: string,
   scoreFn: (source: string, symbol: string, candidate: Candidate) => S,
@@ -1887,7 +1894,12 @@ export function rankBy<S extends { score: number }>(
       const score = scoreFn(c.source, symbol, c);
       const why = withheldReason(c, score);
       if (why !== null) {
-        withheld.push({ label: c.label, score: score.score, why });
+        withheld.push({
+          label: c.label,
+          score: score.score,
+          ...(score.rows === undefined ? {} : { rows: score.rows }),
+          why,
+        });
         return;
       }
       results.push({ ...c, order, score });

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -232,9 +232,8 @@ export interface WithheldCandidate {
   /** the denominator that score was measured against — objdiff's row count for THIS candidate's
    *  alignment, so it moves with the spelling. Present whenever the injected scorer supplies one
    *  (the cli and webapp objdiff scorers both do); a scorer whose result carries no `rows` leaves
-   *  it absent rather than inventing a scale. A withheld score is compared across runs exactly
-   *  like a published one, and a bare numerator invites the subtraction on a fixed scale that
-   *  `kleod:CountCollectedGems:agbcc` (290/404 → 171/387) cost an attribution round. */
+   *  it absent rather than inventing a scale. A withheld score is read across runs exactly like a
+   *  published one, and a bare numerator there invites the same subtraction on a scale that moved. */
   rows?: number;
   /** one line: why publication needed a proof this score did not supply */
   why: string;

--- a/packages/core/test/array-rank-guards.test.ts
+++ b/packages/core/test/array-rank-guards.test.ts
@@ -188,6 +188,19 @@ describe('the PUBLICATION rule for a proof-gated spelling (rank.ts withheldReaso
     expect(won.withheld).toEqual([]);
   });
 
+  // A withheld candidate's score is read across runs exactly like a published one, so it carries
+  // the denominator it was measured against — the objdiff row count of THAT spelling's alignment.
+  // A scorer that supplies no `rows` leaves it absent rather than borrowing a scale.
+  test('a withheld candidate carries the denominator its score was measured against', () => {
+    const withRows = rankBy([plain, proofed], 'f', (source) =>
+      source === 'b;' ? { score: 5, rows: 38 } : { score: 40, rows: 64 },
+    );
+    expect(withRows.withheld).toEqual([{ label: 'unsigned/unreduce', score: 5, rows: 38, why: expect.any(String) }]);
+
+    const noRows = rankBy([plain, proofed], 'f', (source) => ({ score: source === 'b;' ? 5 : 40 }));
+    expect(noRows.withheld[0]).not.toHaveProperty('rows');
+  });
+
   test('an all-withheld list fails LOUD and says so, rather than reading as a scorer failure', () => {
     expect(() => rankBy([proofed], 'f', () => ({ score: 7 }))).toThrow(/1 candidate\(s\) withheld/);
   });


### PR DESCRIPTION
## What this is

Every score this project prints was a bare numerator. `maxScore` — the denominator — was already in
the schema and already rendered by the web report, but the run line, `bench diff`, the CLI's
`[score]`/`[ranked]`/`[withheld]`/`[progress]` lines and the neutrality gate all dropped it. This
branch makes every one of them print `<score>/<rows>`, puts `maxScore` in the gate's watched fields,
and tells the two attribution briefs why a residual is never a partition.

## The premise, verified rather than assumed

`maxScore` is objdiff's row count for the **winning candidate's** alignment, so it is a property of
the candidate, not of the target — a different spelling wins, a different scale is used. Re-derived
independently by four agents from the committed artifacts at `eb6dec7d` and `2fed1e42` (1013
comparable rows):

| | |
|---|---|
| `kleod:CountCollectedGems:agbcc` | **290/404 → 171/387** |
| `kleod:CheckWorldCompletion:agbcc` | 123/208 → 61/194 |
| rows whose denominator moved | **14** (12 asmlift, 2 m2c) |
| of those, ones that moved `maxScore` *without* `score` | **0** |

So the CCG round's headline "119 points" contained **17 points of scale**. That row's residual was
then decomposed into six gaps said to *partition the 290*; the gaps predicted 297 points, delivered
119, and cost an extra attribution round explaining a shortfall that was partly the denominator.
The discard condition for this item — "`maxScore` is fixed per row" — is **falsified at 14 rows**.

## What we verified of the premise, and what we found false

- **CONFIRMED**: the denominator moves, on 14 rows across one artifact pair and 22 across thirteen
  consecutive pairs.
- **FALSE, and corrected in the code**: the first draft said "twelve rows moved their denominator"
  in five places. The gate prints **14** lines — `maxScore` is watched on both sides, and
  `synthetic:sw_jtfall:mwcc_242_81` and `synthetic:sw_jtfalldesc:mwcc_242_81` moved theirs on the
  m2c side. Fixed everywhere.
- **FALSE**: an early commit message and brief edit said the `maxScore` line fires "when the
  denominator moves *on its own*". Measured: all 14 moves printed **both** a `score` and a
  `maxScore` line. A `maxScore` line is never evidence that the score held still. The briefs now say
  "whenever the denominator moves, alone or beside a moving score"; commit `1db082a2`'s subject
  still carries the old phrasing and was not rewritten.
- **FALSE**: a doc note claimed the change voids `docs/ranked-repro.md`'s recorded **stdout** md5s.
  It does not — every score the CLI prints goes to stderr; the generated C is byte-untouched. Only
  the `[score]` md5s are affected, and their line *counts* still compare.
- **FALSE**: the FIELDS docstring justified excluding `symbolsUsed` as "size". Measured at most
  **1,108 chars** on any row — smaller than fields the same list admits *because* they are small.
  The real reason (it is derived from the winner that `source`/`candidateLabel` already name, and it
  moved on 0 rows) is now what the docstring says.
- **FALSE**: a comment claimed `fmt` and `show` degrade on the same predicate. They agree on an
  absent key and disagree on a null one. Claim dropped.

## Commits

- `544a0e34` Print a gap's denominator beside its score on the bench run row line
- `1db082a2` Show a score's denominator in bench diff, and name it when it moves alone
- `8000280a` Carry the row count on the CLI's `[score]` table and `[ranked]` line
- `38495270` Tell the attribution brief that a residual is never a partition
- `acdff6b2` Give every score line in the log a denominator, not just the two that were fixed
- `3018c525` Stop the neutrality gate teaching that a published field does not count
- `fc124f2f` Update the format examples readers are told to copy
- `1d31b0ef` Watch the published fields the neutrality gate was leaving out
- `60a72882` Render every score through one renderer, not five
- `74a0aaaf` Point the briefs at the watched field list instead of a stale copy of it
- `13eeb96b` Correct the field list's account of what it leaves out, and why
- `1a22214e` Regenerate the benchmark artifact on this branch

## The gate got stricter, deliberately

`report/diff.ts`'s `FIELDS` went from

```
asmlift: outcome, score, candidateLabel, source, quality
m2c:     outcome, score, source, quality
```

to those plus `maxScore`, `compileErrors`, `errorMarkers`, `breakdown` and the **counts** of
`droppedCandidates` / `withheldCandidates`. Each admission is measured, not asserted:

- `compileErrors` — published as `noncompile(k)` and `compile errors {n}`. Cost over the pair: **0 lines**.
- `errorMarkers` — the run line's `declined(k gap(s))` and the web's whole declined/failed taxonomy
  column derive from it, and `cache.ts`'s `v17:` note records an incident this repo already paid for
  *because* it was outside `FIELDS.m2c`. Cost: **2 lines, 0 unique rows**. Compared and rendered
  **scrubbed**, like `source`, so a cold run's re-minted scratch paths are not a false line.
- `breakdown` — the web detail view renders its five numbers. 17 lines, 0 unique rows.
- The dropped **count** — not cosmetic: it moves on 2 rows
  (`kleod:ProcessInputAndUpdateEntities:agbcc` 41472→51840, `kleod:UpdateHUDCounterDisplay:agbcc`
  84→105) that **no other watched field moves on**. Identical source, identical score, identical
  label, a fan that demonstrably changed, and a gate that answered "nothing moved". The raw list is
  51,840 entries on one row, so the count is what is watched — the rule the docstring now states is
  "every published claim small enough to print, and the published count for the rest", replacing a
  universal "every field the report shows" that the same file falsified.

`bench diff` is in neither CI workflow, so a stricter `FIELDS` cannot newly fail CI; it only reaches
a human running the gate.

## Bench: yes, needed, and run

The diff touches three measured paths (`packages/core/src`, `packages/cli/src`,
`apps/benchmark/src`), so a full run was owed regardless of the change being rendering-only.

- `pnpm bench run` → **✓ synthetic: 783 results in 344.1s** · **✓ real: 252 results in 4753.8s** ·
  0 SKIPs · exit 0.
- `pnpm bench regression --base origin/main` → **0 lost, 0 missing, 0 gained, 0 other flips** (1035
  committed rows).
- `pnpm bench diff --base origin/main` → **0 field change(s), 0 added, 0 removed** (1035 base rows,
  1035 fresh rows) — and this zero is over the *widened* list above, so it is strictly stronger than
  the zero the old five-field gate would have produced.
- `scripts/check-artifact-provenance.sh origin/main` → **OK — no commit after `13eeb96` touches what
  the artifact measures**.

**Moved-row inventory: none.** Match totals unmoved at asmlift 598 / m2c 412. The regenerated 24 MB
artifact is byte-identical to the base's apart from the provenance stamp and four `"rows": 47`
entries on `synthetic:dmaptrsrc:agbcc`'s `withheldCandidates` — the additive optional schema field
this branch adds. It is in no watched list, so the gate is correctly silent on it.

## Two visible changes a reader should expect

- `[progress]`'s `best so far` now carries `(match)` when the best candidate so far is byte-exact —
  a consequence of routing all four CLI score lines through one renderer, kept deliberately rather
  than suppressing the suffix on one of the four.
- **A published type changed shape.** `packages/cli/package.json` exports `"./*"`, so
  `@asmlift/cli/rank` is public: `RankOptions.onProgress`'s third argument went
  `number | undefined` → `MatchScore | undefined`. No in-repo caller is affected; asmlift has no
  changesets, so this is the note.

## Reviewer findings declined, with reasons

- **Suppress the standalone `maxScore` line when the `score` line already renders both
  denominators.** Declined. The entry is what makes a denominator-only move flunk `report.ok`, and
  that case (winner changes, score ties) is real even though it has occurred 0 times in 22 moves
  across 13 artifact pairs. Recorded in the docstring with the strong number (0 unique rows, not the
  weaker "1.19×" a first pass used) so the next reviewer does not re-litigate it.
- **A shape-renderer for `errorMarkers` in `show`.** Not needed, measured: the longest rendered field
  line over the pair is 191 chars and the field caps at 491. Scrubbing was added instead, which is
  the real hazard.
- **`apps/web`'s `RankPanel.tsx:112` bare `objdiff score`.** Playground, not a surface the
  attribution chain reads, and the panel already renders `{matching}/{rows}` per candidate. The
  report's own two renderers (`Explorer.tsx`, `FunctionDetail.tsx`) *were* fixed, because those are
  the report.
- **`docs/lbg-attribution.md:19`'s bare `best so far 683` and `docs/ranked-repro.md`'s recorded
  runs.** Quoted historical output, left as printed and covered by a parenthetical.
- **A live end-to-end firing of the `[withheld]` line.** Not achieved — constructing a `matchOnly`
  candidate that scores non-zero through the CLI needs a device-register target. Stated as
  unit-verified on the exact artifact shape (`{score: 35, rows: 47}` → `35/47`), not run-verified;
  the artifact regenerated in this PR now carries that shape for real.
- **`pnpm bench smoke`'s `gcc2.7.2` failure.** A/B'd against the unmodified branch state and
  reproduces identically — environmental and pre-existing, not this branch's.

## Gate counts

`npx vitest run` → **211 files, 3680 passed / 2 skipped** · `pnpm test:matching` → **41 files, 359
passed / 0 skipped** (run explicitly; CI structurally cannot) · `pnpm exec vitest run
apps/benchmark/test` → **31 files, 759 passed / 2 skipped** · `pnpm typecheck` clean · `pnpm lint`
**0 errors / 126 warnings** (the pre-existing count) · `pnpm format` clean.

## What this does NOT do

It changes no measurement, no candidate, no ranking and no winner — ranking still compares bare
numerators and is right to, since every candidate in one run is scored against the same target. It
does not add a subcommand, a flag, a file or a pass. It does not fix `symbolsUsed`'s exclusion from
the gate, and it does not chase the finding it surfaced on the way: **asmlift and m2c score the same
row against different denominators** (`synthetic:nestacc1:agbcc` is `asmlift=diff:15/38
m2c=diff:18/39`), so every per-row asmlift-vs-m2c comparison in the corpus was made on numerators
alone. That is now visible in the run line and wants its own round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
