### PR TITLE
Check the tree and the host cpp before a bench run, not 39 minutes after

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -177,21 +177,20 @@ attribution line for every decline naming its first blocker. Constraints learned
    `pnpm bench regression --base origin/main`. **Regression without a preceding run+merge compares
    stale results and is vacuous** — the order is the gate; and without `--base`, a branch that has
    already committed its own artifact compares it against itself, which is vacuous the other way.
-   The commit-first order is now ENFORCED: `pnpm bench run` refuses to start on a tree whose code
+   The commit-first order is ENFORCED: `pnpm bench run` refuses to start on a tree whose code
    differs from HEAD, naming the files, because `bench:merge` refuses those numbers anyway ~39
    minutes later — and twice that refusal was a single untracked env file. Put anything a worktree
    needs locally (env exports, PATH overrides) in **`.envrc.local`**, gitignored for exactly this —
    nothing loads it, so `source .envrc.local` yourself — and anything else under **`.local/`**,
    gitignored too. `$(git rev-parse --git-path info/exclude)` is the last resort, for a path you
-   cannot move: from a worktree it is the MAIN checkout's file, shared with every other worktree and
-   never pruned (113 lines, 40 of them one repeated pattern), so add ONE line and `grep` for it
-   first. Never reach for a way around the refusal. What is exempt is a run that rewrites no tier file WHOLE — the Phase-6 smoke runs carry
+   cannot move: from a worktree it is the MAIN checkout's file, shared with every other worktree
+   and never pruned, so add ONE line and `grep` for it first. Never reach for a way around the
+   refusal. Exempt is a run that rewrites no tier file WHOLE — the Phase-6 smoke runs carry
    `--only`, which scopes both tiers. `--project` alone scopes only real and `--toolchain` alone
    only synthetic, so pair either with its `--tier` or the other tier is run whole and refused. A
-   scoped run is not read-only either: it rewrites `results/<tier>.json` with only its own rows. The
-   `cpp` probe is on a DIFFERENT axis and this exemption does NOT cover it: **every run that touches
-   the real tier is probed, `--only` included** — that is where the trap bites (measured: one row,
-   `diff:27/32` under the GNU shim, `noncompile(1)` under Apple clang, exit 0 both times). A refusal
+   scoped run is not read-only either: it rewrites `results/<tier>.json` with only its own rows.
+   The `cpp` probe is on a DIFFERENT axis and this exemption does NOT cover it: **every run that
+   touches the real tier is probed, `--only` included** — that is where TRAP 6 bites. A refusal
    there means your shell resolved `cpp` to Apple clang, which a LOGIN shell does; a WARNING means
    no MIPS toolchain is installed, so those rows would SKIP. A synthetic-only run is never probed —
    no synthetic row preprocesses. **So a real-tier `noncompile` you see in Phase 6 is a real

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -178,13 +178,19 @@ attribution line for every decline naming its first blocker. Constraints learned
    stale results and is vacuous** — the order is the gate; and without `--base`, a branch that has
    already committed its own artifact compares it against itself, which is vacuous the other way.
    The commit-first order is now ENFORCED: `pnpm bench run` refuses to start on a tree whose code
-   differs from HEAD, naming the files, because `bench:merge` refuses those numbers anyway 30
+   differs from HEAD, naming the files, because `bench:merge` refuses those numbers anyway ~39
    minutes later — and twice that refusal was a single untracked env file. Put anything a worktree
-   needs locally (env exports, PATH overrides) in **`.envrc.local`**, gitignored for exactly this,
-   or in `$(git rev-parse --git-path info/exclude)`; never reach for a way around the refusal. The
-   smoke runs in Phase 6 are scoped (`--only`/`--toolchain`) and are never refused. The same
-   preflight probes `cpp` — a refusal there means your shell resolved it to Apple clang, which a
-   LOGIN shell does, and the run would have failed 44 rows while reporting `✓` and exit 0.
+   needs locally (env exports, PATH overrides) in **`.envrc.local`**, gitignored for exactly this —
+   nothing loads it, so `source .envrc.local` yourself — or in
+   `$(git rev-parse --git-path info/exclude)` (from a worktree that is the MAIN checkout's file,
+   shared with every other worktree: add, never overwrite); never reach for a way around the
+   refusal. What is exempt is a run that rewrites no tier file WHOLE — the Phase-6 smoke runs carry
+   `--only`, which scopes both tiers. `--project` alone scopes only real and `--toolchain` alone
+   only synthetic, so pair either with its `--tier` or the other tier is run whole and refused. A
+   scoped run is not read-only either: it rewrites `results/<tier>.json` with only its own rows. The
+   same preflight probes `cpp` — a refusal there means your shell resolved it to Apple clang, which
+   a LOGIN shell does, and the run would have failed 44 rows while reporting `✓` and exit 0 (a
+   WARNING instead of a refusal means no MIPS toolchain is installed, so those rows would SKIP).
 2. Expect the two tag-vocabulary tests to fail BETWEEN adding the tag and merging the artifacts;
    they must pass after. `npx vitest run`, `pnpm test:matching`, `pnpm typecheck`,
    `pnpm lint`, `pnpm format` check.

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -181,16 +181,21 @@ attribution line for every decline naming its first blocker. Constraints learned
    differs from HEAD, naming the files, because `bench:merge` refuses those numbers anyway ~39
    minutes later — and twice that refusal was a single untracked env file. Put anything a worktree
    needs locally (env exports, PATH overrides) in **`.envrc.local`**, gitignored for exactly this —
-   nothing loads it, so `source .envrc.local` yourself — or in
-   `$(git rev-parse --git-path info/exclude)` (from a worktree that is the MAIN checkout's file,
-   shared with every other worktree: add, never overwrite); never reach for a way around the
-   refusal. What is exempt is a run that rewrites no tier file WHOLE — the Phase-6 smoke runs carry
+   nothing loads it, so `source .envrc.local` yourself — and anything else under **`.local/`**,
+   gitignored too. `$(git rev-parse --git-path info/exclude)` is the last resort, for a path you
+   cannot move: from a worktree it is the MAIN checkout's file, shared with every other worktree and
+   never pruned (113 lines, 40 of them one repeated pattern), so add ONE line and `grep` for it
+   first. Never reach for a way around the refusal. What is exempt is a run that rewrites no tier file WHOLE — the Phase-6 smoke runs carry
    `--only`, which scopes both tiers. `--project` alone scopes only real and `--toolchain` alone
    only synthetic, so pair either with its `--tier` or the other tier is run whole and refused. A
    scoped run is not read-only either: it rewrites `results/<tier>.json` with only its own rows. The
-   same preflight probes `cpp` — a refusal there means your shell resolved it to Apple clang, which
-   a LOGIN shell does, and the run would have failed 44 rows while reporting `✓` and exit 0 (a
-   WARNING instead of a refusal means no MIPS toolchain is installed, so those rows would SKIP).
+   `cpp` probe is on a DIFFERENT axis and this exemption does NOT cover it: **every run that touches
+   the real tier is probed, `--only` included** — that is where the trap bites (measured: one row,
+   `diff:27/32` under the GNU shim, `noncompile(1)` under Apple clang, exit 0 both times). A refusal
+   there means your shell resolved `cpp` to Apple clang, which a LOGIN shell does; a WARNING means
+   no MIPS toolchain is installed, so those rows would SKIP. A synthetic-only run is never probed —
+   no synthetic row preprocesses. **So a real-tier `noncompile` you see in Phase 6 is a real
+   attribution signal, not your shell: the preflight has already ruled that out.**
 2. Expect the two tag-vocabulary tests to fail BETWEEN adding the tag and merging the artifacts;
    they must pass after. `npx vitest run`, `pnpm test:matching`, `pnpm typecheck`,
    `pnpm lint`, `pnpm format` check.

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -177,6 +177,14 @@ attribution line for every decline naming its first blocker. Constraints learned
    `pnpm bench regression --base origin/main`. **Regression without a preceding run+merge compares
    stale results and is vacuous** — the order is the gate; and without `--base`, a branch that has
    already committed its own artifact compares it against itself, which is vacuous the other way.
+   The commit-first order is now ENFORCED: `pnpm bench run` refuses to start on a tree whose code
+   differs from HEAD, naming the files, because `bench:merge` refuses those numbers anyway 30
+   minutes later — and twice that refusal was a single untracked env file. Put anything a worktree
+   needs locally (env exports, PATH overrides) in **`.envrc.local`**, gitignored for exactly this,
+   or in `$(git rev-parse --git-path info/exclude)`; never reach for a way around the refusal. The
+   smoke runs in Phase 6 are scoped (`--only`/`--toolchain`) and are never refused. The same
+   preflight probes `cpp` — a refusal there means your shell resolved it to Apple clang, which a
+   LOGIN shell does, and the run would have failed 44 rows while reporting `✓` and exit 0.
 2. Expect the two tag-vocabulary tests to fail BETWEEN adding the tag and merging the artifacts;
    they must pass after. `npx vitest run`, `pnpm test:matching`, `pnpm typecheck`,
    `pnpm lint`, `pnpm format` check.

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -91,6 +91,15 @@ Per commit:
 
 ## Phase 4 — Full-bench zero-flip gate
 
+`pnpm bench run` now REFUSES to start when the tree's code differs from HEAD, naming the files —
+because `pnpm bench:merge` refuses those numbers anyway, 30 minutes later, and twice that refusal
+was one untracked env file. Commit first. Anything local a worktree needs (env exports, PATH
+overrides) goes in **`.envrc.local`**, which is gitignored for exactly this; anything else local
+goes in `$(git rev-parse --git-path info/exclude)`. Scoped runs (`--only`/`--project`/
+`--toolchain`) are never refused — the dirty-tree dev loop of Phase 3 is untouched. The same
+preflight probes `cpp`: if it refuses there, your shell resolved `cpp` to Apple clang (a LOGIN
+shell does), and the run would have failed 44 rows while reporting `✓` and exit 0.
+
 Before declaring the branch done: `pnpm bench run` (all tiers), `pnpm bench:merge`, then
 `pnpm bench regression --base origin/main` and `pnpm bench diff --base origin/main`. **Any lost
 match blocks the branch.** Pass the base ref: both gates read the COMMITTED artifact, so on a

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -92,13 +92,22 @@ Per commit:
 ## Phase 4 — Full-bench zero-flip gate
 
 `pnpm bench run` now REFUSES to start when the tree's code differs from HEAD, naming the files —
-because `pnpm bench:merge` refuses those numbers anyway, 30 minutes later, and twice that refusal
+because `pnpm bench:merge` refuses those numbers anyway, ~39 minutes later, and twice that refusal
 was one untracked env file. Commit first. Anything local a worktree needs (env exports, PATH
-overrides) goes in **`.envrc.local`**, which is gitignored for exactly this; anything else local
-goes in `$(git rev-parse --git-path info/exclude)`. Scoped runs (`--only`/`--project`/
-`--toolchain`) are never refused — the dirty-tree dev loop of Phase 3 is untouched. The same
-preflight probes `cpp`: if it refuses there, your shell resolved `cpp` to Apple clang (a LOGIN
-shell does), and the run would have failed 44 rows while reporting `✓` and exit 0.
+overrides) goes in **`.envrc.local`**, which is gitignored for exactly this — but nothing loads it,
+so `source .envrc.local` yourself in the shell you run from; anything else local goes in
+`$(git rev-parse --git-path info/exclude)` (which from a worktree resolves to the MAIN checkout's
+file, shared with every other worktree — add, never overwrite).
+
+What is exempt is the run that rewrites no tier file WHOLE: `--only` scopes both tiers, so the
+Phase-3 dev loop is untouched, but `--project` scopes only the real tier and `--toolchain` only the
+synthetic one — pair those with `--tier real` / `--tier synthetic` or the other tier is still run
+whole and still refused. And note a scoped run is not read-only: it REWRITES
+`apps/benchmark/results/<tier>.json` with only the rows it selected (measured), so always run whole
+before `bench:merge`. The same preflight probes `cpp`: if it refuses there, your shell resolved
+`cpp` to Apple clang (a LOGIN shell does), and the run would have failed 44 rows while reporting
+`✓` and exit 0. If it only WARNS there, no MIPS toolchain is installed, so those rows were going to
+SKIP anyway.
 
 Before declaring the branch done: `pnpm bench run` (all tiers), `pnpm bench:merge`, then
 `pnpm bench regression --base origin/main` and `pnpm bench diff --base origin/main`. **Any lost

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -91,31 +91,29 @@ Per commit:
 
 ## Phase 4 — Full-bench zero-flip gate
 
-`pnpm bench run` now REFUSES to start when the tree's code differs from HEAD, naming the files —
-because `pnpm bench:merge` refuses those numbers anyway, ~39 minutes later, and twice that refusal
-was one untracked env file. Commit first. Anything local a worktree needs (env exports, PATH
-overrides) goes in **`.envrc.local`**, which is gitignored for exactly this — but nothing loads it,
-so `source .envrc.local` yourself in the shell you run from; anything else local goes under
+`pnpm bench run` REFUSES to start when the tree's code differs from HEAD, and names the files:
+`pnpm bench:merge` refuses those numbers anyway, ~39 minutes later, and twice that refusal was one
+untracked env file. Commit first. Anything local a worktree needs (env exports, PATH overrides)
+goes in **`.envrc.local`**, gitignored for exactly this — but nothing loads it, so
+`source .envrc.local` yourself in the shell you run from; anything else local goes under
 **`.local/`**, gitignored too. Reach for `$(git rev-parse --git-path info/exclude)` only for a path
 you cannot move: from a worktree it resolves to the MAIN checkout's file, shared with every other
-worktree and never pruned (it is at 113 lines, 40 of them one repeated pattern), so add ONE line and
-`grep` for it first.
+worktree and never pruned, so add ONE line and `grep` for it first.
 
-What is exempt is the run that rewrites no tier file WHOLE: `--only` scopes both tiers, so the
-Phase-3 dev loop is untouched, but `--project` scopes only the real tier and `--toolchain` only the
-synthetic one — pair those with `--tier real` / `--tier synthetic` or the other tier is still run
-whole and still refused. And note a scoped run is not read-only: it REWRITES
-`apps/benchmark/results/<tier>.json` with only the rows it selected (measured), so always run whole
-before `bench:merge`.
+Exempt is the run that rewrites no tier file WHOLE: `--only` scopes both tiers, so the Phase-3 dev
+loop is untouched, but `--project` scopes only the real tier and `--toolchain` only the synthetic
+one — pair those with `--tier real` / `--tier synthetic` or the other tier is still run whole and
+still refused. A scoped run is not read-only either: it REWRITES
+`apps/benchmark/results/<tier>.json` with only the rows it selected, so always run whole before
+`bench:merge`.
 
-The `cpp` probe is on a DIFFERENT axis and the scoping above does not exempt it: **every run that
-touches the real tier is probed, `--only` included**, because that is where TRAP 6 bites (measured:
-one row, `diff:27/32` under the GNU shim, `noncompile(1)` under Apple clang, exit 0 and no line
-naming `cpp` either time). If it refuses, your shell resolved `cpp` to Apple clang — a LOGIN shell
-does — and the run would have failed those rows while reporting `✓` and exit 0; if it only WARNS,
+The `cpp` probe is on a DIFFERENT axis and that scoping does not exempt it: **every run that
+touches the real tier is probed, `--only` included**, because the scoped loop is where TRAP 6
+bites. If it refuses, your shell resolved `cpp` to Apple clang — a LOGIN shell does — and the run
+would have failed every real ido/kmc/gcc272 row while reporting `✓` and exit 0; if it only WARNS,
 no MIPS toolchain is installed here, so those rows were going to SKIP anyway. A synthetic-only run
 is never probed: no synthetic row preprocesses with the host `cpp`. So a real-tier row that comes
-back `noncompile` was NOT your shell — the preflight already ruled that out.
+back `noncompile` is a real signal, not your shell — the preflight already ruled that out.
 
 Before declaring the branch done: `pnpm bench run` (all tiers), `pnpm bench:merge`, then
 `pnpm bench regression --base origin/main` and `pnpm bench diff --base origin/main`. **Any lost

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -95,19 +95,27 @@ Per commit:
 because `pnpm bench:merge` refuses those numbers anyway, ~39 minutes later, and twice that refusal
 was one untracked env file. Commit first. Anything local a worktree needs (env exports, PATH
 overrides) goes in **`.envrc.local`**, which is gitignored for exactly this — but nothing loads it,
-so `source .envrc.local` yourself in the shell you run from; anything else local goes in
-`$(git rev-parse --git-path info/exclude)` (which from a worktree resolves to the MAIN checkout's
-file, shared with every other worktree — add, never overwrite).
+so `source .envrc.local` yourself in the shell you run from; anything else local goes under
+**`.local/`**, gitignored too. Reach for `$(git rev-parse --git-path info/exclude)` only for a path
+you cannot move: from a worktree it resolves to the MAIN checkout's file, shared with every other
+worktree and never pruned (it is at 113 lines, 40 of them one repeated pattern), so add ONE line and
+`grep` for it first.
 
 What is exempt is the run that rewrites no tier file WHOLE: `--only` scopes both tiers, so the
 Phase-3 dev loop is untouched, but `--project` scopes only the real tier and `--toolchain` only the
 synthetic one — pair those with `--tier real` / `--tier synthetic` or the other tier is still run
 whole and still refused. And note a scoped run is not read-only: it REWRITES
 `apps/benchmark/results/<tier>.json` with only the rows it selected (measured), so always run whole
-before `bench:merge`. The same preflight probes `cpp`: if it refuses there, your shell resolved
-`cpp` to Apple clang (a LOGIN shell does), and the run would have failed 44 rows while reporting
-`✓` and exit 0. If it only WARNS there, no MIPS toolchain is installed, so those rows were going to
-SKIP anyway.
+before `bench:merge`.
+
+The `cpp` probe is on a DIFFERENT axis and the scoping above does not exempt it: **every run that
+touches the real tier is probed, `--only` included**, because that is where TRAP 6 bites (measured:
+one row, `diff:27/32` under the GNU shim, `noncompile(1)` under Apple clang, exit 0 and no line
+naming `cpp` either time). If it refuses, your shell resolved `cpp` to Apple clang — a LOGIN shell
+does — and the run would have failed those rows while reporting `✓` and exit 0; if it only WARNS,
+no MIPS toolchain is installed here, so those rows were going to SKIP anyway. A synthetic-only run
+is never probed: no synthetic row preprocesses with the host `cpp`. So a real-tier row that comes
+back `noncompile` was NOT your shell — the preflight already ruled that out.
 
 Before declaring the branch done: `pnpm bench run` (all tiers), `pnpm bench:merge`, then
 `pnpm bench regression --base origin/main` and `pnpm bench diff --base origin/main`. **Any lost

--- a/.gitignore
+++ b/.gitignore
@@ -33,15 +33,13 @@ _site/
 # local Claude Code state
 .claude/worktrees
 research/
-# the ONE sanctioned name for a per-worktree env/scratch file. `bench run` refuses to start on a
-# tree whose code differs from HEAD (apps/benchmark/src/run/preflight.ts), and an untracked env
-# file is what tripped that twice, at ~2,350s each — so give it a name the check cannot see.
-# NOTHING SOURCES IT: it is a name, not a loader. `source .envrc.local` in the shell you run from.
+# The sanctioned names for per-worktree local state. `bench run` refuses to start on a tree whose
+# code differs from HEAD (apps/benchmark/src/run/preflight.ts), so anything a worktree keeps
+# locally needs a name that check cannot see. `.envrc.local` holds env exports — NOTHING SOURCES
+# IT, it is a name and not a loader, so `source .envrc.local` yourself; `.local/` holds everything
+# else (scratch objects, probe scripts, a symlinked checkout). Not `$(git rev-parse --git-path
+# info/exclude)`: from any worktree that resolves to the MAIN checkout's file, which every other
+# worktree reads and nothing prunes.
 .envrc.local
-# ...and `.local/` for everything else a worktree needs to keep around: scratch objects, probe
-# scripts, a symlinked checkout. The alternative a round reaches for is
-# `$(git rev-parse --git-path info/exclude)`, which from ANY worktree is the MAIN checkout's file:
-# it outlives the worktree, nothing ever prunes it, and it is currently 113 lines holding 24
-# unique patterns — 40 copies of one of them. A gitignored directory is scoped and disposable.
 .local/
 packages/cli/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,8 @@ _site/
 # local Claude Code state
 .claude/worktrees
 research/
+# the ONE sanctioned name for a per-worktree env/scratch file. `bench run` refuses to start on a
+# tree whose code differs from HEAD (apps/benchmark/src/run/preflight.ts), and an untracked env
+# file is what tripped that twice, at ~2,350s each — so give it a name the check cannot see.
+.envrc.local
 packages/cli/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,10 @@ research/
 # file is what tripped that twice, at ~2,350s each — so give it a name the check cannot see.
 # NOTHING SOURCES IT: it is a name, not a loader. `source .envrc.local` in the shell you run from.
 .envrc.local
+# ...and `.local/` for everything else a worktree needs to keep around: scratch objects, probe
+# scripts, a symlinked checkout. The alternative a round reaches for is
+# `$(git rev-parse --git-path info/exclude)`, which from ANY worktree is the MAIN checkout's file:
+# it outlives the worktree, nothing ever prunes it, and it is currently 113 lines holding 24
+# unique patterns — 40 copies of one of them. A gitignored directory is scoped and disposable.
+.local/
 packages/cli/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ research/
 # the ONE sanctioned name for a per-worktree env/scratch file. `bench run` refuses to start on a
 # tree whose code differs from HEAD (apps/benchmark/src/run/preflight.ts), and an untracked env
 # file is what tripped that twice, at ~2,350s each — so give it a name the check cannot see.
+# NOTHING SOURCES IT: it is a name, not a loader. `source .envrc.local` in the shell you run from.
 .envrc.local
 packages/cli/dist/

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -126,12 +126,10 @@ function casesFor(tier: Tier) {
 
 switch (command) {
   case 'run': {
-    // `--shard` is meaningful only on the `--serial` path: the fan-out branch below never reads
-    // `opts.shard`, so `run --shard 1/1` silently DISCARDED the shard, fanned all 8 children over
-    // the whole tier and rewrote `results/<tier>.json` — while the preflight, which exempts a
-    // shard CHILD on the ground that its parent already checked, exempted it too. That made
-    // `--shard` an untraceable way past both refusals. Reject the combination instead: it was a
-    // mis-parse before this check existed.
+    // `--shard` is meaningful only on the `--serial` path — the fan-out branch below never reads
+    // `opts.shard`. Left to run, `run --shard i/N` discards the shard, fans every child over the
+    // whole tier and rewrites `results/<tier>.json`, while looking to a reader like the one argv
+    // the preflight exempts. Reject the argv rather than interpret it.
     if (opts.shard && !opts.serial) {
       console.error(
         `--shard ${opts.shard} without --serial: this path fans out across --jobs children and ignores the shard.\n` +
@@ -139,8 +137,8 @@ switch (command) {
       );
       process.exit(2);
     }
-    // BEFORE anything that costs: the two conditions that make a whole-tier run worthless are both
-    // decidable in under a second, and both have been paid for at ~2,350 s each. See run/preflight.ts.
+    // BEFORE anything that costs: the two conditions that make a run's numbers worthless are both
+    // decidable in under a second. See run/preflight.ts.
     const preflight = preflightRefusals({
       tiers,
       only: opts.only,
@@ -158,8 +156,7 @@ switch (command) {
     }
     // Deliberately NOT folded into `preflightRefusals`: that function's two verdicts are each
     // gated on a predicate (whole-tier / touches-real), while the m2c pin applies to EVERY run,
-    // shard children and `--only` included, and it throws its own remediation line. Two shapes
-    // because they answer to two audiences, not by accident.
+    // shard children and `--only` included, and throws its own remediation line.
     const { assertM2cPinned } = await import('./eval/m2c');
     assertM2cPinned();
     if (opts.serial) {

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -128,15 +128,18 @@ switch (command) {
   case 'run': {
     // BEFORE anything that costs: the two conditions that make a whole-tier run worthless are both
     // decidable in under a second, and both have been paid for at ~2,350 s each. See run/preflight.ts.
-    const refusals = preflightRefusals({
+    const preflight = preflightRefusals({
       tiers,
       only: opts.only,
       project: opts.project,
       toolchain: opts.toolchain,
       shard: opts.shard,
     });
-    if (refusals.length > 0) {
-      console.error(refusals.join('\n\n'));
+    for (const w of preflight.warnings) {
+      console.error(`${w}\n`);
+    }
+    if (preflight.refusals.length > 0) {
+      console.error(preflight.refusals.join('\n\n'));
       process.exit(1);
     }
     const { assertM2cPinned } = await import('./eval/m2c');

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -53,6 +53,7 @@ import { materializeScoringContext, writeScoreConfig } from './decomp-config';
 import { merge } from './report/merge';
 import { publish } from './report/publish';
 import { type Tier, emptySelectionError, orchestrate, tierIsFiltered } from './run/orchestrate';
+import { preflightRefusals } from './run/preflight';
 import { parseShard, runCases } from './run/runner';
 import { smoke } from './run/smoke';
 import { verify } from './run/verify';
@@ -125,6 +126,19 @@ function casesFor(tier: Tier) {
 
 switch (command) {
   case 'run': {
+    // BEFORE anything that costs: the two conditions that make a whole-tier run worthless are both
+    // decidable in under a second, and both have been paid for at ~2,350 s each. See run/preflight.ts.
+    const refusals = preflightRefusals({
+      tiers,
+      only: opts.only,
+      project: opts.project,
+      toolchain: opts.toolchain,
+      shard: opts.shard,
+    });
+    if (refusals.length > 0) {
+      console.error(refusals.join('\n\n'));
+      process.exit(1);
+    }
     const { assertM2cPinned } = await import('./eval/m2c');
     assertM2cPinned();
     if (opts.serial) {

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -126,6 +126,19 @@ function casesFor(tier: Tier) {
 
 switch (command) {
   case 'run': {
+    // `--shard` is meaningful only on the `--serial` path: the fan-out branch below never reads
+    // `opts.shard`, so `run --shard 1/1` silently DISCARDED the shard, fanned all 8 children over
+    // the whole tier and rewrote `results/<tier>.json` — while the preflight, which exempts a
+    // shard CHILD on the ground that its parent already checked, exempted it too. That made
+    // `--shard` an untraceable way past both refusals. Reject the combination instead: it was a
+    // mis-parse before this check existed.
+    if (opts.shard && !opts.serial) {
+      console.error(
+        `--shard ${opts.shard} without --serial: this path fans out across --jobs children and ignores the shard.\n` +
+          'Use `--serial --shard i/N` (what orchestrate.ts spawns), or drop --shard.',
+      );
+      process.exit(2);
+    }
     // BEFORE anything that costs: the two conditions that make a whole-tier run worthless are both
     // decidable in under a second, and both have been paid for at ~2,350 s each. See run/preflight.ts.
     const preflight = preflightRefusals({
@@ -134,6 +147,7 @@ switch (command) {
       project: opts.project,
       toolchain: opts.toolchain,
       shard: opts.shard,
+      serial: opts.serial,
     });
     for (const w of preflight.warnings) {
       console.error(`${w}\n`);
@@ -142,6 +156,10 @@ switch (command) {
       console.error(preflight.refusals.join('\n\n'));
       process.exit(1);
     }
+    // Deliberately NOT folded into `preflightRefusals`: that function's two verdicts are each
+    // gated on a predicate (whole-tier / touches-real), while the m2c pin applies to EVERY run,
+    // shard children and `--only` included, and it throws its own remediation line. Two shapes
+    // because they answer to two audiences, not by accident.
     const { assertM2cPinned } = await import('./eval/m2c');
     assertM2cPinned();
     if (opts.serial) {

--- a/apps/benchmark/src/compile/gcc272.ts
+++ b/apps/benchmark/src/compile/gcc272.ts
@@ -11,7 +11,7 @@ import { CPP } from '../config';
 import type { BuiltTarget } from '../toolchains';
 import { stripPrototype } from './agbcc';
 import type { RealCompile, RealProjectCfg } from './types';
-import { compilerDiagnostics, contentDir, run } from './util';
+import { CPP_PREPROCESS_FLAGS, compilerDiagnostics, contentDir, run } from './util';
 
 /** .i → pooled docker GCC 2.7.2 → .o (same helper score.ts uses). */
 function compile(dir: string, iName: string, oName: string): void {
@@ -48,7 +48,7 @@ export const gcc272Real: RealCompile = {
       iPath = join(dir, 'c.i'),
       oPath = join(dir, 'c.o');
     writeFileSync(cPath, tu);
-    const cpp = run(CPP, ['-P', '-nostdinc', cPath, '-o', iPath]);
+    const cpp = run(CPP, [...CPP_PREPROCESS_FLAGS, cPath, '-o', iPath]);
     if (cpp.status !== 0) {
       throw new Error(`cpp failed: ${compilerDiagnostics(cpp.stderr)}`);
     }

--- a/apps/benchmark/src/compile/ido.ts
+++ b/apps/benchmark/src/compile/ido.ts
@@ -8,7 +8,7 @@ import { CPP } from '../config';
 import type { BuiltTarget } from '../toolchains';
 import { stripPrototype } from './agbcc';
 import type { RealCompile, RealProjectCfg } from './types';
-import { compilerDiagnostics, contentDir, run, scratchSlot } from './util';
+import { CPP_PREPROCESS_FLAGS, compilerDiagnostics, contentDir, run, scratchSlot } from './util';
 
 /** .i → IDO cc → .o. Shared by target and candidate. */
 function compile(iPath: string, oPath: string): void {
@@ -46,7 +46,7 @@ export const idoReal: RealCompile = {
       iPath = join(dir, 'c.i'),
       oPath = join(dir, 'c.o');
     writeFileSync(cPath, tu);
-    const cpp = run(CPP, ['-P', '-nostdinc', cPath, '-o', iPath]);
+    const cpp = run(CPP, [...CPP_PREPROCESS_FLAGS, cPath, '-o', iPath]);
     if (cpp.status !== 0) {
       throw new Error(`cpp failed: ${compilerDiagnostics(cpp.stderr)}`);
     }

--- a/apps/benchmark/src/compile/kmc.ts
+++ b/apps/benchmark/src/compile/kmc.ts
@@ -10,7 +10,7 @@ import { CPP } from '../config';
 import type { BuiltTarget } from '../toolchains';
 import { stripPrototype } from './agbcc';
 import type { RealCompile, RealProjectCfg } from './types';
-import { compilerDiagnostics, contentDir, run } from './util';
+import { CPP_PREPROCESS_FLAGS, compilerDiagnostics, contentDir, run } from './util';
 
 /** .i → pooled docker KMC gcc → .o (same helper score.ts uses). */
 function compile(dir: string, iName: string, oName: string): void {
@@ -48,7 +48,7 @@ export const kmcReal: RealCompile = {
       iPath = join(dir, 'c.i'),
       oPath = join(dir, 'c.o');
     writeFileSync(cPath, tu);
-    const cpp = run(CPP, ['-P', '-nostdinc', cPath, '-o', iPath]);
+    const cpp = run(CPP, [...CPP_PREPROCESS_FLAGS, cPath, '-o', iPath]);
     if (cpp.status !== 0) {
       throw new Error(`cpp failed: ${compilerDiagnostics(cpp.stderr)}`);
     }

--- a/apps/benchmark/src/compile/util.ts
+++ b/apps/benchmark/src/compile/util.ts
@@ -23,6 +23,14 @@ export function run(cmd: string, args: string[], cwd?: string, env?: Record<stri
   return r;
 }
 
+/** The flags the three cpp-preprocessing rungs (`ido`, `kmc`, `gcc272`) pass to `CPP` for a
+ *  CANDIDATE translation unit, and the same flags `run/preflight.ts` probes `cpp` with at run
+ *  start. One constant rather than four copies: the preflight's claim to be "the failure itself"
+ *  holds only while its argv is the rung's argv, and a copy that drifts degrades the probe into
+ *  "some cpp somewhere honours -o" without anything going red. (`preprocess()` for a real project
+ *  adds the project's own -I/-D and deliberately drops -nostdinc, so it is NOT this list.) */
+export const CPP_PREPROCESS_FLAGS = ['-P', '-nostdinc'] as const;
+
 /** Select the diagnostic lines of a compiler's output. `file:line:` prefixes count — pre-3.0 gcc
  *  writes errors without the word "error" (`` c.i:12: `x' undeclared ``), and keyword matching
  *  alone would surface only the `In function` banner. The word "failed" deliberately does NOT

--- a/apps/benchmark/src/provenance.ts
+++ b/apps/benchmark/src/provenance.ts
@@ -29,13 +29,12 @@ const ARTIFACT_PATH = /^(apps\/benchmark\/results\/|apps\/web\/src\/pages\/bench
 // bench invocation launched through the agent would inherit.
 const UNTRACKED_NONCODE = /^\.claude\/commands\//;
 
-/** WHICH paths in this `git status --porcelain` output make the tree's CODE differ from HEAD.
+/** WHICH lines of this `git status --porcelain` output make the tree's CODE differ from HEAD.
  *  Split out so the exclusions are testable without a git checkout to mutate, and returning the
- *  paths rather than a boolean because the two callers need different things from the same rule:
- *  the provenance stamp only asks whether, while `run/preflight.ts` refuses a run and has to say
- *  WHICH file — a refusal that does not name the file sends the reader back to `git status` to
- *  guess which of its lines this rule counted, and the two incidents behind that preflight were
- *  both a single untracked env file among the run's own artifact churn. */
+ *  lines rather than a boolean because the two callers want different things from one rule: the
+ *  provenance stamp asks only whether, while `run/preflight.ts` refuses a run and must say WHICH
+ *  file — a refusal that names none sends the reader back to `git status` to guess which of its
+ *  lines this rule counted, among the run's own artifact churn. */
 export function codeDirtyPaths(porcelain: string): string[] {
   return (
     porcelain
@@ -47,9 +46,10 @@ export function codeDirtyPaths(porcelain: string): string[] {
         const path = l.slice(3).replace(/^"|"$/g, '');
         return !ARTIFACT_PATH.test(path) && !(l.startsWith('??') && UNTRACKED_NONCODE.test(path));
       })
-      // Trailing whitespace only: porcelain's TWO status columns are staged-then-unstaged, so
-      // `l.trim()` maps ` M x` and `M  x` onto the same string and throws away exactly the
-      // distinction this refusal exists to spare the reader a second `git status` for.
+      // Trailing whitespace only. Porcelain's first two columns are staged-then-unstaged, and
+      // `l.trim()` would eat the leading one: ` M x` (unstaged) comes back as `M x`, which reads
+      // as the staged form — the distinction this refusal exists to spare the reader a second
+      // `git status` for.
       .map((l) => l.replace(/\s+$/, ''))
   );
 }

--- a/apps/benchmark/src/provenance.ts
+++ b/apps/benchmark/src/provenance.ts
@@ -29,16 +29,29 @@ const ARTIFACT_PATH = /^(apps\/benchmark\/results\/|apps\/web\/src\/pages\/bench
 // bench invocation launched through the agent would inherit.
 const UNTRACKED_NONCODE = /^\.claude\/commands\//;
 
-/** Does this `git status --porcelain` output describe a tree whose CODE differs from HEAD? Split
- *  out so the exclusions are testable without a git checkout to mutate. */
+/** WHICH paths in this `git status --porcelain` output make the tree's CODE differ from HEAD.
+ *  Split out so the exclusions are testable without a git checkout to mutate, and returning the
+ *  paths rather than a boolean because the two callers need different things from the same rule:
+ *  the provenance stamp only asks whether, while `run/preflight.ts` refuses a run and has to say
+ *  WHICH file — a refusal that does not name the file sends the reader back to `git status` to
+ *  guess which of its lines this rule counted, and the two incidents behind that preflight were
+ *  both a single untracked env file among the run's own artifact churn. */
+export function codeDirtyPaths(porcelain: string): string[] {
+  return porcelain
+    .split('\n')
+    .filter((l) => {
+      if (l.trim() === '') {
+        return false;
+      }
+      const path = l.slice(3).replace(/^"|"$/g, '');
+      return !ARTIFACT_PATH.test(path) && !(l.startsWith('??') && UNTRACKED_NONCODE.test(path));
+    })
+    .map((l) => l.trim());
+}
+
+/** Does this `git status --porcelain` output describe a tree whose CODE differs from HEAD? */
 export function codeDirtyFrom(porcelain: string): boolean {
-  return porcelain.split('\n').some((l) => {
-    if (l.trim() === '') {
-      return false;
-    }
-    const path = l.slice(3).replace(/^"|"$/g, '');
-    return !ARTIFACT_PATH.test(path) && !(l.startsWith('??') && UNTRACKED_NONCODE.test(path));
-  });
+  return codeDirtyPaths(porcelain).length > 0;
 }
 
 /** The repo paths a benchmark measurement depends on — the SAME list

--- a/apps/benchmark/src/provenance.ts
+++ b/apps/benchmark/src/provenance.ts
@@ -37,16 +37,21 @@ const UNTRACKED_NONCODE = /^\.claude\/commands\//;
  *  guess which of its lines this rule counted, and the two incidents behind that preflight were
  *  both a single untracked env file among the run's own artifact churn. */
 export function codeDirtyPaths(porcelain: string): string[] {
-  return porcelain
-    .split('\n')
-    .filter((l) => {
-      if (l.trim() === '') {
-        return false;
-      }
-      const path = l.slice(3).replace(/^"|"$/g, '');
-      return !ARTIFACT_PATH.test(path) && !(l.startsWith('??') && UNTRACKED_NONCODE.test(path));
-    })
-    .map((l) => l.trim());
+  return (
+    porcelain
+      .split('\n')
+      .filter((l) => {
+        if (l.trim() === '') {
+          return false;
+        }
+        const path = l.slice(3).replace(/^"|"$/g, '');
+        return !ARTIFACT_PATH.test(path) && !(l.startsWith('??') && UNTRACKED_NONCODE.test(path));
+      })
+      // Trailing whitespace only: porcelain's TWO status columns are staged-then-unstaged, so
+      // `l.trim()` maps ` M x` and `M  x` onto the same string and throws away exactly the
+      // distinction this refusal exists to spare the reader a second `git status` for.
+      .map((l) => l.replace(/\s+$/, ''))
+  );
 }
 
 /** Does this `git status --porcelain` output describe a tree whose CODE differs from HEAD? */
@@ -56,7 +61,7 @@ export function codeDirtyFrom(porcelain: string): boolean {
 
 /** The repo paths a benchmark measurement depends on — the SAME list
  *  `scripts/check-artifact-provenance.sh` invalidates the committed artifact on, kept in step by
- *  `provenance-paths.test.ts` because two copies of a list like this drift silently and the
+ *  `fidelity-provenance.test.ts` because two copies of a list like this drift silently and the
  *  drift is only ever discovered by a gate that should have fired. Deliberately the WIDE list
  *  (`paths`, not `measures`): asking "could this commit have changed a number" must err toward
  *  yes. */

--- a/apps/benchmark/src/run/preflight.ts
+++ b/apps/benchmark/src/run/preflight.ts
@@ -23,6 +23,20 @@
 // the tier at the end, not that nothing was written. Say the true thing here: the reader of this
 // refusal is deciding whether to commit or to route around it.
 //
+// TWO LAWS, TWO PREDICATES. `runIsWholeTier` asks "does this invocation rewrite a tier file
+// whole", which is the git question and only the git question. The `cpp` question is a different
+// one — "will this invocation preprocess anything with the host `cpp`" — and keying it off
+// whole-tier-ness got it wrong in BOTH directions (measured, both on this branch before the fix):
+// a whole `--tier synthetic` run was REFUSED under a broken `cpp` that six synthetic ido rows then
+// compiled and scored under, and `--tier real --only <sym>` — the shape Phase 3 of
+// `match-function.md` and Phase 6 of `attribute-function.md` both prescribe — got no verdict at
+// all while turning a `diff:27/32` row into `noncompile(1)` at exit 0. The scoped loop is where
+// TRAP 6 actually lives, so it is the last place the probe may be silent. `runUsesHostCpp` is the
+// right axis: every `CPP` call site in `compile/{ido,kmc,gcc272}.ts` sits inside the `*Real`
+// export, and `compile/real.ts` is their only consumer, so the tier alone decides it. Note
+// `--toolchain` does NOT scope the real tier (`cases/real.ts` takes only `project`/`only`), so it
+// cannot narrow this question either.
+//
 // The `cpp` probe rides along for free and is NOT priced as a saving: its prose version ("spend one
 // second on `which cpp` before spending 30 minutes") has been written down for four ship rounds and
 // has not stopped anything. Its incident is a login shell resolving `cpp` to Apple clang, which
@@ -41,18 +55,27 @@ import { codeDirtyPaths } from '../provenance';
 import { type ToolchainId, availableToolchains } from '../toolchains';
 import { type Tier, tierIsFiltered } from './orchestrate';
 
-/** The gitignored name a local env/scratch file is expected to take, quoted in the refusal. One
- *  sanctioned name beats an escape hatch: without it every round that trips this refusal invents
- *  its own way past it, and lands back on the 39-minute loss at `bench:merge`. */
+/** The gitignored name a local env file is expected to take, quoted in the refusal. One sanctioned
+ *  name beats an escape hatch: without it every round that trips this refusal invents its own way
+ *  past it, and lands back on the 39-minute loss at `bench:merge`. */
 export const LOCAL_ENV_FILE = '.envrc.local';
+
+/** ...and the gitignored directory for everything else local. Named here rather than
+ *  `$(git rev-parse --git-path info/exclude)` because that path, from any worktree, is the MAIN
+ *  checkout's file — it outlives the worktree that appended to it and nothing prunes it (measured:
+ *  113 lines, 24 unique patterns, 40 copies of one). A directory is scoped and disposable. */
+export const LOCAL_SCRATCH_DIR = '.local/';
 
 /** How many dirty paths the refusal lists before it summarises the rest. */
 const PATHS_SHOWN = 20;
 
-/** The toolchains whose CANDIDATE compiles preprocess with the host `cpp` (`compile/{ido,kmc,
- *  gcc272}.ts`). agbcc uses `arm-none-eabi-cpp` and mwcc/ppc preprocess inside docker, so a broken
- *  `cpp` costs them nothing. */
-const CPP_TOOLCHAINS: readonly ToolchainId[] = ['ido7.1', 'gcc2.7.2kmc', 'gcc2.7.2'];
+/** The toolchains whose REAL-TIER candidate compiles preprocess with the host `cpp`
+ *  (`compile/{ido,kmc,gcc272}.ts`, all three inside their `*Real` export). agbcc uses
+ *  `arm-none-eabi-cpp` and mwcc/ppc preprocess inside docker, so a broken `cpp` costs them
+ *  nothing — and NO synthetic row preprocesses at all, which is the tier qualifier this comment
+ *  and the rule below were both missing. Hand-maintained, so `preflight.test.ts` derives the same set
+ *  by scanning `compile/` and `REAL_COMPILERS`, and fails if a rung added later diverges from it. */
+export const CPP_TOOLCHAINS: readonly ToolchainId[] = ['ido7.1', 'gcc2.7.2kmc', 'gcc2.7.2'];
 
 export interface PreflightOptions {
   tiers: Tier[];
@@ -60,14 +83,33 @@ export interface PreflightOptions {
   project?: string;
   toolchain?: string;
   shard?: string;
+  serial?: boolean;
+}
+
+/** A shard CHILD, exempt from BOTH verdicts: the parent that spawned it has already answered them
+ *  once, and eight children re-answering would print the same refusal eight times. `--shard` alone
+ *  is NOT that child — `cli.ts`'s fan-out branch ignores it and runs the tier whole — so the test
+ *  is `--shard` AND `--serial`, which is exactly how `orchestrate.ts` spawns one
+ *  (`run --serial --tier X --shard i/N`). `cli.ts` rejects the other combination outright. */
+function isShardChild(opts: PreflightOptions): boolean {
+  return opts.shard !== undefined && opts.serial === true;
 }
 
 /** Will this invocation rewrite at least one tier file WHOLE? That — not "is it slow" — is the
  *  question, because a tier file written whole is what `merge` publishes and what the provenance
- *  refusal is about. A shard CHILD is exempt: the parent that spawned it has already run this,
- *  and eight children re-answering it would print the same refusal eight times. */
+ *  refusal is about. */
 export function runIsWholeTier(opts: PreflightOptions): boolean {
-  return opts.shard === undefined && opts.tiers.some((tier) => !tierIsFiltered(tier, opts));
+  return !isShardChild(opts) && opts.tiers.some((tier) => !tierIsFiltered(tier, opts));
+}
+
+/** Will this invocation compile anything through the host `cpp`? The REAL tier does, on the three
+ *  rungs in `CPP_TOOLCHAINS`; the synthetic tier never does. Scoping does not change the answer —
+ *  `--only`/`--project` still compile real rows, and `--toolchain` does not filter the real tier at
+ *  all — so a one-row `--only` run is checked exactly like a whole one. It is cheaper than
+ *  whole-tier-ness too: a synthetic-only run now pays neither the 42 ms probe nor, on a broken
+ *  `cpp`, the 274 ms toolchain scan. */
+export function runUsesHostCpp(opts: PreflightOptions): boolean {
+  return !isShardChild(opts) && opts.tiers.includes('real');
 }
 
 /** The refusal text for a dirty tree, or undefined when there is nothing to refuse. Pure, so the
@@ -86,8 +128,8 @@ export function dirtyTreeRefusal(paths: readonly string[]): string | undefined {
     ...(paths.length > shown.length ? [`  …and ${paths.length - shown.length} more`] : []),
     '',
     'A full run against this tree produces numbers no commit holds, and `bench merge` refuses to',
-    'publish them — 39 minutes from now. Commit the change, or, if this is a local env/scratch',
-    `file, name it \`${LOCAL_ENV_FILE}\` (gitignored) or add it to \`$(git rev-parse --git-path info/exclude)\`.`,
+    'publish them — 39 minutes from now. Commit the change, or, if it is local scratch, move it:',
+    `env exports go in \`${LOCAL_ENV_FILE}\`, anything else under \`${LOCAL_SCRATCH_DIR}\` — both gitignored.`,
     'A scoped run is not refused — it is the dev loop, and it is meant to run dirty. It still',
     'REWRITES `results/<tier>.json` with only the rows it selected, so run whole before',
     '`bench:merge`. And note `--only` scopes both tiers, while `--project` scopes real and',
@@ -105,8 +147,9 @@ export function cppRefusal(probe: { ok: boolean; how: string }): string | undefi
     `bench run REFUSED: \`${CPP}\` does not preprocess to \`-o\` (${probe.how}).`,
     '',
     'That is Apple clang answering to `cpp` — a login shell puts /usr/bin ahead of ~/.local/bin.',
-    'The ido, kmc and gcc272 rows would all fail to compile and the run would still report `✓` on',
-    'both tiers and exit 0. Put the GNU shim first on PATH, or set ASMLIFT_CPP, then re-run:',
+    'Every REAL-tier ido, kmc and gcc272 row would come back `noncompile` and the run would still',
+    'report `✓` and exit 0 — one row or 300 of them. Put the GNU shim first on PATH, or set',
+    'ASMLIFT_CPP, then re-run:',
     '  export PATH="$HOME/.local/bin:$PATH"',
   ].join('\n');
 }
@@ -148,7 +191,9 @@ export function cppUsingToolchains(): ToolchainId[] {
 
 /** Every start-time verdict, in the order they cost: the git one first, because it is the one with
  *  4,688 s of measured incidents behind it. Returns them rather than exiting, so the caller owns
- *  the exit code and the test owns neither.
+ *  the exit code and the test owns neither. Each verdict is gated on ITS OWN predicate — see the
+ *  header: `runIsWholeTier` for git, `runUsesHostCpp` for the probe — so a scoped real run is
+ *  checked for `cpp` and not for dirt, and a whole synthetic run the other way round.
  *
  *  A WARNING and not a refusal when `cpp` is broken but no toolchain that uses it is installed:
  *  this harness's standing policy is that a missing tool SKIPS its rows (`toolchains.ts` →
@@ -161,17 +206,22 @@ export function preflightRefusals(
   opts: PreflightOptions,
   deps: PreflightDeps = {},
 ): { refusals: string[]; warnings: string[] } {
-  if (!runIsWholeTier(opts)) {
-    return { refusals: [], warnings: [] };
+  const refusals: string[] = [];
+  const warnings: string[] = [];
+  if (runIsWholeTier(opts)) {
+    const status = spawnSync('git', ['-C', deps.repoRoot ?? REPO_ROOT, 'status', '--porcelain'], { encoding: 'utf8' });
+    // git being unreadable is not a dirty tree, and the run-time stamp already reports that case as
+    // dirty on its own. Refusing here on it would block a bench run in a tarball checkout.
+    const dirty = status.status === 0 ? dirtyTreeRefusal(codeDirtyPaths(status.stdout)) : undefined;
+    if (dirty !== undefined) {
+      refusals.push(dirty);
+    }
   }
-  const status = spawnSync('git', ['-C', deps.repoRoot ?? REPO_ROOT, 'status', '--porcelain'], { encoding: 'utf8' });
-  // git being unreadable is not a dirty tree, and the run-time stamp already reports that case as
-  // dirty on its own. Refusing here on it would block a bench run in a tarball checkout.
-  const dirty = status.status === 0 ? dirtyTreeRefusal(codeDirtyPaths(status.stdout)) : undefined;
+  if (!runUsesHostCpp(opts)) {
+    return { refusals, warnings };
+  }
   const cpp = (deps.probe ?? probeCpp)();
   const cppMsg = cppRefusal(cpp);
-  const refusals = dirty === undefined ? [] : [dirty];
-  const warnings: string[] = [];
   if (cppMsg !== undefined) {
     const users = (deps.cppUsingToolchains ?? cppUsingToolchains)();
     if (users.length > 0) {

--- a/apps/benchmark/src/run/preflight.ts
+++ b/apps/benchmark/src/run/preflight.ts
@@ -1,49 +1,41 @@
-// What a full `bench run` is checked for BEFORE it spends half an hour, as opposed to what it is
+// What a `bench run` is checked for BEFORE it spends half an hour, as opposed to what it is
 // checked for after.
 //
 // `provenance.ts` samples the tree DURING the run and `report/merge.ts` refuses to merge a tier
-// whose sample came back dirty. That pair is correct and stays exactly as it is — a mutation that
-// lands mid-run is invisible to anything sampled at the start, and a tree dirtied at second 400 is
-// a real incident this repo has had. But it makes the loss maximal for the one case that was
-// already decidable at second 0: four full runs were discarded across recent rounds, and two of
-// them (2,329.8 s and 2,358.5 s) were a single UNTRACKED ENV FILE — `.envrc.probe`, `envrc.sh` —
-// sitting in a worktree the whole time. `merge` said so, correctly, 39 minutes late.
+// whose sample came back dirty. That pair is correct and stays as it is — a mutation that lands
+// mid-run is invisible to anything sampled at the start. But it makes the loss maximal for the one
+// case that is already decidable at second 0: a dirty tree at the start is almost always a dirty
+// tree at the end, and twice it was a single UNTRACKED ENV FILE sitting in a worktree, costing a
+// ~2,350 s run each time. `merge` said so, correctly, 39 minutes late.
 //
 // So this is the same rule asked at the start. It refuses strictly LESS than `merge` does: every
-// tree it rejects is one whose run stamp would come back dirty and be rejected there anyway, so a
-// run that passes today still passes. It only refuses runs that REWRITE A TIER WHOLE — the scoped
-// dev loop is the shape you run on a dirty tree on purpose, and refusing it would get this whole
-// check traded away inside one round.
+// tree it rejects would have had its run stamp come back dirty and be rejected there anyway. And
+// it refuses only runs that REWRITE A TIER WHOLE — the scoped dev loop is the shape you run on a
+// dirty tree on purpose, and a check that stopped it would be traded away inside one round.
 //
-// "WHOLE" is the exact word. A scoped run does NOT leave its tier file alone: `cli.ts` writes
-// `results/<tier>.json` — the canonical file `merge` publishes — holding only the selected rows
-// (measured: `--tier synthetic --only add --toolchain agbcc --serial` wrote an 11-row
-// `synthetic.json`), and `runner.ts:75-81` records the incident where that file came back with
-// `results: []`. What makes the scoped loop safe to run dirty is that `bench:merge` still refuses
-// the tier at the end, not that nothing was written. Say the true thing here: the reader of this
-// refusal is deciding whether to commit or to route around it.
+// "WHOLE" is the exact word, because a scoped run does NOT leave its tier file alone: `cli.ts`
+// writes `results/<tier>.json` — the canonical file `merge` publishes — holding only the selected
+// rows (measured: `--tier synthetic --only add --toolchain agbcc --serial` wrote an 11-row
+// `synthetic.json`; see `runner.ts`'s `writeEmpty` for the `results: []` case). What makes the
+// scoped loop safe to run dirty is that `bench:merge` still refuses the tier at the end, not that
+// nothing was written — and the reader of this refusal is deciding whether to commit or to route
+// around it.
 //
 // TWO LAWS, TWO PREDICATES. `runIsWholeTier` asks "does this invocation rewrite a tier file
 // whole", which is the git question and only the git question. The `cpp` question is a different
-// one — "will this invocation preprocess anything with the host `cpp`" — and keying it off
-// whole-tier-ness got it wrong in BOTH directions (measured, both on this branch before the fix):
-// a whole `--tier synthetic` run was REFUSED under a broken `cpp` that six synthetic ido rows then
-// compiled and scored under, and `--tier real --only <sym>` — the shape Phase 3 of
-// `match-function.md` and Phase 6 of `attribute-function.md` both prescribe — got no verdict at
-// all while turning a `diff:27/32` row into `noncompile(1)` at exit 0. The scoped loop is where
-// TRAP 6 actually lives, so it is the last place the probe may be silent. `runUsesHostCpp` is the
-// right axis: every `CPP` call site in `compile/{ido,kmc,gcc272}.ts` sits inside the `*Real`
-// export, and `compile/real.ts` is their only consumer, so the tier alone decides it. Note
-// `--toolchain` does NOT scope the real tier (`cases/real.ts` takes only `project`/`only`), so it
-// cannot narrow this question either.
+// one — "will this invocation preprocess anything with the host `cpp`" — and the tier alone
+// decides it: every `CPP` call site in `compile/{ido,kmc,gcc272}.ts` sits inside the `*Real`
+// export, `compile/real.ts` is their only consumer, and no synthetic row preprocesses. Scoping
+// cannot narrow it (`--toolchain` does not filter the real tier at all — `cases/real.ts` takes
+// only `project`/`only`), and it must not: the scoped `--tier real --only <sym>` loop that both
+// briefs prescribe is exactly where TRAP 6 bites, so it is the last place the probe may be silent.
 //
-// The `cpp` probe rides along for free and is NOT priced as a saving: its prose version ("spend one
-// second on `which cpp` before spending 30 minutes") has been written down for four ship rounds and
-// has not stopped anything. Its incident is a login shell resolving `cpp` to Apple clang, which
-// ignores `-o`, writes the preprocessed text to stdout and exits 1 — 44 rows failed and the run
-// reported itself successful with a `✓` on both tiers and exit 0. The probe is the failure itself,
-// run on one line of C: it does not care which `cpp` is on PATH, only whether that one honours
-// `-o`.
+// The `cpp` probe rides along for free and is NOT priced as a saving: its prose version ("spend
+// one second on `which cpp` before spending 30 minutes") has been written down repeatedly and has
+// stopped nothing. Its incident is a login shell resolving `cpp` to Apple clang, which ignores
+// `-o`, writes the preprocessed text to stdout and exits 1 — 44 rows failed and the run reported
+// itself successful, `✓` on both tiers and exit 0. The probe is the failure itself, run on one
+// line of C: it does not care which `cpp` is on PATH, only whether that one honours `-o`.
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -61,9 +53,9 @@ import { type Tier, tierIsFiltered } from './orchestrate';
 export const LOCAL_ENV_FILE = '.envrc.local';
 
 /** ...and the gitignored directory for everything else local. Named here rather than
- *  `$(git rev-parse --git-path info/exclude)` because that path, from any worktree, is the MAIN
- *  checkout's file — it outlives the worktree that appended to it and nothing prunes it (measured:
- *  113 lines, 24 unique patterns, 40 copies of one). A directory is scoped and disposable. */
+ *  `$(git rev-parse --git-path info/exclude)` because that path, from ANY worktree, resolves to
+ *  the MAIN checkout's file: it outlives the worktree that appended to it, every other worktree
+ *  reads it, and nothing prunes it. A gitignored directory is scoped and disposable. */
 export const LOCAL_SCRATCH_DIR = '.local/';
 
 /** How many dirty paths the refusal lists before it summarises the rest. */
@@ -72,9 +64,8 @@ const PATHS_SHOWN = 20;
 /** The toolchains whose REAL-TIER candidate compiles preprocess with the host `cpp`
  *  (`compile/{ido,kmc,gcc272}.ts`, all three inside their `*Real` export). agbcc uses
  *  `arm-none-eabi-cpp` and mwcc/ppc preprocess inside docker, so a broken `cpp` costs them
- *  nothing — and NO synthetic row preprocesses at all, which is the tier qualifier this comment
- *  and the rule below were both missing. Hand-maintained, so `preflight.test.ts` derives the same set
- *  by scanning `compile/` and `REAL_COMPILERS`, and fails if a rung added later diverges from it. */
+ *  nothing. Hand-maintained, so `preflight.test.ts` derives the same set by scanning `compile/`
+ *  and `REAL_COMPILERS`, and fails if a rung added later diverges from it. */
 export const CPP_TOOLCHAINS: readonly ToolchainId[] = ['ido7.1', 'gcc2.7.2kmc', 'gcc2.7.2'];
 
 export interface PreflightOptions {
@@ -87,9 +78,9 @@ export interface PreflightOptions {
 }
 
 /** A shard CHILD, exempt from BOTH verdicts: the parent that spawned it has already answered them
- *  once, and eight children re-answering would print the same refusal eight times. `--shard` alone
- *  is NOT that child — `cli.ts`'s fan-out branch ignores it and runs the tier whole — so the test
- *  is `--shard` AND `--serial`, which is exactly how `orchestrate.ts` spawns one
+ *  once, and every child re-answering would print the same refusal N times. `--shard` alone is NOT
+ *  that child — `cli.ts`'s fan-out branch ignores the shard and runs the tier whole — so the test
+ *  is `--shard` AND `--serial`, exactly how `orchestrate.ts` spawns one
  *  (`run --serial --tier X --shard i/N`). `cli.ts` rejects the other combination outright. */
 function isShardChild(opts: PreflightOptions): boolean {
   return opts.shard !== undefined && opts.serial === true;
@@ -105,9 +96,8 @@ export function runIsWholeTier(opts: PreflightOptions): boolean {
 /** Will this invocation compile anything through the host `cpp`? The REAL tier does, on the three
  *  rungs in `CPP_TOOLCHAINS`; the synthetic tier never does. Scoping does not change the answer —
  *  `--only`/`--project` still compile real rows, and `--toolchain` does not filter the real tier at
- *  all — so a one-row `--only` run is checked exactly like a whole one. It is cheaper than
- *  whole-tier-ness too: a synthetic-only run now pays neither the 42 ms probe nor, on a broken
- *  `cpp`, the 274 ms toolchain scan. */
+ *  all — so a one-row `--only` run is checked exactly like a whole one, and a synthetic-only run
+ *  pays neither the probe nor, on a broken `cpp`, the toolchain scan. */
 export function runUsesHostCpp(opts: PreflightOptions): boolean {
   return !isShardChild(opts) && opts.tiers.includes('real');
 }
@@ -119,8 +109,7 @@ export function dirtyTreeRefusal(paths: readonly string[]): string | undefined {
     return undefined;
   }
   // Capped: a tree after a rebase or a `pnpm format` sweep has hundreds of paths, and printing
-  // them all scrolls the three actionable sentences off the reader's screen — which is where the
-  // reader decides whether to commit or to invent a way around this.
+  // them all scrolls the actionable sentences below off the reader's screen.
   const shown = paths.slice(0, PATHS_SHOWN);
   return [
     `bench run REFUSED: the working tree's code differs from HEAD, in ${paths.length} path${paths.length === 1 ? '' : 's'}:`,
@@ -146,7 +135,7 @@ export function cppRefusal(probe: { ok: boolean; how: string }): string | undefi
   return [
     `bench run REFUSED: \`${CPP}\` does not preprocess to \`-o\` (${probe.how}).`,
     '',
-    'That is Apple clang answering to `cpp` — a login shell puts /usr/bin ahead of ~/.local/bin.',
+    'Usually that is Apple clang answering to `cpp`: a login shell puts /usr/bin ahead of the shim.',
     'Every REAL-tier ido, kmc and gcc272 row would come back `noncompile` and the run would still',
     'report `✓` and exit 0 — one row or 300 of them. Put the GNU shim first on PATH, or set',
     'ASMLIFT_CPP, then re-run:',
@@ -189,19 +178,18 @@ export function cppUsingToolchains(): ToolchainId[] {
     .filter((id) => CPP_TOOLCHAINS.includes(id));
 }
 
-/** Every start-time verdict, in the order they cost: the git one first, because it is the one with
- *  4,688 s of measured incidents behind it. Returns them rather than exiting, so the caller owns
- *  the exit code and the test owns neither. Each verdict is gated on ITS OWN predicate — see the
- *  header: `runIsWholeTier` for git, `runUsesHostCpp` for the probe — so a scoped real run is
- *  checked for `cpp` and not for dirt, and a whole synthetic run the other way round.
+/** Every start-time verdict. Returned rather than exited on, so the caller owns the exit code and
+ *  the test owns neither. Each verdict is gated on ITS OWN predicate — see the header:
+ *  `runIsWholeTier` for git, `runUsesHostCpp` for the probe — so a scoped real run is checked for
+ *  `cpp` and not for dirt, and a whole synthetic run the other way round.
  *
  *  A WARNING and not a refusal when `cpp` is broken but no toolchain that uses it is installed:
  *  this harness's standing policy is that a missing tool SKIPS its rows (`toolchains.ts` →
  *  `runner.ts`: `SKIP <id>: toolchain unavailable`), so refusing a whole agbcc run on a GBA-only
  *  macOS checkout — where the default `cpp` IS Apple clang and every ido/kmc/gcc272 row would have
  *  skipped — would be this check inventing a policy stricter than the run it guards. Availability
- *  is consulted ONLY on the failing path: `availableToolchains()` costs 274 ms here (it probes
- *  docker) against `probeCpp`'s 42 ms, and a `cpp` that works never pays it. */
+ *  is consulted ONLY on the failing path: `availableToolchains()` probes docker and costs several
+ *  times what `probeCpp` does, and a `cpp` that works never pays it. */
 export function preflightRefusals(
   opts: PreflightOptions,
   deps: PreflightDeps = {},

--- a/apps/benchmark/src/run/preflight.ts
+++ b/apps/benchmark/src/run/preflight.ts
@@ -11,9 +11,17 @@
 //
 // So this is the same rule asked at the start. It refuses strictly LESS than `merge` does: every
 // tree it rejects is one whose run stamp would come back dirty and be rejected there anyway, so a
-// run that passes today still passes. It only refuses runs that REWRITE A TIER WHOLE — the
-// `--only`/`--project`/`--toolchain` dev loop is the shape you run on a dirty tree on purpose, and
-// its tier files are left unchanged (see `tierIsFiltered`).
+// run that passes today still passes. It only refuses runs that REWRITE A TIER WHOLE — the scoped
+// dev loop is the shape you run on a dirty tree on purpose, and refusing it would get this whole
+// check traded away inside one round.
+//
+// "WHOLE" is the exact word. A scoped run does NOT leave its tier file alone: `cli.ts` writes
+// `results/<tier>.json` — the canonical file `merge` publishes — holding only the selected rows
+// (measured: `--tier synthetic --only add --toolchain agbcc --serial` wrote an 11-row
+// `synthetic.json`), and `runner.ts:75-81` records the incident where that file came back with
+// `results: []`. What makes the scoped loop safe to run dirty is that `bench:merge` still refuses
+// the tier at the end, not that nothing was written. Say the true thing here: the reader of this
+// refusal is deciding whether to commit or to route around it.
 //
 // The `cpp` probe rides along for free and is NOT priced as a saving: its prose version ("spend one
 // second on `which cpp` before spending 30 minutes") has been written down for four ship rounds and
@@ -23,18 +31,28 @@
 // run on one line of C: it does not care which `cpp` is on PATH, only whether that one honours
 // `-o`.
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { CPP_PREPROCESS_FLAGS } from '../compile/util';
 import { CPP, REPO_ROOT } from '../config';
 import { codeDirtyPaths } from '../provenance';
+import { type ToolchainId, availableToolchains } from '../toolchains';
 import { type Tier, tierIsFiltered } from './orchestrate';
 
 /** The gitignored name a local env/scratch file is expected to take, quoted in the refusal. One
  *  sanctioned name beats an escape hatch: without it every round that trips this refusal invents
  *  its own way past it, and lands back on the 39-minute loss at `bench:merge`. */
 export const LOCAL_ENV_FILE = '.envrc.local';
+
+/** How many dirty paths the refusal lists before it summarises the rest. */
+const PATHS_SHOWN = 20;
+
+/** The toolchains whose CANDIDATE compiles preprocess with the host `cpp` (`compile/{ido,kmc,
+ *  gcc272}.ts`). agbcc uses `arm-none-eabi-cpp` and mwcc/ppc preprocess inside docker, so a broken
+ *  `cpp` costs them nothing. */
+const CPP_TOOLCHAINS: readonly ToolchainId[] = ['ido7.1', 'gcc2.7.2kmc', 'gcc2.7.2'];
 
 export interface PreflightOptions {
   tiers: Tier[];
@@ -58,14 +76,23 @@ export function dirtyTreeRefusal(paths: readonly string[]): string | undefined {
   if (paths.length === 0) {
     return undefined;
   }
+  // Capped: a tree after a rebase or a `pnpm format` sweep has hundreds of paths, and printing
+  // them all scrolls the three actionable sentences off the reader's screen — which is where the
+  // reader decides whether to commit or to invent a way around this.
+  const shown = paths.slice(0, PATHS_SHOWN);
   return [
     `bench run REFUSED: the working tree's code differs from HEAD, in ${paths.length} path${paths.length === 1 ? '' : 's'}:`,
-    ...paths.map((p) => `  ${p}`),
+    ...shown.map((p) => `  ${p}`),
+    ...(paths.length > shown.length ? [`  …and ${paths.length - shown.length} more`] : []),
     '',
     'A full run against this tree produces numbers no commit holds, and `bench merge` refuses to',
     'publish them — 39 minutes from now. Commit the change, or, if this is a local env/scratch',
     `file, name it \`${LOCAL_ENV_FILE}\` (gitignored) or add it to \`$(git rev-parse --git-path info/exclude)\`.`,
-    'A scoped run (--only/--project/--toolchain) is not refused: it leaves the tier files alone.',
+    'A scoped run is not refused — it is the dev loop, and it is meant to run dirty. It still',
+    'REWRITES `results/<tier>.json` with only the rows it selected, so run whole before',
+    '`bench:merge`. And note `--only` scopes both tiers, while `--project` scopes real and',
+    '`--toolchain` scopes synthetic: pair those two with `--tier real` / `--tier synthetic`, or the',
+    'other tier is still rewritten whole and this refusal still fires.',
   ].join('\n');
 }
 
@@ -85,31 +112,79 @@ export function cppRefusal(probe: { ok: boolean; how: string }): string | undefi
 }
 
 /** Ask the configured `cpp` to do the one thing the harness needs of it. */
-export function probeCpp(): { ok: boolean; how: string } {
+export function probeCpp(cpp: string = CPP): { ok: boolean; how: string } {
   const dir = mkdtempSync(join(tmpdir(), 'asmlift-cpp-'));
-  const cPath = join(dir, 'probe.c');
-  const iPath = join(dir, 'probe.i');
-  writeFileSync(cPath, 'int probe;\n');
-  const r = spawnSync(CPP, ['-P', '-nostdinc', cPath, '-o', iPath], { encoding: 'utf8' });
-  if (r.error) {
-    return { ok: false, how: `cannot be run: ${r.error.message}` };
+  try {
+    const cPath = join(dir, 'probe.c');
+    const iPath = join(dir, 'probe.i');
+    writeFileSync(cPath, 'int probe;\n');
+    const r = spawnSync(cpp, [...CPP_PREPROCESS_FLAGS, cPath, '-o', iPath], { encoding: 'utf8' });
+    if (r.error) {
+      return { ok: false, how: `cannot be run: ${r.error.message}` };
+    }
+    if (r.status !== 0) {
+      return { ok: false, how: `exit ${r.status}: ${(r.stderr ?? '').trim().split('\n')[0]}` };
+    }
+    return existsSync(iPath) ? { ok: true, how: 'ok' } : { ok: false, how: 'exit 0 but wrote no output file' };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
-  if (r.status !== 0) {
-    return { ok: false, how: `exit ${r.status}: ${(r.stderr ?? '').trim().split('\n')[0]}` };
-  }
-  return existsSync(iPath) ? { ok: true, how: 'ok' } : { ok: false, how: 'exit 0 but wrote no output file' };
 }
 
-/** Every start-time refusal, in the order they cost: the git one first, because it is the one with
- *  4,688 s of measured incidents behind it. Returns the refusals rather than exiting, so the
- *  caller owns the exit code and the test owns neither. */
-export function preflightRefusals(opts: PreflightOptions): string[] {
+/** What `preflightRefusals` reads from the world, injectable so every branch of it is testable
+ *  against a throwaway checkout and a stub `cpp` instead of the machine it happens to run on. */
+export interface PreflightDeps {
+  repoRoot?: string;
+  probe?: () => { ok: boolean; how: string };
+  cppUsingToolchains?: () => ToolchainId[];
+}
+
+/** Which of the cpp-preprocessing toolchains are actually installed here. */
+export function cppUsingToolchains(): ToolchainId[] {
+  return availableToolchains()
+    .map((t) => t.id)
+    .filter((id) => CPP_TOOLCHAINS.includes(id));
+}
+
+/** Every start-time verdict, in the order they cost: the git one first, because it is the one with
+ *  4,688 s of measured incidents behind it. Returns them rather than exiting, so the caller owns
+ *  the exit code and the test owns neither.
+ *
+ *  A WARNING and not a refusal when `cpp` is broken but no toolchain that uses it is installed:
+ *  this harness's standing policy is that a missing tool SKIPS its rows (`toolchains.ts` →
+ *  `runner.ts`: `SKIP <id>: toolchain unavailable`), so refusing a whole agbcc run on a GBA-only
+ *  macOS checkout — where the default `cpp` IS Apple clang and every ido/kmc/gcc272 row would have
+ *  skipped — would be this check inventing a policy stricter than the run it guards. Availability
+ *  is consulted ONLY on the failing path: `availableToolchains()` costs 274 ms here (it probes
+ *  docker) against `probeCpp`'s 42 ms, and a `cpp` that works never pays it. */
+export function preflightRefusals(
+  opts: PreflightOptions,
+  deps: PreflightDeps = {},
+): { refusals: string[]; warnings: string[] } {
   if (!runIsWholeTier(opts)) {
-    return [];
+    return { refusals: [], warnings: [] };
   }
-  const status = spawnSync('git', ['-C', REPO_ROOT, 'status', '--porcelain'], { encoding: 'utf8' });
+  const status = spawnSync('git', ['-C', deps.repoRoot ?? REPO_ROOT, 'status', '--porcelain'], { encoding: 'utf8' });
   // git being unreadable is not a dirty tree, and the run-time stamp already reports that case as
   // dirty on its own. Refusing here on it would block a bench run in a tarball checkout.
   const dirty = status.status === 0 ? dirtyTreeRefusal(codeDirtyPaths(status.stdout)) : undefined;
-  return [dirty, cppRefusal(probeCpp())].filter((r) => r !== undefined);
+  const cpp = (deps.probe ?? probeCpp)();
+  const cppMsg = cppRefusal(cpp);
+  const refusals = dirty === undefined ? [] : [dirty];
+  const warnings: string[] = [];
+  if (cppMsg !== undefined) {
+    const users = (deps.cppUsingToolchains ?? cppUsingToolchains)();
+    if (users.length > 0) {
+      refusals.push(cppMsg);
+    } else {
+      warnings.push(
+        [
+          `bench run WARNING: \`${CPP}\` does not preprocess to \`-o\` (${cpp.how}). Not refused —`,
+          `none of ${CPP_TOOLCHAINS.join(' / ')} is installed here, so every row that would have used`,
+          'it is going to SKIP anyway. Install one of them and this becomes a refusal.',
+        ].join('\n'),
+      );
+    }
+  }
+  return { refusals, warnings };
 }

--- a/apps/benchmark/src/run/preflight.ts
+++ b/apps/benchmark/src/run/preflight.ts
@@ -1,0 +1,115 @@
+// What a full `bench run` is checked for BEFORE it spends half an hour, as opposed to what it is
+// checked for after.
+//
+// `provenance.ts` samples the tree DURING the run and `report/merge.ts` refuses to merge a tier
+// whose sample came back dirty. That pair is correct and stays exactly as it is — a mutation that
+// lands mid-run is invisible to anything sampled at the start, and a tree dirtied at second 400 is
+// a real incident this repo has had. But it makes the loss maximal for the one case that was
+// already decidable at second 0: four full runs were discarded across recent rounds, and two of
+// them (2,329.8 s and 2,358.5 s) were a single UNTRACKED ENV FILE — `.envrc.probe`, `envrc.sh` —
+// sitting in a worktree the whole time. `merge` said so, correctly, 39 minutes late.
+//
+// So this is the same rule asked at the start. It refuses strictly LESS than `merge` does: every
+// tree it rejects is one whose run stamp would come back dirty and be rejected there anyway, so a
+// run that passes today still passes. It only refuses runs that REWRITE A TIER WHOLE — the
+// `--only`/`--project`/`--toolchain` dev loop is the shape you run on a dirty tree on purpose, and
+// its tier files are left unchanged (see `tierIsFiltered`).
+//
+// The `cpp` probe rides along for free and is NOT priced as a saving: its prose version ("spend one
+// second on `which cpp` before spending 30 minutes") has been written down for four ship rounds and
+// has not stopped anything. Its incident is a login shell resolving `cpp` to Apple clang, which
+// ignores `-o`, writes the preprocessed text to stdout and exits 1 — 44 rows failed and the run
+// reported itself successful with a `✓` on both tiers and exit 0. The probe is the failure itself,
+// run on one line of C: it does not care which `cpp` is on PATH, only whether that one honours
+// `-o`.
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { CPP, REPO_ROOT } from '../config';
+import { codeDirtyPaths } from '../provenance';
+import { type Tier, tierIsFiltered } from './orchestrate';
+
+/** The gitignored name a local env/scratch file is expected to take, quoted in the refusal. One
+ *  sanctioned name beats an escape hatch: without it every round that trips this refusal invents
+ *  its own way past it, and lands back on the 39-minute loss at `bench:merge`. */
+export const LOCAL_ENV_FILE = '.envrc.local';
+
+export interface PreflightOptions {
+  tiers: Tier[];
+  only?: string;
+  project?: string;
+  toolchain?: string;
+  shard?: string;
+}
+
+/** Will this invocation rewrite at least one tier file WHOLE? That — not "is it slow" — is the
+ *  question, because a tier file written whole is what `merge` publishes and what the provenance
+ *  refusal is about. A shard CHILD is exempt: the parent that spawned it has already run this,
+ *  and eight children re-answering it would print the same refusal eight times. */
+export function runIsWholeTier(opts: PreflightOptions): boolean {
+  return opts.shard === undefined && opts.tiers.some((tier) => !tierIsFiltered(tier, opts));
+}
+
+/** The refusal text for a dirty tree, or undefined when there is nothing to refuse. Pure, so the
+ *  message is testable without a checkout to dirty. */
+export function dirtyTreeRefusal(paths: readonly string[]): string | undefined {
+  if (paths.length === 0) {
+    return undefined;
+  }
+  return [
+    `bench run REFUSED: the working tree's code differs from HEAD, in ${paths.length} path${paths.length === 1 ? '' : 's'}:`,
+    ...paths.map((p) => `  ${p}`),
+    '',
+    'A full run against this tree produces numbers no commit holds, and `bench merge` refuses to',
+    'publish them — 39 minutes from now. Commit the change, or, if this is a local env/scratch',
+    `file, name it \`${LOCAL_ENV_FILE}\` (gitignored) or add it to \`$(git rev-parse --git-path info/exclude)\`.`,
+    'A scoped run (--only/--project/--toolchain) is not refused: it leaves the tier files alone.',
+  ].join('\n');
+}
+
+/** The refusal text for a `cpp` that does not honour `-o`. */
+export function cppRefusal(probe: { ok: boolean; how: string }): string | undefined {
+  if (probe.ok) {
+    return undefined;
+  }
+  return [
+    `bench run REFUSED: \`${CPP}\` does not preprocess to \`-o\` (${probe.how}).`,
+    '',
+    'That is Apple clang answering to `cpp` — a login shell puts /usr/bin ahead of ~/.local/bin.',
+    'The ido, kmc and gcc272 rows would all fail to compile and the run would still report `✓` on',
+    'both tiers and exit 0. Put the GNU shim first on PATH, or set ASMLIFT_CPP, then re-run:',
+    '  export PATH="$HOME/.local/bin:$PATH"',
+  ].join('\n');
+}
+
+/** Ask the configured `cpp` to do the one thing the harness needs of it. */
+export function probeCpp(): { ok: boolean; how: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'asmlift-cpp-'));
+  const cPath = join(dir, 'probe.c');
+  const iPath = join(dir, 'probe.i');
+  writeFileSync(cPath, 'int probe;\n');
+  const r = spawnSync(CPP, ['-P', '-nostdinc', cPath, '-o', iPath], { encoding: 'utf8' });
+  if (r.error) {
+    return { ok: false, how: `cannot be run: ${r.error.message}` };
+  }
+  if (r.status !== 0) {
+    return { ok: false, how: `exit ${r.status}: ${(r.stderr ?? '').trim().split('\n')[0]}` };
+  }
+  return existsSync(iPath) ? { ok: true, how: 'ok' } : { ok: false, how: 'exit 0 but wrote no output file' };
+}
+
+/** Every start-time refusal, in the order they cost: the git one first, because it is the one with
+ *  4,688 s of measured incidents behind it. Returns the refusals rather than exiting, so the
+ *  caller owns the exit code and the test owns neither. */
+export function preflightRefusals(opts: PreflightOptions): string[] {
+  if (!runIsWholeTier(opts)) {
+    return [];
+  }
+  const status = spawnSync('git', ['-C', REPO_ROOT, 'status', '--porcelain'], { encoding: 'utf8' });
+  // git being unreadable is not a dirty tree, and the run-time stamp already reports that case as
+  // dirty on its own. Refusing here on it would block a bench run in a tarball checkout.
+  const dirty = status.status === 0 ? dirtyTreeRefusal(codeDirtyPaths(status.stdout)) : undefined;
+  return [dirty, cppRefusal(probeCpp())].filter((r) => r !== undefined);
+}

--- a/apps/benchmark/test/preflight.test.ts
+++ b/apps/benchmark/test/preflight.test.ts
@@ -2,9 +2,21 @@
 // merge refusal; this pins what is refused before the run spends anything, and — the part that
 // actually matters — what is NOT refused, because a preflight that stops the `--only` dev loop
 // would be traded away within a round.
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, test } from 'vitest';
 
-import { cppRefusal, dirtyTreeRefusal, runIsWholeTier } from '../src/run/preflight';
+import { cppRefusal, dirtyTreeRefusal, preflightRefusals, probeCpp, runIsWholeTier } from '../src/run/preflight';
+
+/** A `cpp` stub with the given body, executable, on disk. */
+function stubCpp(body: string): string {
+  const path = join(mkdtempSync(join(tmpdir(), 'asmlift-cppstub-')), 'cpp');
+  writeFileSync(path, `#!/bin/sh\n${body}\n`);
+  chmodSync(path, 0o755);
+  return path;
+}
 
 describe('which runs are checked at all', () => {
   test('an unfiltered run of either tier is — it rewrites the tier file whole', () => {
@@ -46,6 +58,14 @@ describe('the dirty-tree refusal', () => {
     expect(dirtyTreeRefusal(['?? envrc.sh'])).toContain('.envrc.local');
   });
 
+  test('caps the list, so the three actionable sentences stay on screen after a format sweep', () => {
+    const msg = dirtyTreeRefusal(Array.from({ length: 57 }, (_, i) => ` M packages/core/src/f${i}.ts`));
+    expect(msg).toContain('57 paths');
+    expect(msg).toContain(' M packages/core/src/f19.ts');
+    expect(msg).not.toContain(' M packages/core/src/f20.ts');
+    expect(msg).toContain('…and 37 more');
+  });
+
   test('a clean tree refuses nothing', () => {
     expect(dirtyTreeRefusal([])).toBeUndefined();
   });
@@ -60,5 +80,108 @@ describe('the cpp probe refusal', () => {
 
   test('a working cpp refuses nothing', () => {
     expect(cppRefusal({ ok: true, how: 'ok' })).toBeUndefined();
+  });
+});
+
+// The two functions the acceptance criterion is actually about — the probe that decides, and the
+// composition that spawns git — were the two with no test. Neither is pure, so both are given the
+// thing they read (a `cpp` path, a repo root) rather than mocked.
+describe('the cpp probe itself', () => {
+  test('the incident is caught: a cpp that writes to stdout, ignores -o and exits 1', () => {
+    // Apple's /usr/bin/cpp answering as clang, reproduced. Measured against the real binary:
+    // "cc: error: no input files", exit 1, no output file.
+    const probe = probeCpp(stubCpp('echo "int probe;"; echo "cc: error: no input files" >&2; exit 1'));
+    expect(probe.ok).toBe(false);
+    expect(probe.how).toContain('no input files');
+  });
+
+  test('a cpp that exits 0 and STILL writes no -o file is caught', () => {
+    // The nastier half of the same shape: exit 0 would sail past a status-only check and the
+    // compile rung would then read a file that is not there.
+    expect(probeCpp(stubCpp('exit 0')).ok).toBe(false);
+  });
+
+  test('a cpp that honours -o passes', () => {
+    expect(
+      probeCpp(stubCpp('while [ $# -gt 1 ]; do [ "$1" = "-o" ] && { echo x > "$2"; exit 0; }; shift; done; exit 1')).ok,
+    ).toBe(true);
+  });
+
+  test('a cpp that is not there is a failure, not a throw', () => {
+    const probe = probeCpp(join(tmpdir(), 'asmlift-no-such-cpp'));
+    expect(probe.ok).toBe(false);
+    expect(probe.how).toContain('cannot be run');
+  });
+});
+
+describe('the whole preflight, against a real throwaway checkout', () => {
+  const repo = () => {
+    const dir = mkdtempSync(join(tmpdir(), 'asmlift-preflight-repo-'));
+    execFileSync('git', ['-C', dir, 'init', '-q']);
+    return dir;
+  };
+
+  test('an untracked file in a clean-but-for-it checkout refuses the whole-tier run, by name', () => {
+    const dir = repo();
+    writeFileSync(join(dir, '.envrc.probe'), 'export FOO=1\n');
+    const { refusals } = preflightRefusals({ tiers: ['real'] }, { repoRoot: dir });
+    const dirty = refusals.find((r) => r.includes("working tree's code differs"));
+    expect(dirty).toBeDefined();
+    expect(dirty).toContain('.envrc.probe');
+  });
+
+  test('the same tree does NOT refuse the scoped dev loop', () => {
+    const dir = repo();
+    writeFileSync(join(dir, '.envrc.probe'), 'export FOO=1\n');
+    expect(preflightRefusals({ tiers: ['real'], only: 'dmaback' }, { repoRoot: dir })).toEqual({
+      refusals: [],
+      warnings: [],
+    });
+  });
+
+  test('an empty checkout refuses nothing on the git axis', () => {
+    expect(
+      preflightRefusals({ tiers: ['real'] }, { repoRoot: repo() }).refusals.some((r) =>
+        r.includes('differs from HEAD'),
+      ),
+    ).toBe(false);
+  });
+});
+
+// The probe's claim to BE the failure holds only while its argv is the compile rung's argv. That is
+// now one exported constant instead of four copies, and this is the guard against someone
+// re-inlining the flags in one of the three rungs — the same shape `fidelity-provenance.test.ts`
+// uses to hold `check-artifact-provenance.sh` and `MEASURED_PATHS` in step.
+describe('the cpp argv is not four copies', () => {
+  test('every candidate-compile rung preprocesses through the constant the probe uses', () => {
+    for (const mod of ['ido', 'kmc', 'gcc272']) {
+      const src = readFileSync(join(import.meta.dirname, '..', 'src', 'compile', `${mod}.ts`), 'utf8');
+      expect(src, `${mod}.ts must import the shared flags`).toContain('CPP_PREPROCESS_FLAGS');
+      expect(src, `${mod}.ts re-inlines the probe's flags`).not.toContain("'-P', '-nostdinc'");
+    }
+  });
+});
+
+// The branch that decides whether a broken `cpp` is fatal. Both sides are pinned because the
+// no-toolchain side is unreachable on a machine that HAS the MIPS toolchains — which is every
+// machine that runs the full bench, and therefore not the machine this regresses on.
+describe('a broken cpp is fatal only when something here would have used it', () => {
+  const broken = () => ({ ok: false, how: 'exit 1: cc: error: no input files' });
+  const clean = mkdtempSync(join(tmpdir(), 'asmlift-preflight-clean-'));
+  execFileSync('git', ['-C', clean, 'init', '-q']);
+
+  test('with a MIPS toolchain installed it REFUSES', () => {
+    const r = preflightRefusals(
+      { tiers: ['real'] },
+      { repoRoot: clean, probe: broken, cppUsingToolchains: () => ['ido7.1'] },
+    );
+    expect(r.refusals.some((m) => m.includes('does not preprocess'))).toBe(true);
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('with none installed it WARNS and lets the run go — the rows would SKIP', () => {
+    const r = preflightRefusals({ tiers: ['real'] }, { repoRoot: clean, probe: broken, cppUsingToolchains: () => [] });
+    expect(r.refusals).toEqual([]);
+    expect(r.warnings.join('\n')).toContain('WARNING');
   });
 });

--- a/apps/benchmark/test/preflight.test.ts
+++ b/apps/benchmark/test/preflight.test.ts
@@ -1,0 +1,64 @@
+// The START-time half of the provenance story. `provenance.test.ts` pins the mid-run sample and the
+// merge refusal; this pins what is refused before the run spends anything, and — the part that
+// actually matters — what is NOT refused, because a preflight that stops the `--only` dev loop
+// would be traded away within a round.
+import { describe, expect, test } from 'vitest';
+
+import { cppRefusal, dirtyTreeRefusal, runIsWholeTier } from '../src/run/preflight';
+
+describe('which runs are checked at all', () => {
+  test('an unfiltered run of either tier is — it rewrites the tier file whole', () => {
+    expect(runIsWholeTier({ tiers: ['synthetic', 'real'] })).toBe(true);
+    expect(runIsWholeTier({ tiers: ['real'] })).toBe(true);
+    expect(runIsWholeTier({ tiers: ['synthetic'] })).toBe(true);
+  });
+
+  test('the scoped dev loop is NOT — a dirty tree is the point of it', () => {
+    expect(runIsWholeTier({ tiers: ['real'], only: 'sub_802DFC8' })).toBe(false);
+    expect(runIsWholeTier({ tiers: ['synthetic'], toolchain: 'agbcc' })).toBe(false);
+    expect(runIsWholeTier({ tiers: ['real'], project: 'kleod' })).toBe(false);
+  });
+
+  test('a filter that selects in only ONE of two tiers still leaves the other whole', () => {
+    // `--toolchain` filters synthetic alone, so `--tier both --toolchain agbcc` rewrites real.json
+    // in full — the same file merge publishes.
+    expect(runIsWholeTier({ tiers: ['synthetic', 'real'], toolchain: 'agbcc' })).toBe(true);
+    expect(runIsWholeTier({ tiers: ['synthetic', 'real'], project: 'kleod' })).toBe(true);
+    // `--only` reads both tiers, so it scopes the whole run.
+    expect(runIsWholeTier({ tiers: ['synthetic', 'real'], only: 'dmaback' })).toBe(false);
+  });
+
+  test('a shard CHILD is exempt — its parent already answered, once', () => {
+    expect(runIsWholeTier({ tiers: ['real'], shard: '3/8' })).toBe(false);
+  });
+});
+
+describe('the dirty-tree refusal', () => {
+  test('names every offending path, so nobody re-runs git status to guess', () => {
+    const msg = dirtyTreeRefusal(['?? .envrc.probe', 'M packages/core/src/rank.ts']);
+    expect(msg).toContain('.envrc.probe');
+    expect(msg).toContain('packages/core/src/rank.ts');
+    expect(msg).toContain('2 paths');
+  });
+
+  test('points at the ONE sanctioned name for a local env file', () => {
+    // Without a sanctioned name the refusal is just an obstacle, and the round routes around it.
+    expect(dirtyTreeRefusal(['?? envrc.sh'])).toContain('.envrc.local');
+  });
+
+  test('a clean tree refuses nothing', () => {
+    expect(dirtyTreeRefusal([])).toBeUndefined();
+  });
+});
+
+describe('the cpp probe refusal', () => {
+  test('a cpp that ignores -o is refused, with what it did', () => {
+    const msg = cppRefusal({ ok: false, how: 'exit 1: cc: error: no input files' });
+    expect(msg).toContain('no input files');
+    expect(msg).toContain('ASMLIFT_CPP');
+  });
+
+  test('a working cpp refuses nothing', () => {
+    expect(cppRefusal({ ok: true, how: 'ok' })).toBeUndefined();
+  });
+});

--- a/apps/benchmark/test/preflight.test.ts
+++ b/apps/benchmark/test/preflight.test.ts
@@ -3,12 +3,22 @@
 // actually matters — what is NOT refused, because a preflight that stops the `--only` dev loop
 // would be traded away within a round.
 import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, test } from 'vitest';
 
-import { cppRefusal, dirtyTreeRefusal, preflightRefusals, probeCpp, runIsWholeTier } from '../src/run/preflight';
+import {
+  CPP_TOOLCHAINS,
+  LOCAL_ENV_FILE,
+  LOCAL_SCRATCH_DIR,
+  cppRefusal,
+  dirtyTreeRefusal,
+  preflightRefusals,
+  probeCpp,
+  runIsWholeTier,
+  runUsesHostCpp,
+} from '../src/run/preflight';
 
 /** A `cpp` stub with the given body, executable, on disk. */
 function stubCpp(body: string): string {
@@ -41,7 +51,39 @@ describe('which runs are checked at all', () => {
   });
 
   test('a shard CHILD is exempt — its parent already answered, once', () => {
-    expect(runIsWholeTier({ tiers: ['real'], shard: '3/8' })).toBe(false);
+    expect(runIsWholeTier({ tiers: ['real'], shard: '3/8', serial: true })).toBe(false);
+  });
+
+  test('`--shard` WITHOUT `--serial` is not a child and is not exempt', () => {
+    // Measured on this branch before the fix: `pnpm bench run --tier synthetic --shard 1/1` on a
+    // tree carrying `?? .envrc.probe` printed no refusal, fanned 8 children over the whole tier
+    // (the fan-out branch never reads `opts.shard`) and headed for a full rewrite of
+    // synthetic.json. `cli.ts` now rejects that argv with exit 2; this pins the second lock.
+    expect(runIsWholeTier({ tiers: ['synthetic'], shard: '1/1' })).toBe(true);
+    expect(runUsesHostCpp({ tiers: ['real'], shard: '1/1' })).toBe(true);
+  });
+});
+
+// The axis wave 2 found reversed: `runIsWholeTier` is a question about REWRITING A TIER FILE and
+// was deciding the `cpp` probe too, which made the probe silent in the scoped loop where TRAP 6
+// lives and loud on a tier that never preprocesses.
+describe('which runs touch the host cpp at all', () => {
+  test('every real-tier run does — scoped or whole, one row or all of them', () => {
+    expect(runUsesHostCpp({ tiers: ['real'] })).toBe(true);
+    expect(runUsesHostCpp({ tiers: ['real'], only: 'func_800600C0_60CC0' })).toBe(true);
+    expect(runUsesHostCpp({ tiers: ['real'], project: 'marioparty3' })).toBe(true);
+    // `--toolchain` does not filter the real tier (cases/real.ts takes project/only only), so it
+    // cannot narrow this question either — an agbcc-flavoured real run still compiles gcc272 rows.
+    expect(runUsesHostCpp({ tiers: ['real'], toolchain: 'agbcc' })).toBe(true);
+  });
+
+  test('no synthetic-only run does — measured: 6 synthetic ido rows scored under a broken cpp', () => {
+    expect(runUsesHostCpp({ tiers: ['synthetic'] })).toBe(false);
+    expect(runUsesHostCpp({ tiers: ['synthetic'], toolchain: 'ido7.1' })).toBe(false);
+  });
+
+  test('a shard child still asks neither question', () => {
+    expect(runUsesHostCpp({ tiers: ['real'], shard: '3/8', serial: true })).toBe(false);
   });
 });
 
@@ -55,7 +97,13 @@ describe('the dirty-tree refusal', () => {
 
   test('points at the ONE sanctioned name for a local env file', () => {
     // Without a sanctioned name the refusal is just an obstacle, and the round routes around it.
-    expect(dirtyTreeRefusal(['?? envrc.sh'])).toContain('.envrc.local');
+    // Asserted through the export, not a fifth copy of the literal: the constant exists precisely
+    // to be the single source of truth, and a test that restates the string leaves it with no
+    // consumer at all.
+    expect(dirtyTreeRefusal(['?? envrc.sh'])).toContain(LOCAL_ENV_FILE);
+    // ...and the scoped home for everything that is not an env file, so the reader is not sent to
+    // the main checkout's `info/exclude`, which no worktree ever cleans up.
+    expect(dirtyTreeRefusal(['?? scratch.o'])).toContain(LOCAL_SCRATCH_DIR);
   });
 
   test('caps the list, so the three actionable sentences stay on screen after a format sweep', () => {
@@ -115,6 +163,9 @@ describe('the cpp probe itself', () => {
 });
 
 describe('the whole preflight, against a real throwaway checkout', () => {
+  // These are about the GIT axis, so the probe is injected healthy: a real-tier run now asks the
+  // cpp question too, and none of these assertions is about whichever `cpp` the machine has.
+  const ok = () => ({ ok: true, how: 'ok' });
   const repo = () => {
     const dir = mkdtempSync(join(tmpdir(), 'asmlift-preflight-repo-'));
     execFileSync('git', ['-C', dir, 'init', '-q']);
@@ -124,16 +175,18 @@ describe('the whole preflight, against a real throwaway checkout', () => {
   test('an untracked file in a clean-but-for-it checkout refuses the whole-tier run, by name', () => {
     const dir = repo();
     writeFileSync(join(dir, '.envrc.probe'), 'export FOO=1\n');
-    const { refusals } = preflightRefusals({ tiers: ['real'] }, { repoRoot: dir });
+    const { refusals } = preflightRefusals({ tiers: ['real'] }, { repoRoot: dir, probe: ok });
     const dirty = refusals.find((r) => r.includes("working tree's code differs"));
     expect(dirty).toBeDefined();
     expect(dirty).toContain('.envrc.probe');
   });
 
   test('the same tree does NOT refuse the scoped dev loop', () => {
+    // The GIT axis only. The probe is injected healthy because a scoped real run now DOES ask the
+    // cpp question, and this test is about dirt, not about whichever `cpp` the machine has.
     const dir = repo();
     writeFileSync(join(dir, '.envrc.probe'), 'export FOO=1\n');
-    expect(preflightRefusals({ tiers: ['real'], only: 'dmaback' }, { repoRoot: dir })).toEqual({
+    expect(preflightRefusals({ tiers: ['real'], only: 'dmaback' }, { repoRoot: dir, probe: ok })).toEqual({
       refusals: [],
       warnings: [],
     });
@@ -141,24 +194,59 @@ describe('the whole preflight, against a real throwaway checkout', () => {
 
   test('an empty checkout refuses nothing on the git axis', () => {
     expect(
-      preflightRefusals({ tiers: ['real'] }, { repoRoot: repo() }).refusals.some((r) =>
+      preflightRefusals({ tiers: ['real'] }, { repoRoot: repo(), probe: ok }).refusals.some((r) =>
         r.includes('differs from HEAD'),
       ),
     ).toBe(false);
   });
 });
 
-// The probe's claim to BE the failure holds only while its argv is the compile rung's argv. That is
-// now one exported constant instead of four copies, and this is the guard against someone
-// re-inlining the flags in one of the three rungs — the same shape `fidelity-provenance.test.ts`
-// uses to hold `check-artifact-provenance.sh` and `MEASURED_PATHS` in step.
-describe('the cpp argv is not four copies', () => {
-  test('every candidate-compile rung preprocesses through the constant the probe uses', () => {
-    for (const mod of ['ido', 'kmc', 'gcc272']) {
-      const src = readFileSync(join(import.meta.dirname, '..', 'src', 'compile', `${mod}.ts`), 'utf8');
-      expect(src, `${mod}.ts must import the shared flags`).toContain('CPP_PREPROCESS_FLAGS');
-      expect(src, `${mod}.ts re-inlines the probe's flags`).not.toContain("'-P', '-nostdinc'");
+// The probe's claim to BE the failure holds only while its argv is the compile rung's argv, and
+// `CPP_TOOLCHAINS`' claim to name the affected rows holds only while it names every rung that
+// preprocesses. Both are guarded here, and both are guarded against a SCAN rather than a list:
+// the first version of this test looped over the literal ['ido','kmc','gcc272'] — the three files
+// that already existed — so dropping a 4th rung in (`compile/mips3k.ts` with
+// `run(CPP, ['-P','-nostdinc', ...])`) left it 20 passed. A guard against copies must not be a
+// copy of the list it guards. Same technique `fidelity-provenance.test.ts` uses on
+// `check-artifact-provenance.sh`: parse the source of truth, do not restate it.
+const COMPILE_DIR = join(import.meta.dirname, '..', 'src', 'compile');
+const compileSrc = (f: string) => readFileSync(join(COMPILE_DIR, f), 'utf8');
+
+/** Every module under `src/compile` that pulls the HOST `cpp` out of config — discovered. */
+function hostCppRungs(): string[] {
+  return readdirSync(COMPILE_DIR)
+    .filter((f) => f.endsWith('.ts'))
+    .filter((f) => /import\s*\{[^}]*\bCPP\b[^}]*\}\s*from\s*'\.\.\/config'/.test(compileSrc(f)));
+}
+
+describe('the cpp rungs are discovered, not listed', () => {
+  test('every rung that preprocesses does it through the constant the probe uses', () => {
+    const rungs = hostCppRungs();
+    expect(rungs.length, 'no compile module imports CPP — the scan is broken, not the code').toBeGreaterThan(0);
+    for (const f of rungs) {
+      expect(compileSrc(f), `${f} must import the shared flags`).toContain('CPP_PREPROCESS_FLAGS');
+      expect(compileSrc(f), `${f} re-inlines the probe's flags`).not.toContain("'-P', '-nostdinc'");
     }
+  });
+
+  test('CPP_TOOLCHAINS names exactly the toolchain ids those rungs serve', () => {
+    // Derived through `REAL_COMPILERS`, the one table that maps a toolchain id to its rung, so a
+    // rung added later cannot silently degrade a refusal into a warning by being absent from a
+    // hand list. (`CPP_TOOLCHAINS` is load-bearing for the refuse-vs-warn branch.)
+    const real = readFileSync(join(COMPILE_DIR, 'real.ts'), 'utf8');
+    const table = real.slice(real.indexOf('REAL_COMPILERS'), real.indexOf('export function realCompilerFor'));
+    const byExport = new Map<string, string>();
+    for (const f of readdirSync(COMPILE_DIR).filter((x) => x.endsWith('.ts'))) {
+      for (const m of compileSrc(f).matchAll(/export const (\w+)\s*:\s*RealCompile/g)) {
+        byExport.set(m[1], f);
+      }
+    }
+    const rungs = new Set(hostCppRungs());
+    const derived = [...table.matchAll(/^\s*'?([\w.\-]+)'?\s*:\s*(\w+)\s*,/gm)]
+      .filter(([, , sym]) => rungs.has(byExport.get(sym) ?? ''))
+      .map(([, id]) => id);
+    expect(derived.length, 'REAL_COMPILERS did not parse — fix this test, not the constant').toBeGreaterThan(0);
+    expect([...derived].sort()).toEqual([...CPP_TOOLCHAINS].sort());
   });
 });
 
@@ -183,5 +271,41 @@ describe('a broken cpp is fatal only when something here would have used it', ()
     const r = preflightRefusals({ tiers: ['real'] }, { repoRoot: clean, probe: broken, cppUsingToolchains: () => [] });
     expect(r.refusals).toEqual([]);
     expect(r.warnings.join('\n')).toContain('WARNING');
+  });
+
+  test('the SCOPED real run is refused too — that is where the incident actually happens', () => {
+    // Measured on this branch before the fix, same worktree, same row, only ASMLIFT_CPP differing:
+    // `--tier real --only func_800600C0_60CC0` gave `asmlift=diff:27/32` under the GNU shim and
+    // `asmlift=noncompile(1)` under a broken one, exit 0 both times, with the preflight silent.
+    // `attribute-function.md` reads `noncompile` as a signal to act on.
+    for (const opts of [
+      { tiers: ['real' as const], only: 'func_800600C0_60CC0' },
+      { tiers: ['real' as const], project: 'marioparty3' },
+    ]) {
+      const r = preflightRefusals(opts, { repoRoot: clean, probe: broken, cppUsingToolchains: () => ['ido7.1'] });
+      expect(
+        r.refusals.some((m) => m.includes('does not preprocess')),
+        JSON.stringify(opts),
+      ).toBe(true);
+    }
+  });
+
+  test('a synthetic-only run says NOTHING about cpp, whole tier included', () => {
+    // The other direction of the same reversed axis: a whole `--tier synthetic` run was refused
+    // outright under a cpp that six synthetic ido rows then compiled and scored under.
+    for (const opts of [{ tiers: ['synthetic' as const] }, { tiers: ['synthetic' as const], toolchain: 'ido7.1' }]) {
+      const r = preflightRefusals(opts, {
+        repoRoot: clean,
+        probe: broken,
+        cppUsingToolchains: () => {
+          throw new Error('a synthetic run must not even ask which toolchains are installed');
+        },
+      });
+      expect(
+        r.refusals.some((m) => m.includes('does not preprocess')),
+        JSON.stringify(opts),
+      ).toBe(false);
+      expect(r.warnings, JSON.stringify(opts)).toEqual([]);
+    }
   });
 });

--- a/apps/benchmark/test/preflight.test.ts
+++ b/apps/benchmark/test/preflight.test.ts
@@ -55,18 +55,17 @@ describe('which runs are checked at all', () => {
   });
 
   test('`--shard` WITHOUT `--serial` is not a child and is not exempt', () => {
-    // Measured on this branch before the fix: `pnpm bench run --tier synthetic --shard 1/1` on a
-    // tree carrying `?? .envrc.probe` printed no refusal, fanned 8 children over the whole tier
-    // (the fan-out branch never reads `opts.shard`) and headed for a full rewrite of
-    // synthetic.json. `cli.ts` now rejects that argv with exit 2; this pins the second lock.
+    // That argv fans out across `--jobs` children and never reads the shard, so it rewrites the
+    // tier whole while looking like the one shape the exemption is for. `cli.ts` rejects it with
+    // exit 2; this is the second lock, in case the argv ever becomes meaningful.
     expect(runIsWholeTier({ tiers: ['synthetic'], shard: '1/1' })).toBe(true);
     expect(runUsesHostCpp({ tiers: ['real'], shard: '1/1' })).toBe(true);
   });
 });
 
-// The axis wave 2 found reversed: `runIsWholeTier` is a question about REWRITING A TIER FILE and
-// was deciding the `cpp` probe too, which made the probe silent in the scoped loop where TRAP 6
-// lives and loud on a tier that never preprocesses.
+// A separate axis from `runIsWholeTier`, which asks only about REWRITING A TIER FILE. Deciding
+// the probe by that one silences it in the scoped loop, where TRAP 6 lives, and fires it on a tier
+// that never preprocesses.
 describe('which runs touch the host cpp at all', () => {
   test('every real-tier run does — scoped or whole, one row or all of them', () => {
     expect(runUsesHostCpp({ tiers: ['real'] })).toBe(true);
@@ -77,7 +76,7 @@ describe('which runs touch the host cpp at all', () => {
     expect(runUsesHostCpp({ tiers: ['real'], toolchain: 'agbcc' })).toBe(true);
   });
 
-  test('no synthetic-only run does — measured: 6 synthetic ido rows scored under a broken cpp', () => {
+  test('no synthetic-only run does — no synthetic row preprocesses with the host cpp', () => {
     expect(runUsesHostCpp({ tiers: ['synthetic'] })).toBe(false);
     expect(runUsesHostCpp({ tiers: ['synthetic'], toolchain: 'ido7.1' })).toBe(false);
   });
@@ -97,9 +96,8 @@ describe('the dirty-tree refusal', () => {
 
   test('points at the ONE sanctioned name for a local env file', () => {
     // Without a sanctioned name the refusal is just an obstacle, and the round routes around it.
-    // Asserted through the export, not a fifth copy of the literal: the constant exists precisely
-    // to be the single source of truth, and a test that restates the string leaves it with no
-    // consumer at all.
+    // Asserted through the export, not another copy of the literal: the constant exists to be the
+    // single source of truth, and a test that restates the string leaves it with no consumer.
     expect(dirtyTreeRefusal(['?? envrc.sh'])).toContain(LOCAL_ENV_FILE);
     // ...and the scoped home for everything that is not an env file, so the reader is not sent to
     // the main checkout's `info/exclude`, which no worktree ever cleans up.
@@ -131,9 +129,8 @@ describe('the cpp probe refusal', () => {
   });
 });
 
-// The two functions the acceptance criterion is actually about — the probe that decides, and the
-// composition that spawns git — were the two with no test. Neither is pure, so both are given the
-// thing they read (a `cpp` path, a repo root) rather than mocked.
+// The probe that decides and the composition that spawns git. Neither is pure, so both are given
+// the thing they read (a `cpp` path, a repo root) rather than mocked.
 describe('the cpp probe itself', () => {
   test('the incident is caught: a cpp that writes to stdout, ignores -o and exits 1', () => {
     // Apple's /usr/bin/cpp answering as clang, reproduced. Measured against the real binary:
@@ -182,8 +179,6 @@ describe('the whole preflight, against a real throwaway checkout', () => {
   });
 
   test('the same tree does NOT refuse the scoped dev loop', () => {
-    // The GIT axis only. The probe is injected healthy because a scoped real run now DOES ask the
-    // cpp question, and this test is about dirt, not about whichever `cpp` the machine has.
     const dir = repo();
     writeFileSync(join(dir, '.envrc.probe'), 'export FOO=1\n');
     expect(preflightRefusals({ tiers: ['real'], only: 'dmaback' }, { repoRoot: dir, probe: ok })).toEqual({
@@ -203,12 +198,10 @@ describe('the whole preflight, against a real throwaway checkout', () => {
 
 // The probe's claim to BE the failure holds only while its argv is the compile rung's argv, and
 // `CPP_TOOLCHAINS`' claim to name the affected rows holds only while it names every rung that
-// preprocesses. Both are guarded here, and both are guarded against a SCAN rather than a list:
-// the first version of this test looped over the literal ['ido','kmc','gcc272'] — the three files
-// that already existed — so dropping a 4th rung in (`compile/mips3k.ts` with
-// `run(CPP, ['-P','-nostdinc', ...])`) left it 20 passed. A guard against copies must not be a
-// copy of the list it guards. Same technique `fidelity-provenance.test.ts` uses on
-// `check-artifact-provenance.sh`: parse the source of truth, do not restate it.
+// preprocesses. Both are guarded by a SCAN rather than a list: a guard against copies must not be
+// a copy of the list it guards, or a 4th rung dropped into `compile/` passes it. Same technique
+// `fidelity-provenance.test.ts` uses on `check-artifact-provenance.sh`: parse the source of truth,
+// do not restate it.
 const COMPILE_DIR = join(import.meta.dirname, '..', 'src', 'compile');
 const compileSrc = (f: string) => readFileSync(join(COMPILE_DIR, f), 'utf8');
 
@@ -274,10 +267,10 @@ describe('a broken cpp is fatal only when something here would have used it', ()
   });
 
   test('the SCOPED real run is refused too — that is where the incident actually happens', () => {
-    // Measured on this branch before the fix, same worktree, same row, only ASMLIFT_CPP differing:
-    // `--tier real --only func_800600C0_60CC0` gave `asmlift=diff:27/32` under the GNU shim and
-    // `asmlift=noncompile(1)` under a broken one, exit 0 both times, with the preflight silent.
-    // `attribute-function.md` reads `noncompile` as a signal to act on.
+    // Measured, same worktree and row, only ASMLIFT_CPP differing: `--tier real --only
+    // func_800600C0_60CC0` gave `asmlift=diff:27/32` under the GNU shim and `asmlift=noncompile(1)`
+    // under a broken one, exit 0 both times. `attribute-function.md` reads `noncompile` as a
+    // signal to act on.
     for (const opts of [
       { tiers: ['real' as const], only: 'func_800600C0_60CC0' },
       { tiers: ['real' as const], project: 'marioparty3' },
@@ -291,8 +284,8 @@ describe('a broken cpp is fatal only when something here would have used it', ()
   });
 
   test('a synthetic-only run says NOTHING about cpp, whole tier included', () => {
-    // The other direction of the same reversed axis: a whole `--tier synthetic` run was refused
-    // outright under a cpp that six synthetic ido rows then compiled and scored under.
+    // The other direction: synthetic ido rows compile and score fine under a `cpp` this refusal
+    // would have stopped the run for.
     for (const opts of [{ tiers: ['synthetic' as const] }, { tiers: ['synthetic' as const], toolchain: 'ido7.1' }]) {
       const r = preflightRefusals(opts, {
         repoRoot: clean,

--- a/apps/benchmark/test/provenance.test.ts
+++ b/apps/benchmark/test/provenance.test.ts
@@ -5,7 +5,7 @@
 import type { BenchOutput } from '@asmlift/bench-schema';
 import { describe, expect, test } from 'vitest';
 
-import { codeDirtyFrom, combineProvenance } from '../src/provenance';
+import { codeDirtyFrom, codeDirtyPaths, combineProvenance } from '../src/provenance';
 import { checkTierProvenance } from '../src/report/merge';
 
 const tier = (asmlift?: { commit: string; dirty: boolean }): BenchOutput =>
@@ -34,6 +34,16 @@ describe('what counts as a dirty tree', () => {
   test('a clean tree is clean', () => {
     expect(codeDirtyFrom('')).toBe(false);
     expect(codeDirtyFrom('\n')).toBe(false);
+  });
+
+  // The preflight refusal quotes these lines back, so the rule has to survive being asked WHICH
+  // rather than WHETHER: the same exclusions, and the offending lines kept whole (status letters
+  // included) so a reader can tell an untracked file from a modified one without re-running git.
+  test('the same rule can name the offending lines, artifact churn excluded', () => {
+    expect(
+      codeDirtyPaths(' M apps/benchmark/results/results.json\n?? .envrc.probe\n M packages/core/src/rank.ts\n'),
+    ).toEqual(['?? .envrc.probe', 'M packages/core/src/rank.ts']);
+    expect(codeDirtyPaths('')).toEqual([]);
   });
 });
 

--- a/apps/benchmark/test/provenance.test.ts
+++ b/apps/benchmark/test/provenance.test.ts
@@ -42,8 +42,11 @@ describe('what counts as a dirty tree', () => {
   test('the same rule can name the offending lines, artifact churn excluded', () => {
     expect(
       codeDirtyPaths(' M apps/benchmark/results/results.json\n?? .envrc.probe\n M packages/core/src/rank.ts\n'),
-    ).toEqual(['?? .envrc.probe', 'M packages/core/src/rank.ts']);
+    ).toEqual(['?? .envrc.probe', ' M packages/core/src/rank.ts']);
     expect(codeDirtyPaths('')).toEqual([]);
+    // Porcelain's two columns are staged-then-unstaged. Keeping them is the whole point of
+    // "without re-running git": ` M x` (unstaged) and `M  x` (staged) must not collapse.
+    expect(codeDirtyPaths('M  packages/core/src/rank.ts\n')).toEqual(['M  packages/core/src/rank.ts']);
   });
 });
 


### PR DESCRIPTION
## What this is

`bench run` now refuses, at second 0, to start a run that rewrites a tier file WHOLE on a working
tree whose code differs from `HEAD` — and names the files it counted. It also probes the host `cpp`
before any run that touches the real tier.

Both refusals exist because the loss they prevent was already being taken, ~39 minutes late:

- **The dirty tree.** `report/merge.ts` (line 35) already throws on any tier whose run stamp came
  back `dirty: true`, and that stamp is sticky from `orchestrate`'s pre-spawn sample. So every tree
  this new check rejects is a tree whose run `bench:merge` would have rejected anyway. The refusal
  is a strict subset of an existing refusal, moved ~2,350 s earlier. Twice the dirty path was a
  single untracked env file in a worktree.
- **The `cpp` probe.** A login shell resolves `cpp` to Apple clang, which ignores `-o`, writes the
  preprocessed text to stdout and exits 1. 44 real-tier rows came back `noncompile` while the run
  printed `✓` on both tiers and exited 0. The probe *is* that failure, run on one line of C
  through the same argv the rungs use — it does not ask which `cpp` is on PATH, only whether that
  one honours `-o`.

## Premises verified — and the one that was false

| premise | verdict |
|---|---|
| `codeDirtyFrom(porcelain)` in `provenance.ts` is a pure string predicate, callable at run start | TRUE (`git status --porcelain` measured at 27 ms) |
| `merge.ts` already refuses a dirty run stamp, so this refuses strictly less | TRUE — `report/merge.ts:35` |
| root `.gitignore` has no env-file entry | TRUE |
| the command briefs have a "worktree-setup line" to name the env file in | **FALSE** — neither brief contains any worktree/symlink/env setup text at all; that lives only in a memory file. The name went into the full-bench step of each brief instead, which is the step the refusal fires in |
| `--toolchain` narrows the real tier | **FALSE** — `cases/real.ts` takes only `project`/`only`, so `--tier real --toolchain agbcc` still compiles every gcc272 row. A proposed `&& CPP_TOOLCHAINS.includes(toolchain)` clause on the cpp predicate was dropped for this reason; the tier is the whole answer |
| the `.trim()` comment's stated mechanism (`' M x'` and `'M  x'` trim to the same string) | **FALSE** — measured, they do not. The code was right; only its reason was. `trim()` eats the LEADING column, so unstaged ` M x` comes back reading as staged. Rewritten, and `provenance.test.ts` now pins both columns |
| "the main checkout's `info/exclude` is 113 lines, 24 unique, 40 copies of one pattern" | partly false and machine-local — 113 ✓, 17 unique *patterns*, and **two** of them have 40 copies. Removed from the shipped prose; the *why* is kept |

## Scope — what is deliberately NOT refused

Two laws, two predicates, because they are different questions:

- `runIsWholeTier` — "does this invocation rewrite a tier file whole?" The Phase-3 dev loop
  (`bench run --tier real --only <sym>`) is *meant* to run on a dirty tree, and refusing it would
  have got this whole check traded away inside one round. Non-obvious case pinned in a test:
  `--tier both --toolchain agbcc` IS refused, because `--toolchain` filters synthetic only, so
  `real.json` is still rewritten whole.
- `runUsesHostCpp` — "will this invocation preprocess with the host `cpp`?" Answered by the tier
  alone. The first shape of this shipped one predicate for both laws, and it was **backwards**:
  loud on the synthetic tier, which never preprocesses, and silent on the scoped real loop, which
  is exactly where the incident lives. Measured before the fix:
  `--tier real --only func_800600C0_60CC0 --serial` under `/usr/bin/cpp` returned `noncompile`,
  exit 0, with the preflight saying nothing.
- A shard child (`--serial --shard i/N`, how `orchestrate.ts` spawns) is exempt from both — the
  parent already answered them.
- `cpp` broken **and** no MIPS toolchain installed → WARN, not refuse: those rows were going to
  `SKIP` anyway, which keeps the harness's standing policy instead of inventing a stricter one at
  the door. `availableToolchains()` (231 ms) is consulted only on the branch that is already
  failing, so a healthy machine pays nothing but the 42 ms probe.

## Commits

- `59e3442b` **Let the dirty-tree rule name the files it counted** — `codeDirtyPaths(porcelain)`
  added to `provenance.ts`; `codeDirtyFrom` becomes its emptiness test. Same exclusions, same
  predicate.
- `dc385d7e` **Refuse a whole-tier bench run that starts on a dirty tree** — new
  `run/preflight.ts`, wired into `cli.ts` `case 'run'` before `assertM2cPinned()`.
- `15eb49f9` **Give a worktree's local env file a gitignored name, and name it in both briefs** —
  `.envrc.local` in `.gitignore`, written into `match-function.md` Phase 4 and
  `attribute-function.md` Phase 7.
- `4cbbd58d` **Keep git status' staged column in the paths the refusal names** — `.trim()` →
  `replace(/\s+$/, '')`.
- `8b36c3c6` **Preprocess candidates through one cpp argv instead of three copies of it** —
  `CPP_PREPROCESS_FLAGS` in `compile/util.ts`, consumed by `ido.ts`, `kmc.ts`, `gcc272.ts` and the
  probe. The probe's claim to *be* the failure holds only while its argv is the rungs' argv.
- `626ce6ca` **Say what a scoped bench run really does, and let a broken cpp be fatal only when it
  matters** — a scoped run is not read-only: it rewrites `results/<tier>.json` with only its rows.
- `4b83dc81` **Ask the cpp question on the axis the cpp incident lives on, and stop letting
  `--shard` turn the preflight off** — `runUsesHostCpp`; and `--shard` without `--serial` now exits
  2 (that argv was a mis-parse independent of this branch: `cli.ts`'s fan-out branch never read
  `opts.shard`, so it fanned across 8 children and ignored the shard).
- `32878101` **The dirty-path comment explained the rule by a string identity that is not true** —
  comment audit; the false `.trim()` rationale, an over-claiming "That is Apple clang" for every
  probe failure, a stale line citation, and machine-local numbers that drift by the hour.

## Bench

**Yes, this touches a measured path**, so a full bench was run rather than skipped:
`apps/benchmark/src/` gains `run/preflight.ts` and edits to `cli.ts`, `provenance.ts` and
`compile/{util,ido,kmc,gcc272}.ts`. The last four are the argv refactor, which is the only edit on
this branch that a compiled row could possibly see.

One full `pnpm bench run`, clean tree, `cpp` = the GNU shim:

```
✓ synthetic: 783 results in 211.1s → results/synthetic.json
✓ real:      252 results in 6605.0s → results/real.json
Done in 6605.2s.   EXIT=0
pnpm bench:merge                     Merged 1035 results (783 synthetic + 252 real)
pnpm bench regression --base origin/main   0 lost, 0 missing, 0 gained, 0 other flips (1035 rows)
pnpm bench diff --base origin/main         0 field change(s), 0 added, 0 removed
                                           (1035 base rows, 1035 fresh rows)
```

**Moved-row inventory: empty.** Not "0 outcome flips" — 0 FIELD changes across all 1035 rows, so
the source bytes, scores, candidate labels and gap counts are identical to `origin/main`'s
artifact. `apps/web/src/data/summary.json` regenerated with the same totals (asmlift 598, m2c 412);
its only diff was `meta.commit`.

The real tier took 110 minutes rather than the usual ~25. That is one row —
`kleod:ProcessInputAndUpdateEntities:agbcc`, whose shard logged 156,079 candidate compiles with
77,912 uncacheable keys — on a machine whose load average sat between 10 and 25 from other work.
Every other shard finished in under 20 minutes. Nothing on this branch is on that path.

**The artifact is NOT committed.** With 0 field changes over 1035 rows, committing it would
republish identical numbers under a new stamp and make this branch "publish numbers of its own" for
no reason. `scripts/check-artifact-provenance.sh` exits 0: *artifact is byte-identical to the
base's — this branch publishes no numbers of its own.*

## Reviewer findings declined, with reasons

- **Fold `assertM2cPinned()` into `preflightRefusals`.** The two preflight verdicts are each gated
  on a predicate (whole-tier / touches-real); the m2c pin applies to **every** run, shard children
  and `--only` included, and throws its own remediation line. Folding it in would either change
  when it fires or add a third "always" gate inside a function whose whole shape is conditional,
  and it would drag `eval/m2c` into every unit test of the preflight (`cli.ts` imports it
  dynamically on purpose). The reason is written into `cli.ts` where the next author will read it.
- **Split `probeCpp`'s `{ok, how}` return type** (`how: 'ok'` is never read). The uniform shape is
  what makes the function injectable as one value in `PreflightDeps`.
- **A drift test for the four `.envrc.local` literals.** Three of the four are prose, and a wrong
  copy costs a reader one confused minute, not a run — unlike the argv copies, whose drift would
  silently degrade the probe into "some cpp somewhere honours `-o`". That one was fixed
  structurally (`8b36c3c6`) rather than tested.
- **`bench fidelity` gets no preflight.** A real gap — `cpp` breaks it identically — but a
  different command with a different cost profile, and bolting it on here would make this branch's
  acceptance criterion untestable.
- **The one-line availability check** `idoAvailable() || gcc272Available() || <kmc>`.
  `gcc272Available()` and the kmc check *are* `dockerAvailable()`, so the one-liner pays 231 ms on
  every healthy run. The lazy form gets the same semantics for free.
- **`&& CPP_TOOLCHAINS.includes(toolchain)` on the cpp predicate.** Dropped as wrong — see the
  premise table; it would have re-opened the hole it was meant to narrow.
- **A subprocess test that `cli.ts` exits 1.** Measured by hand instead (exit 1, 0.73 s); a test
  that boots tsx and pnpm per assertion costs more than the one line of wiring it pins.

Findings that were CONFIRMED and fixed rather than declined, for the record: the message taught a
false invariant about scoped runs (measured, twice); `--shard` without `--serial` turned the whole
preflight off (reproduced: 8 part files on disk, no refusal); the drift guard added in wave 1 was a
copy of the list it guards (reproduced with an injected `compile/mips3k.ts` rung — the old guard
passed, the replacement fails); `LOCAL_ENV_FILE` was exported with zero consumers; the sanctioned
escape hatch was an unbounded repo-global mutation; the path list was uncapped; `probeCpp` leaked a
temp dir per run.

## Gate counts

```
pnpm bench run                            ✓ synthetic (783) · ✓ real (252) · EXIT=0
pnpm bench:merge                          1035 results
pnpm bench regression --base origin/main  0 lost, 0 missing, 0 gained, 0 other flips
pnpm bench diff --base origin/main        0 field changes, 0 added, 0 removed
npx vitest run                            212 files · 3708 passed | 2 skipped
pnpm test:matching                        41 files · 359 passed
pnpm exec vitest run apps/benchmark/test  32 files · 787 passed | 2 skipped
pnpm typecheck                            clean
pnpm lint                                 0 errors · 126 warnings (unchanged; none in touched files)
pnpm format                               clean, tree unchanged
scripts/check-artifact-provenance.sh      exit 0
```

`git rebase origin/main` was a no-op: `77a635f1` was already this branch's merge-base, so the
earlier items merged in this chain are all under it.

## What this does NOT do

- It does not refuse a scoped run on a dirty tree, and it does not make one read-only.
- It does not preflight `bench fidelity`, `bench merge`, or any command but `bench run`.
- It does not load `.envrc.local`. That is a gitignored *name*, not a loader — `source` it
  yourself; both briefs say so.
- It changes no decompiler behaviour and moves no benchmark row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
