### PR TITLE
Sweep the name-coalescing fuzz at 4,000 seeds again, and pin the witnesses it cannot reach

### DIFF
--- a/apps/benchmark/dataset/synthetic.ts
+++ b/apps/benchmark/dataset/synthetic.ts
@@ -6271,9 +6271,8 @@ export const SYNTHETIC: SynthSpec[] = [
   //    refuses one gate later on `loop-escape` (`structure/namecoalesce.ts`), which that file
   //    called blunter than the hazard it restates and which is in fact LOAD-BEARING — dropping it
   //    lets an inner loop's variable adopt the enclosing loop's carrier and overwrite it every
-  //    iteration, so the function computes something else. Both witnesses are frozen as literal IR
-  //    in `namecoalesce.test.ts`; no arm of `namecoalesce-fuzz` reaches them, because its ablating
-  //    arm filters on `sound` and this gate is not. Taking the second half
+  //    iteration, so the function computes something else — frozen as IR in `namecoalesce.test.ts`,
+  //    where the differential sweep cannot reach it. Taking the second half
   //    needs `carriesPreUpdate` lifted to name classes, which that file already names as the work.
   //    The other door — waiving `enclosingNames` in the loop-header seeding — reaches 11 under a
   //    probe and would be a new ranked axis with the same soundness question.

--- a/apps/benchmark/dataset/synthetic.ts
+++ b/apps/benchmark/dataset/synthetic.ts
@@ -6270,8 +6270,10 @@ export const SYNTHETIC: SynthSpec[] = [
   //    NOT this walk: with the interference rule made edge-aware the same way, `/merge-names`
   //    refuses one gate later on `loop-escape` (`structure/namecoalesce.ts`), which that file
   //    called blunter than the hazard it restates and which is in fact LOAD-BEARING — dropping it
-  //    makes 2 of 7,535 nested generated functions compute something else
-  //    (`namecoalesce-fuzz.test.ts`, `depth: 2`, seeds 5104 and 6437). Taking the second half
+  //    lets an inner loop's variable adopt the enclosing loop's carrier and overwrite it every
+  //    iteration, so the function computes something else. Both witnesses are frozen as literal IR
+  //    in `namecoalesce.test.ts`; no arm of `namecoalesce-fuzz` reaches them, because its ablating
+  //    arm filters on `sound` and this gate is not. Taking the second half
   //    needs `carriesPreUpdate` lifted to name classes, which that file already names as the work.
   //    The other door — waiving `enclosingNames` in the loop-header seeding — reaches 11 under a
   //    probe and would be a new ranked axis with the same soundness question.

--- a/packages/core/src/structure/namecoalesce.ts
+++ b/packages/core/src/structure/namecoalesce.ts
@@ -62,12 +62,26 @@
 // are not the hazard, none of which this has. It IS load-bearing, and the measurement that says so
 // is not a benchmark one: dropping it over 773 rows improves 12 and regresses none (#55), and
 // `nestedloop` is `int s = 0; … s += i*j`, one accumulator the pass emits as two — but with it
-// dropped, `namecoalesce-fuzz`'s NESTED arm finds two generated functions in 7,535 that compute
-// something else, and it finds them with the interference rule at either strength. A byte score
+// dropped, two generated functions COMPUTE SOMETHING ELSE: an inner loop's variable adopts the
+// enclosing loop's carrier and then overwrites it every iteration. Both are frozen as literal IR in
+// `namecoalesce.test.ts`, which asserts the escape copy the gate forces on one side and its absence
+// on the other. NO ARM OF `namecoalesce-fuzz` FINDS THEM and no sweep size ever will: its ablating
+// arm iterates `NAME_COALESCE_GATES.filter((x) => x.sound)` and this entry is `sound: false`, so the
+// barrier is a predicate, not a range. They were found by ablating BY NAME at depth 2, first witness
+// seed 5104 and second 6437, with nothing at all in 1..4000. A byte score
 // cannot see that failure, which is the whole reason that fuzz exists. So the 12 rows are real and
 // so is the hazard, and taking them still needs `carriesPreUpdate` lifted to name classes: the
 // class-level closure, since a merge can reach a loop variable's name through an edge that carried
 // no loop variable at all.
+//
+// THE UNCOMFORTABLE PART, recorded here because this is where the flag is set. A rule whose removal
+// changes what the program COMPUTES is a legality property, and `sound: false` in this table means
+// fidelity — its neighbour `param` genuinely is fidelity. So the flag reads wrong. Relabelling it is
+// not free: `namecoalesce-fuzz`'s ablating arm would then sweep it and demand a witness inside
+// `SEEDS`, and there is none — measured, the only two witnesses in 1..7000 are 5104 and 6437, both
+// at depth 2. So the flag stays `false` on the second criterion above (not shown sound, and blunter
+// than the rule it restates), the coverage does not wait on it, and this note is the whole argument
+// so it is not re-derived in a test file.
 //
 // TWO KNOWN GAPS, both on the READ side of a relocated write:
 //
@@ -183,6 +197,10 @@ export const NAME_COALESCE_GATES: readonly Gate<NameMerge>[] = [
     id: 'loop-escape',
     why: 'outside the loop a loop variable’s name holds the value from BEFORE the update',
     sound: false,
+    // Unsound gates owe no guard, but this one HAS one and it is the only evidence that exists —
+    // the fuzz next door structurally cannot reach it (see the header), so naming the test is what
+    // keeps `gate-contract`'s title check from letting it be deleted silently.
+    guardedBy: 'namecoalesce.test.ts: ablating loop-escape lets an inner loop clobber the enclosing loop variable',
     rejects: (c) => c.loopEscapes,
   },
 ];

--- a/packages/core/src/structure/namecoalesce.ts
+++ b/packages/core/src/structure/namecoalesce.ts
@@ -57,31 +57,24 @@
 // the outer variable's home is outside the inner body, a disjoint pair in both directions — so the
 // enclosing-loop rule needs no gate of its own.
 //
-// It is NOT marked sound, because it has not been shown to be, and it is BLUNTER than the rule it
-// restates: `carriesPreUpdate` branches on which emitter owns the latch and names four shapes that
-// are not the hazard, none of which this has. It IS load-bearing, and the measurement that says so
-// is not a benchmark one: dropping it over 773 rows improves 12 and regresses none (#55), and
-// `nestedloop` is `int s = 0; … s += i*j`, one accumulator the pass emits as two — but with it
-// dropped, two generated functions COMPUTE SOMETHING ELSE: an inner loop's variable adopts the
-// enclosing loop's carrier and then overwrites it every iteration. Both are frozen as literal IR in
-// `namecoalesce.test.ts`, which asserts the escape copy the gate forces on one side and its absence
-// on the other. NO ARM OF `namecoalesce-fuzz` FINDS THEM and no sweep size ever will: its ablating
-// arm iterates `NAME_COALESCE_GATES.filter((x) => x.sound)` and this entry is `sound: false`, so the
-// barrier is a predicate, not a range. They were found by ablating BY NAME at depth 2, first witness
-// seed 5104 and second 6437, with nothing at all in 1..4000. A byte score
-// cannot see that failure, which is the whole reason that fuzz exists. So the 12 rows are real and
-// so is the hazard, and taking them still needs `carriesPreUpdate` lifted to name classes: the
-// class-level closure, since a merge can reach a loop variable's name through an edge that carried
-// no loop variable at all.
+// It is BLUNTER than the rule it restates: `carriesPreUpdate` branches on which emitter owns the
+// latch and names four shapes that are not the hazard, none of which this has. It IS load-bearing,
+// and the measurement that says so is not a benchmark one: dropping it over 773 rows improves 12
+// and regresses none (#55), and `nestedloop` is `int s = 0; … s += i*j`, one accumulator the pass
+// emits as two — but with it dropped, two generated functions COMPUTE SOMETHING ELSE: an inner
+// loop's variable adopts the enclosing loop's carrier and then overwrites it every iteration. Both
+// are frozen as literal IR in `namecoalesce.test.ts`, which asserts the escape copy the gate forces
+// on one side and its absence on the other. A byte score cannot see that failure, which is the
+// whole reason that fuzz exists. So the 12 rows are real and so is the hazard, and taking them
+// still needs `carriesPreUpdate` lifted to name classes: the class-level closure, since a merge can
+// reach a loop variable's name through an edge that carried no loop variable at all.
 //
-// THE UNCOMFORTABLE PART, recorded here because this is where the flag is set. A rule whose removal
-// changes what the program COMPUTES is a legality property, and `sound: false` in this table means
-// fidelity — its neighbour `param` genuinely is fidelity. So the flag reads wrong. Relabelling it is
-// not free: `namecoalesce-fuzz`'s ablating arm would then sweep it and demand a witness inside
-// `SEEDS`, and there is none — measured, the only two witnesses in 1..7000 are 5104 and 6437, both
-// at depth 2. So the flag stays `false` on the second criterion above (not shown sound, and blunter
-// than the rule it restates), the coverage does not wait on it, and this note is the whole argument
-// so it is not re-derived in a test file.
+// WHY THE FLAG IS `false` ANYWAY, recorded here because this is where it is set. By `gates.ts`'s
+// definition — remove it and some candidate is WRONG — this gate qualifies, and the two frozen
+// witnesses are the proof. It stays `false` on the bluntness above: what is shown wrong is the
+// SHAPE this rejects, not the rule as written, which also refuses merges `carriesPreUpdate` would
+// allow. Flipping it costs a line in `namecoalesce-fuzz`'s `OUT_OF_REACH` — the ablating arm has no
+// witness inside `SEEDS` — and buys no coverage that `namecoalesce.test.ts` does not already hold.
 //
 // TWO KNOWN GAPS, both on the READ side of a relocated write:
 //
@@ -197,9 +190,8 @@ export const NAME_COALESCE_GATES: readonly Gate<NameMerge>[] = [
     id: 'loop-escape',
     why: 'outside the loop a loop variable’s name holds the value from BEFORE the update',
     sound: false,
-    // Unsound gates owe no guard, but this one HAS one and it is the only evidence that exists —
-    // the fuzz next door structurally cannot reach it (see the header), so naming the test is what
-    // keeps `gate-contract`'s title check from letting it be deleted silently.
+    // Not required of an unsound gate, and named anyway: the differential fuzz never ablates this
+    // one, so the frozen witnesses are its only evidence and `gate-contract` pins their test.
     guardedBy: 'namecoalesce.test.ts: ablating loop-escape lets an inner loop clobber the enclosing loop variable',
     rejects: (c) => c.loopEscapes,
   },

--- a/packages/core/test/carrier-name-fuzz.test.ts
+++ b/packages/core/test/carrier-name-fuzz.test.ts
@@ -41,19 +41,26 @@ const ADMIT_NOTHING: readonly Gate<CarrierName>[] = [
 ];
 
 // SIZED, not maximal, but the size is now a statement about the sweep rather than about the
-// runner. This stood at 250 for two days: at 4,000 this file plus the nested arm next door put 30%
-// more CPU into `test:offline` than vitest's own reporter could keep up with, and two of three runs
-// ended `2696 passed` plus an unhandled `[vitest-worker]: Timeout calling "onTaskUpdate"`, which
-// fails the job. That was never a CPU ceiling — the birpc reply had already arrived, and its 60 s
-// timer matured first only because the sweep never yielded. `breathe()` below fixed the cause, so
-// the number it forced is no longer owed to anyone.
+// runner. This stood at 250 for two days: at 4,000 this file plus the nested arm next door ended
+// two of three `test:offline` runs on `2696 passed` plus an unhandled `[vitest-worker]: Timeout
+// calling "onTaskUpdate"`, which fails the job. That was never a CPU ceiling — the birpc reply had
+// already arrived, and its 60 s timer matured first only because the sweep never yielded.
+// `breathe()` below fixed the cause, so the number it forced is no longer owed to anyone.
+//
+// The 30% of `test:offline` that cut was justified by (102.9 -> 134.2 s, on the two-core hosted
+// runner) was the price of these two arms EXISTING, not of their size: restoring only the seed
+// counts measures +6.6 s of test CPU here, ~6.5% of a ~102 s baseline, and the two files cost
+// +12.9 s between them. Quote that pair of numbers rather than the 30% if you are budgeting.
 //
 // Back to 4,000, the size the two arms that predate this file have always run. Arm A is the
 // expensive half — it structures every generated function TWICE, three depths — and 16x of it
-// costs this file a few seconds; arm B is flat in SEEDS, since it stops at the first seed that
-// proves a gate load-bearing and every reachable one does that within the first handful. RAISE IT
-// FURTHER when hunting: the `loop-escape` finding next door was taken at 8,000, and its two seeds
-// (5104 and 6437) are outside even this range.
+// costs this file a few seconds; arm B is near-flat in SEEDS, since it stops at the first seed that
+// proves a gate load-bearing, though not always early: `sibling-param`'s first acyclic witness is
+// seed 289, past where this sat, and only depth 1's seed 52 kept that gate proven at 250.
+//
+// RAISING THIS DOES NOT REACH `loop-escape`, and never could: that finding belongs to
+// `namecoalesce-fuzz`, and the arm that would ablate it filters on `sound`, which the table denies
+// that gate. It is pinned by seed over there instead. The barrier is a predicate, not a range.
 const SEEDS = 4000;
 
 /** Both spellings of one seed, or null when the shape is not one this can judge. */

--- a/packages/core/test/carrier-name-fuzz.test.ts
+++ b/packages/core/test/carrier-name-fuzz.test.ts
@@ -40,18 +40,21 @@ const ADMIT_NOTHING: readonly Gate<CarrierName>[] = [
   },
 ];
 
-// SIZED, not maximal, and the size is a CI budget rather than a confidence statement. Arm A is the
-// expensive half — it structures every generated function TWICE — and `test:offline` shares a
-// two-core runner with `narrowlocal-fuzz`, which alone takes a minute there. At 4,000 this file
-// plus the nested arm next door put 30% more CPU into that suite than vitest's own reporter could
-// keep up with: two of three runs ended `2696 passed` and an unhandled
-// `[vitest-worker]: Timeout calling "onTaskUpdate"`, which fails the job.
+// SIZED, not maximal, but the size is now a statement about the sweep rather than about the
+// runner. This stood at 250 for two days: at 4,000 this file plus the nested arm next door put 30%
+// more CPU into `test:offline` than vitest's own reporter could keep up with, and two of three runs
+// ended `2696 passed` plus an unhandled `[vitest-worker]: Timeout calling "onTaskUpdate"`, which
+// fails the job. That was never a CPU ceiling — the birpc reply had already arrived, and its 60 s
+// timer matured first only because the sweep never yielded. `breathe()` below fixed the cause, so
+// the number it forced is no longer owed to anyone.
 //
-// 250 still judges an order of magnitude more functions than the vacuity guard below asks for, and
-// arm B is unaffected — it stops at the first seed that proves a gate load-bearing, which every
-// reachable one does within the first handful. RAISE IT LOCALLY when hunting: that is how the
-// `loop-escape` finding next door was taken, at 8,000.
-const SEEDS = 250;
+// Back to 4,000, the size the two arms that predate this file have always run. Arm A is the
+// expensive half — it structures every generated function TWICE, three depths — and 16x of it
+// costs this file a few seconds; arm B is flat in SEEDS, since it stops at the first seed that
+// proves a gate load-bearing and every reachable one does that within the first handful. RAISE IT
+// FURTHER when hunting: the `loop-escape` finding next door was taken at 8,000, and its two seeds
+// (5104 and 6437) are outside even this range.
+const SEEDS = 4000;
 
 /** Both spellings of one seed, or null when the shape is not one this can judge. */
 function spellings(seed: number, depth: 0 | 1 | 2, drop?: string): { off: Event[]; on: Event[] } | null {

--- a/packages/core/test/carrier-name-fuzz.test.ts
+++ b/packages/core/test/carrier-name-fuzz.test.ts
@@ -40,37 +40,20 @@ const ADMIT_NOTHING: readonly Gate<CarrierName>[] = [
   },
 ];
 
-// SIZED, not maximal, but the size is now a statement about the sweep rather than about the
-// runner. This stood at 250 for two days: at 4,000 this file plus the nested arm next door ended
-// two of three `test:offline` runs on `2696 passed` plus an unhandled `[vitest-worker]: Timeout
-// calling "onTaskUpdate"`, which fails the job. That was never a CPU ceiling — the birpc reply had
-// already arrived, and its 60 s timer matured first only because the sweep never yielded.
-// `breathe()` below fixed the cause, so the number it forced is no longer owed to anyone.
+// SIZED, not maximal: 4,000 is the size the sibling fuzz's arms run, and the cost of matching it is
+// single-digit seconds of CPU against `test:offline`'s ~102 s. Arm A is the expensive half — it
+// structures every generated function TWICE, at three depths; arm B is near-flat in SEEDS, since it
+// stops at the first seed that proves a gate load-bearing.
 //
-// The 30% of `test:offline` that cut was justified by (102.9 -> 134.2 s, on the two-core hosted
-// runner) was the price of these two arms EXISTING, not of their size. What the seed counts
-// themselves cost, re-measured on a 10-core laptop under load: this file alone 2.6 -> 6.2 s of user
-// CPU (+3.6), this file plus the nested arm next door 4.0 -> 12.5 s (+8.5). The same pair came out
-// at +6.6 and +12.9 on the runner, so quote a number with the machine attached — the part that does
-// not move between boxes is the shape: single-digit seconds against a ~102 s baseline, not 30%.
+// WHAT THE SIZE BUYS HERE IS ARM A's BREADTH, NOT GATE COVERAGE. Measured: cut to 250 all four
+// tests still pass, because every sound gate keeps a witness under it — `sibling-param`'s first
+// ACYCLIC witness is seed 289, but depth 1's seed 52 proves it anyway; `carrier-live` lands at seed
+// 6 and `re-derives` at 22. Gate coverage is what a small size costs NEXT DOOR: `namecoalesce-fuzz`
+// goes red at 250, its `sibling-params` having no witness before seed 299 at any depth.
 //
-// Back to 4,000, the size the two arms that predate this file have always run. Arm A is the
-// expensive half — it structures every generated function TWICE, three depths — and 16x of it
-// costs this file a few seconds; arm B is near-flat in SEEDS, since it stops at the first seed that
-// proves a gate load-bearing.
-//
-// WHAT 4,000 BUYS HERE IS ARM A's BREADTH, NOT GATE COVERAGE — worth being exact about, because the
-// two live in different files. Measured: with this file alone cut to 250, all four of its tests
-// still pass. Every sound gate here is still proven — `sibling-param`'s first ACYCLIC witness is
-// seed 289, past where this sat, but depth 1's seed 52 proves it anyway; `carrier-live` lands at
-// seed 6 and `re-derives` at 22. The gate coverage 250 actually costs is NEXT DOOR, and it is a
-// different gate with a nearby number: `namecoalesce-fuzz`'s ablating arm goes RED at 250, because
-// its own `sibling-params` has no witness before seed 299 at any depth.
-//
-// RAISING THIS DOES NOT REACH `loop-escape`, and never could: that finding belongs to the
-// `namecoalesce` tables, and the arm that would ablate it filters on `sound`, which the table
-// denies that gate. Its two witnesses are frozen as literal IR in `namecoalesce.test.ts` instead.
-// The barrier is a predicate, not a range.
+// RAISING THIS DOES NOT REACH `namecoalesce`'s `loop-escape`, and never could — the arm that would
+// ablate it filters on `sound`, which that table denies the gate. The barrier is a predicate, not a
+// range, and its witnesses are frozen as IR in `namecoalesce.test.ts` instead.
 const SEEDS = 4000;
 
 /** Both spellings of one seed, or null when the shape is not one this can judge. */

--- a/packages/core/test/carrier-name-fuzz.test.ts
+++ b/packages/core/test/carrier-name-fuzz.test.ts
@@ -48,19 +48,29 @@ const ADMIT_NOTHING: readonly Gate<CarrierName>[] = [
 // `breathe()` below fixed the cause, so the number it forced is no longer owed to anyone.
 //
 // The 30% of `test:offline` that cut was justified by (102.9 -> 134.2 s, on the two-core hosted
-// runner) was the price of these two arms EXISTING, not of their size: restoring only the seed
-// counts measures +6.6 s of test CPU here, ~6.5% of a ~102 s baseline, and the two files cost
-// +12.9 s between them. Quote that pair of numbers rather than the 30% if you are budgeting.
+// runner) was the price of these two arms EXISTING, not of their size. What the seed counts
+// themselves cost, re-measured on a 10-core laptop under load: this file alone 2.6 -> 6.2 s of user
+// CPU (+3.6), this file plus the nested arm next door 4.0 -> 12.5 s (+8.5). The same pair came out
+// at +6.6 and +12.9 on the runner, so quote a number with the machine attached — the part that does
+// not move between boxes is the shape: single-digit seconds against a ~102 s baseline, not 30%.
 //
 // Back to 4,000, the size the two arms that predate this file have always run. Arm A is the
 // expensive half — it structures every generated function TWICE, three depths — and 16x of it
 // costs this file a few seconds; arm B is near-flat in SEEDS, since it stops at the first seed that
-// proves a gate load-bearing, though not always early: `sibling-param`'s first acyclic witness is
-// seed 289, past where this sat, and only depth 1's seed 52 kept that gate proven at 250.
+// proves a gate load-bearing.
 //
-// RAISING THIS DOES NOT REACH `loop-escape`, and never could: that finding belongs to
-// `namecoalesce-fuzz`, and the arm that would ablate it filters on `sound`, which the table denies
-// that gate. It is pinned by seed over there instead. The barrier is a predicate, not a range.
+// WHAT 4,000 BUYS HERE IS ARM A's BREADTH, NOT GATE COVERAGE — worth being exact about, because the
+// two live in different files. Measured: with this file alone cut to 250, all four of its tests
+// still pass. Every sound gate here is still proven — `sibling-param`'s first ACYCLIC witness is
+// seed 289, past where this sat, but depth 1's seed 52 proves it anyway; `carrier-live` lands at
+// seed 6 and `re-derives` at 22. The gate coverage 250 actually costs is NEXT DOOR, and it is a
+// different gate with a nearby number: `namecoalesce-fuzz`'s ablating arm goes RED at 250, because
+// its own `sibling-params` has no witness before seed 299 at any depth.
+//
+// RAISING THIS DOES NOT REACH `loop-escape`, and never could: that finding belongs to the
+// `namecoalesce` tables, and the arm that would ablate it filters on `sound`, which the table
+// denies that gate. Its two witnesses are frozen as literal IR in `namecoalesce.test.ts` instead.
+// The barrier is a predicate, not a range.
 const SEEDS = 4000;
 
 /** Both spellings of one seed, or null when the shape is not one this can judge. */

--- a/packages/core/test/namecoalesce-fuzz.test.ts
+++ b/packages/core/test/namecoalesce-fuzz.test.ts
@@ -92,31 +92,15 @@ describe.each([
   });
 });
 
-// THE ONE PIECE OF EVIDENCE NO SWEEP ABOVE CAN PRODUCE, pinned rather than hunted for.
-//
-// `namecoalesce.ts` credits this arm with the `loop-escape` finding: dropped, that gate makes some
-// nested functions compute something else. No shipped arm has ever ablated it, and raising `SEEDS`
-// never will — arm B below iterates `NAME_COALESCE_GATES.filter((x) => x.sound)` and the table
-// declares `loop-escape` `sound: false`, so the barrier is a PREDICATE, not a range. (The seeds are
-// also outside 4,000: measured, there is no witness at all in 1..4000 at depth 2.) The recipe, for
-// whoever comes to reproduce it: drop the gate BY NAME, depth 2, at least 6,437 seeds.
-//
-// Pinned two-sided — with the gate KEPT both seeds trace identically — so this asserts the gate's
-// own work, not a difference the pass would make regardless. Which is also the uncomfortable part:
-// a rule whose removal changes what the program COMPUTES is a legality property, while `sound:
-// false` in this table means fidelity (its neighbour `param` genuinely is fidelity). Relabelling it
-// is not free — arm B would then sweep the gate and go red at `SEEDS` = 4000, since its first
-// witness is 5104 — so that stays its own decision, and this coverage does not wait on it.
-test('`loop-escape` is load-bearing, at the two seeds no sweep in this file reaches', () => {
-  for (const seed of [5104, 6437]) {
-    const dropped = spellings(seed, 2, 'loop-escape');
-    const kept = spellings(seed, 2);
-    expect(dropped, `seed ${seed} must still be a shape this can judge`).not.toBeNull();
-    expect(kept, `seed ${seed} must still be a shape this can judge`).not.toBeNull();
-    expect(tracesDiffer(dropped!), `seed ${seed}: dropping \`loop-escape\` must change the trace`).toBe(true);
-    expect(tracesDiffer(kept!), `seed ${seed}: with \`loop-escape\` kept the trace must not change`).toBe(false);
-  }
-});
+// THE ONE GATE IN THE TABLE THIS FILE CANNOT JUDGE AT ANY SIZE. Arm B below iterates
+// `NAME_COALESCE_GATES.filter((x) => x.sound)` and the table declares `loop-escape` `sound: false`,
+// so no arm here has ever ablated it and raising `SEEDS` never will — the barrier is a PREDICATE,
+// not a range. (It is also out of range: measured, the only two witnesses in 1..7000 are 5104 and
+// 6437, both at depth 2.) Its evidence is two of those functions FROZEN AS IR in
+// `namecoalesce.test.ts`, asserted two-sided there — a seed replayed here would break on any edit
+// to `generateSsaFn` and would then read as the gate being inert. To re-hunt: drop the gate by
+// name, depth 2, at least 6,437 seeds. Why the flag stays `false` is argued once, in
+// `namecoalesce.ts`'s header, where the flag is set.
 
 // The one sound rule this generator cannot reach, and why. `type` needs two names whose
 // DECLARATIONS disagree, which takes a value pool of more than one width AND a mismatch that

--- a/packages/core/test/namecoalesce-fuzz.test.ts
+++ b/packages/core/test/namecoalesce-fuzz.test.ts
@@ -69,27 +69,53 @@ function spellings(seed: number, depth: 0 | 1 | 2, drop?: string): { off: Event[
 // `carrier-name-fuzz` produced a fully green `test:offline` that still failed on an unhandled
 // `Timeout calling "onTaskUpdate"`. That was a sweep not yielding to the reporter, not a CPU
 // ceiling, and #171 fixed it with the `breathe()` call below; the size it forced went back up with
-// the sibling's. The finding `namecoalesce.ts` credits to this arm — `loop-escape` dropped makes 2
-// of 7,535 nested functions compute something else — was taken at 8,000 seeds, so its two (5104
-// and 6437) are outside even 4,000. Reproduce it by raising this number, not by hunting inside it.
+// the sibling's. The table is two columns because all three arms take `SEEDS`: a per-arm size was
+// the exception this restore deleted, and a third column re-spelling one constant would be a knob
+// claiming an asymmetry the file no longer has.
 describe.each([
-  ['acyclic', 0, SEEDS],
-  ['loop-bearing', 1, SEEDS],
-  ['nested', 2, SEEDS],
-] as const)('%s', (_name, depth, seeds) => {
+  ['acyclic', 0],
+  ['loop-bearing', 1],
+  ['nested', 2],
+] as const)('%s', (_name, depth) => {
   test('no merge the pass makes changes what the function does', async () => {
     const bad: number[] = [];
     let judged = 0;
-    for (let seed = 1; seed <= seeds; seed++) {
+    for (let seed = 1; seed <= SEEDS; seed++) {
       if (seed % BREATHE_EVERY === 0) await breathe();
       const r = spellings(seed, depth);
       if (!r) continue;
       judged++;
       if (tracesDiffer(r)) bad.push(seed);
     }
-    expect(judged).toBeGreaterThan(seeds / 10); // the sweep is not vacuous
+    expect(judged).toBeGreaterThan(SEEDS / 10); // the sweep is not vacuous
     expect(bad).toEqual([]);
   });
+});
+
+// THE ONE PIECE OF EVIDENCE NO SWEEP ABOVE CAN PRODUCE, pinned rather than hunted for.
+//
+// `namecoalesce.ts` credits this arm with the `loop-escape` finding: dropped, that gate makes some
+// nested functions compute something else. No shipped arm has ever ablated it, and raising `SEEDS`
+// never will — arm B below iterates `NAME_COALESCE_GATES.filter((x) => x.sound)` and the table
+// declares `loop-escape` `sound: false`, so the barrier is a PREDICATE, not a range. (The seeds are
+// also outside 4,000: measured, there is no witness at all in 1..4000 at depth 2.) The recipe, for
+// whoever comes to reproduce it: drop the gate BY NAME, depth 2, at least 6,437 seeds.
+//
+// Pinned two-sided — with the gate KEPT both seeds trace identically — so this asserts the gate's
+// own work, not a difference the pass would make regardless. Which is also the uncomfortable part:
+// a rule whose removal changes what the program COMPUTES is a legality property, while `sound:
+// false` in this table means fidelity (its neighbour `param` genuinely is fidelity). Relabelling it
+// is not free — arm B would then sweep the gate and go red at `SEEDS` = 4000, since its first
+// witness is 5104 — so that stays its own decision, and this coverage does not wait on it.
+test('`loop-escape` is load-bearing, at the two seeds no sweep in this file reaches', () => {
+  for (const seed of [5104, 6437]) {
+    const dropped = spellings(seed, 2, 'loop-escape');
+    const kept = spellings(seed, 2);
+    expect(dropped, `seed ${seed} must still be a shape this can judge`).not.toBeNull();
+    expect(kept, `seed ${seed} must still be a shape this can judge`).not.toBeNull();
+    expect(tracesDiffer(dropped!), `seed ${seed}: dropping \`loop-escape\` must change the trace`).toBe(true);
+    expect(tracesDiffer(kept!), `seed ${seed}: with \`loop-escape\` kept the trace must not change`).toBe(false);
+  }
 });
 
 // The one sound rule this generator cannot reach, and why. `type` needs two names whose

--- a/packages/core/test/namecoalesce-fuzz.test.ts
+++ b/packages/core/test/namecoalesce-fuzz.test.ts
@@ -64,14 +64,9 @@ function spellings(seed: number, depth: 0 | 1 | 2, drop?: string): { off: Event[
   }
 }
 
-// All three arms sweep the same range. The nested one — whose functions are the largest the
-// generator makes — spent two days at 250, because adding it at 4,000 alongside
-// `carrier-name-fuzz` produced a fully green `test:offline` that still failed on an unhandled
-// `Timeout calling "onTaskUpdate"`. That was a sweep not yielding to the reporter, not a CPU
-// ceiling, and #171 fixed it with the `breathe()` call below; the size it forced went back up with
-// the sibling's. The table is two columns because all three arms take `SEEDS`: a per-arm size was
-// the exception this restore deleted, and a third column re-spelling one constant would be a knob
-// claiming an asymmetry the file no longer has.
+// All three arms sweep `SEEDS`, the nested one included even though its functions are the largest
+// the generator makes: it costs a couple of seconds, and a per-arm size would be a knob claiming an
+// asymmetry that is not there.
 describe.each([
   ['acyclic', 0],
   ['loop-bearing', 1],
@@ -92,15 +87,12 @@ describe.each([
   });
 });
 
-// THE ONE GATE IN THE TABLE THIS FILE CANNOT JUDGE AT ANY SIZE. Arm B below iterates
-// `NAME_COALESCE_GATES.filter((x) => x.sound)` and the table declares `loop-escape` `sound: false`,
-// so no arm here has ever ablated it and raising `SEEDS` never will — the barrier is a PREDICATE,
-// not a range. (It is also out of range: measured, the only two witnesses in 1..7000 are 5104 and
-// 6437, both at depth 2.) Its evidence is two of those functions FROZEN AS IR in
-// `namecoalesce.test.ts`, asserted two-sided there — a seed replayed here would break on any edit
-// to `generateSsaFn` and would then read as the gate being inert. To re-hunt: drop the gate by
-// name, depth 2, at least 6,437 seeds. Why the flag stays `false` is argued once, in
-// `namecoalesce.ts`'s header, where the flag is set.
+// `loop-escape` IS LOAD-BEARING AND NO SIZE HERE SHOWS IT. Arm B below iterates
+// `NAME_COALESCE_GATES.filter((x) => x.sound)`, and that gate is `sound: false` — as is `param`,
+// and `type` is exempted below — so raising `SEEDS` never reaches it. Unlike the other two, its
+// ablation changes what a function computes; the witnesses are frozen as IR in
+// `namecoalesce.test.ts`, which also carries how to re-hunt them. Why the flag stays `false` is
+// argued in `namecoalesce.ts`'s header, where it is set.
 
 // The one sound rule this generator cannot reach, and why. `type` needs two names whose
 // DECLARATIONS disagree, which takes a value pool of more than one width AND a mismatch that

--- a/packages/core/test/namecoalesce-fuzz.test.ts
+++ b/packages/core/test/namecoalesce-fuzz.test.ts
@@ -64,18 +64,18 @@ function spellings(seed: number, depth: 0 | 1 | 2, drop?: string): { off: Event[
   }
 }
 
-// The nested arm sweeps FEWER seeds than the two that predate it, and the reason is budget rather
-// than confidence: its functions are the largest the generator makes, and adding it at 4,000
-// alongside `carrier-name-fuzz` put 30% more CPU into `test:offline` than vitest's own reporter
-// could keep up with — a fully green run reported an unhandled `Timeout calling "onTaskUpdate"`
-// and the job failed. The finding `namecoalesce.ts` credits to this arm — `loop-escape` dropped
-// makes 2 of 7,535 nested functions compute something else — was taken at 8,000 seeds, so its two
-// (5104 and 6437) are outside the range that ships. Reproduce it by raising this number, not by
-// hunting inside it.
+// All three arms sweep the same range. The nested one — whose functions are the largest the
+// generator makes — spent two days at 250, because adding it at 4,000 alongside
+// `carrier-name-fuzz` produced a fully green `test:offline` that still failed on an unhandled
+// `Timeout calling "onTaskUpdate"`. That was a sweep not yielding to the reporter, not a CPU
+// ceiling, and #171 fixed it with the `breathe()` call below; the size it forced went back up with
+// the sibling's. The finding `namecoalesce.ts` credits to this arm — `loop-escape` dropped makes 2
+// of 7,535 nested functions compute something else — was taken at 8,000 seeds, so its two (5104
+// and 6437) are outside even 4,000. Reproduce it by raising this number, not by hunting inside it.
 describe.each([
   ['acyclic', 0, SEEDS],
   ['loop-bearing', 1, SEEDS],
-  ['nested', 2, 250],
+  ['nested', 2, SEEDS],
 ] as const)('%s', (_name, depth, seeds) => {
   test('no merge the pass makes changes what the function does', async () => {
     const bad: number[] = [];

--- a/packages/core/test/namecoalesce.test.ts
+++ b/packages/core/test/namecoalesce.test.ts
@@ -8,7 +8,9 @@
 // at the pass's own boundary instead; each says why where it sits.
 //
 // The whole-program check is `namecoalesce-fuzz.test.ts`. These pin named shapes; that one asks
-// whether any merge changes what a function does.
+// whether any merge changes what a function does. Two shapes here borrow that file's interpreter as
+// well, because `loop-escape` is the one gate the sweep structurally cannot reach — see the block
+// above `INNER_CLOBBERS_OUTER` — so its evidence has to be a named shape whose failure is a value.
 import { expect, test } from 'vitest';
 
 import { cBackend } from '../src/backend/c';
@@ -16,25 +18,35 @@ import { Block, Op, Value, mkOp, mkValue } from '../src/ir/core';
 import { parse } from '../src/ir/parse';
 import { T } from '../src/ir/types';
 import { verify } from '../src/ir/verify';
+import type { SFn } from '../src/l3/ast';
 import { without } from '../src/l3/gates';
 import { recoverTypes } from '../src/raise/recover';
 import { NAME_COALESCE_GATES, type NameCoalesceDeps, coalesceNames } from '../src/structure/namecoalesce';
 import { structure } from '../src/structure/structure';
+import { traceOf, tracesDiffer } from './helpers';
 
-const emit = (ir: string, gate?: string): string => {
+/** The structured tree with the axis ON, optionally with one gate ablated. Separate from `emit`
+ *  because two of these are also INTERPRETED: what a merge breaks is a value, and only the tree
+ *  reaches `traceOf`. */
+const tree = (ir: string, gate?: string): SFn => {
   const fn = parse(ir);
   verify(fn);
   recoverTypes(fn);
-  return cBackend.emit(
-    structure(fn, { coalesceMergeNames: true }, gate ? { nameCoalesceGates: without(NAME_COALESCE_GATES, gate) } : {}),
+  return structure(
+    fn,
+    { coalesceMergeNames: true },
+    gate ? { nameCoalesceGates: without(NAME_COALESCE_GATES, gate) } : {},
   );
 };
-const uncoalesced = (ir: string): string => {
+/** The same IR with the axis OFF — the reference spelling every assertion here is against. */
+const treeOff = (ir: string): SFn => {
   const fn = parse(ir);
   verify(fn);
   recoverTypes(fn);
-  return cBackend.emit(structure(fn));
+  return structure(fn);
 };
+const emit = (ir: string, gate?: string): string => cBackend.emit(tree(ir, gate));
+const uncoalesced = (ir: string): string => cBackend.emit(treeOff(ir));
 
 // Two arms, each clamping two loads through an inner join of its own — the chain the naming walk
 // cannot follow, because it only ever adopts a name BACKWARD along one edge. ^bb7 takes the arm-A
@@ -251,6 +263,118 @@ test('a candidate never unlocks a function the primary declines', () => {
   expect(() => uncoalesced(UNLOCKS_A_DECLINE)).toThrow(/pre-update loop variable/);
   expect(() => emit(UNLOCKS_A_DECLINE)).toThrow(/pre-update loop variable/);
 });
+
+// ── the two witnesses a differential fuzz found and no differential fuzz can re-find ───────────
+//
+// `namecoalesce-fuzz`'s ablating arm iterates `NAME_COALESCE_GATES.filter((x) => x.sound)`, and
+// `loop-escape` is `sound: false`. So no sweep over there has ever dropped this gate, and raising
+// its seed count never will — the barrier is a PREDICATE, not a range. These two came out of a
+// by-name ablation at depth 2 (`generateSsaFn(seed, 2)`, `without(..., 'loop-escape')`), and they
+// are the only two witnesses in 1..7000, which is why both are frozen rather than one.
+//
+// FROZEN AS IR, not replayed by seed. A seed is a live coupling to a shared PRNG-driven generator:
+// any edit to `generateSsaFn` desynchronises the stream, and a seed-replayed version then goes red
+// saying the gate is inert when the cause is the generator — the misattribution these tests exist
+// to prevent. Frozen, they are immune, and they run in single-digit milliseconds instead of
+// structuring 5,104 functions to reach the first one.
+//
+// THE SHAPE, in both: an inner loop's variable adopts the ENCLOSING loop's carrier, and then
+// overwrites it every iteration. The gate's work is one statement — the copy that gives the
+// escaping value a home of its own, hoisted to the top of the outer body. Dropped, that copy is
+// gone, the inner loop writes the carrier, and the function returns another number. Nothing
+// throws; this is the failure class the sibling `TRAILING_DOWHILE` test does NOT cover, where the
+// loop emitter's own `pre-update loop variable` check catches the merge loudly.
+const INNER_CLOBBERS_OUTER = [
+  {
+    seed: 5104,
+    escapeCopy: 'v4 = v2;',
+    ir: `fn fz5104 {
+^bb0(%0: s32, %1: s32):
+  %2: s32 = sub %1, %1
+  %3: s32 = sub %1, %1
+  %4: s32 = sub %0, %1
+  %5: s32 = call %1 {target="f1"}
+  br ^bb1(%2, %1)
+^bb1(%6: s32, %7: s32):
+  %8: s32 = sub %1, %0
+  br ^bb2(%6, %3)
+^bb2(%9: s32, %10: s32):
+  %11: s32 = sub %0, %0
+  br ^bb3(%3)
+^bb3(%12: s32):
+  %13: s32 = sub %1, %12
+  %14: s32 = call %12 {target="f1"}
+  %15: s32 = call %0 {target="f2"}
+  %16: u32 = icmp_slt %3, %12
+  cond_br %16, ^bb2(%2, %15), ^bb4(%14)
+^bb4(%17: s32):
+  %18: s32 = add %1, %3
+  %19: s32 = add %2, %17
+  %20: u32 = icmp_slt %17, %0
+  cond_br %20, ^bb1(%0, %2), ^bb5()
+^bb5():
+  %21: s32 = call %0 {target="f0"}
+  %22: s32 = sub %0, %3
+  br ^bb6(%1, %2)
+^bb6(%23: s32, %24: s32):
+  %25: s32 = sub %23, %24
+  %26: s32 = sub %2, %3
+  ret %0
+}
+`,
+  },
+  {
+    seed: 6437,
+    escapeCopy: 'v5 = v4;',
+    ir: `fn fz6437 {
+^bb0(%0: s32, %1: s32):
+  %2: s32 = sub %1, %0
+  %3: s32 = call %0 {target="f1"}
+  %4: s32 = sub %0, %1
+  %5: s32 = call %0 {target="f1"}
+  br ^bb1(%1, %1)
+^bb1(%6: s32, %7: s32):
+  %8: s32 = call %0 {target="f0"}
+  %9: s32 = add %2, %6
+  br ^bb2(%7, %3)
+^bb2(%10: s32, %11: s32):
+  %12: s32 = sub %11, %1
+  br ^bb3(%1)
+^bb3(%13: s32):
+  %14: s32 = sub %2, %2
+  %15: s32 = sub %13, %1
+  %16: s32 = call %15 {target="f2"}
+  %17: u32 = icmp_slt %15, %15
+  cond_br %17, ^bb2(%2, %15), ^bb4(%16)
+^bb4(%18: s32):
+  %19: s32 = sub %0, %2
+  %20: u32 = icmp_slt %2, %1
+  cond_br %20, ^bb1(%3, %3), ^bb5(%3, %2)
+^bb5(%21: s32, %22: s32):
+  %23: s32 = call %22 {target="f0"}
+  %24: s32 = call %2 {target="f1"}
+  br ^bb6(%23, %22)
+^bb6(%25: s32, %26: s32):
+  %27: s32 = add %0, %26
+  ret %3
+}
+`,
+  },
+] as const;
+
+test.each(INNER_CLOBBERS_OUTER)(
+  'ablating loop-escape lets an inner loop clobber the enclosing loop variable (seed $seed)',
+  ({ seed, ir, escapeCopy }) => {
+    // the gate's work, spelled: the escaping value keeps a home of its own
+    expect(emit(ir)).toContain(escapeCopy);
+    expect(emit(ir, 'loop-escape')).not.toContain(escapeCopy);
+    // and that copy is not cosmetic — two-sided, so this asserts the GATE's work and not a
+    // difference the axis would make regardless
+    const off = traceOf(treeOff(ir), seed);
+    expect(tracesDiffer({ off, on: traceOf(tree(ir), seed) })).toBe(false);
+    expect(tracesDiffer({ off, on: traceOf(tree(ir, 'loop-escape'), seed) })).toBe(true);
+  },
+);
 
 // ── the type rule, at the level it decides on ──────────────────────────────────────────────────
 // Two names whose DECLARATIONS disagree. A test cannot choose that freely in parsed IR — a

--- a/packages/core/test/namecoalesce.test.ts
+++ b/packages/core/test/namecoalesce.test.ts
@@ -8,9 +8,9 @@
 // at the pass's own boundary instead; each says why where it sits.
 //
 // The whole-program check is `namecoalesce-fuzz.test.ts`. These pin named shapes; that one asks
-// whether any merge changes what a function does. Two shapes here borrow that file's interpreter as
-// well, because `loop-escape` is the one gate the sweep structurally cannot reach — see the block
-// above `INNER_CLOBBERS_OUTER` — so its evidence has to be a named shape whose failure is a value.
+// whether any merge changes what a function does. Two shapes here also run `helpers.ts`'s
+// interpreter, because `loop-escape` is load-bearing and the sweep never ablates it: what that gate
+// prevents is a wrong VALUE, which no assertion over emitted text can see (`INNER_CLOBBERS_OUTER`).
 import { expect, test } from 'vitest';
 
 import { cBackend } from '../src/backend/c';
@@ -25,9 +25,8 @@ import { NAME_COALESCE_GATES, type NameCoalesceDeps, coalesceNames } from '../sr
 import { structure } from '../src/structure/structure';
 import { traceOf, tracesDiffer } from './helpers';
 
-/** The structured tree with the axis ON, optionally with one gate ablated. Separate from `emit`
- *  because two of these are also INTERPRETED: what a merge breaks is a value, and only the tree
- *  reaches `traceOf`. */
+/** The structured tree with the axis ON, optionally with one gate ablated. Split out of `emit`
+ *  because `traceOf` needs the tree, not the emitted text. */
 const tree = (ir: string, gate?: string): SFn => {
   const fn = parse(ir);
   verify(fn);
@@ -264,26 +263,24 @@ test('a candidate never unlocks a function the primary declines', () => {
   expect(() => emit(UNLOCKS_A_DECLINE)).toThrow(/pre-update loop variable/);
 });
 
-// ── the two witnesses a differential fuzz found and no differential fuzz can re-find ───────────
+// ── the two witnesses no differential sweep can re-find ────────────────────────────────────────
 //
-// `namecoalesce-fuzz`'s ablating arm iterates `NAME_COALESCE_GATES.filter((x) => x.sound)`, and
-// `loop-escape` is `sound: false`. So no sweep over there has ever dropped this gate, and raising
-// its seed count never will — the barrier is a PREDICATE, not a range. These two came out of a
-// by-name ablation at depth 2 (`generateSsaFn(seed, 2)`, `without(..., 'loop-escape')`), and they
-// are the only two witnesses in 1..7000, which is why both are frozen rather than one.
+// `namecoalesce-fuzz`'s ablating arm only drops gates the table calls `sound`, and `loop-escape` is
+// not one, so no seed count over there reaches it. To re-hunt: ablate it by name at depth 2
+// (`generateSsaFn(seed, 2)`, `without(…, 'loop-escape')`) — these are the only two witnesses in
+// 1..7000.
 //
-// FROZEN AS IR, not replayed by seed. A seed is a live coupling to a shared PRNG-driven generator:
-// any edit to `generateSsaFn` desynchronises the stream, and a seed-replayed version then goes red
-// saying the gate is inert when the cause is the generator — the misattribution these tests exist
-// to prevent. Frozen, they are immune, and they run in single-digit milliseconds instead of
-// structuring 5,104 functions to reach the first one.
+// FROZEN AS IR, not replayed by seed, because a seed is a live coupling to a shared PRNG generator:
+// any edit to `generateSsaFn` desynchronises the stream and the test then goes red reading as an
+// inert gate. Frozen, it runs in milliseconds instead of structuring 5,104 functions to reach the
+// first witness.
 //
 // THE SHAPE, in both: an inner loop's variable adopts the ENCLOSING loop's carrier, and then
 // overwrites it every iteration. The gate's work is one statement — the copy that gives the
-// escaping value a home of its own, hoisted to the top of the outer body. Dropped, that copy is
-// gone, the inner loop writes the carrier, and the function returns another number. Nothing
-// throws; this is the failure class the sibling `TRAILING_DOWHILE` test does NOT cover, where the
-// loop emitter's own `pre-update loop variable` check catches the merge loudly.
+// escaping value a home of its own, at the top of the outer body. Dropped, that copy is gone, the
+// inner loop writes the carrier, and the function returns another number. NOTHING THROWS: that is
+// what separates this from the `TRAILING_DOWHILE` shape, where the loop emitter's own `pre-update
+// loop variable` check catches the merge loudly.
 const INNER_CLOBBERS_OUTER = [
   {
     seed: 5104,

--- a/packages/core/test/narrowlocal-fuzz.test.ts
+++ b/packages/core/test/narrowlocal-fuzz.test.ts
@@ -17,7 +17,7 @@
 // table calls SOUND and requires that one of them DOES — written over the table, so a rule added
 // later is held to the same bar without anyone remembering to. Two gates are exempt with their
 // reasons stated at `OUT_OF_REACH`.
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { type Block, type Fn, type Value, mkOp, mkValue } from '../src/ir/core';
 import { type IrType, T } from '../src/ir/types';
@@ -28,6 +28,15 @@ import { NARROW_LOCAL_GATES, narrowBlockLocals } from '../src/raise/narrowlocal'
 import { recoverTypes } from '../src/raise/recover';
 import { structure } from '../src/structure/structure';
 import { BREATHE_EVERY, breathe, mulberry32 } from './helpers';
+
+// CORPUS-SIZED WORK IN A PARALLEL WORKER POOL, budgeted per FILE — the idiom `carrier-name-fuzz`,
+// `namecoalesce-fuzz`, `locals-written` and `structure-purity` already use. Vitest's 5 s default is
+// a LOAD sensitivity here, not a budget: arm A structures and interprets two trees per judged
+// function and the diamond tail multiplies that twentyfold — 2.2 s solo, 9.0 s worst measured
+// inside a full `pnpm test:offline`, where this file records a contention factor of 3.4x. 60 s is a
+// 6.7x margin on that worst case, and a real hang is still loud, just 60 s later. The one arm that
+// needs more says so at its own call, with its own reason.
+vi.setConfig({ testTimeout: 60_000 });
 
 /** A random SSA function whose block parameters are often EXTENDED at their reads — the shape this
  *  pass judges. Definitions dominate uses by construction (entry values plus the reading block's
@@ -365,13 +374,7 @@ describe.each([
     expect(judged).toBeGreaterThan(100);
     expect(bad).toEqual([]);
     judgedByShippedArm.set(withLoop, judged);
-    // Structuring and interpreting two trees per judged function, and the diamond tail multiplies
-    // that count twentyfold — 2.2s alone, and this suite forks 160 files in parallel. 60 s, not the
-    // 30 s this carried while `carrier-name-fuzz` and the nested `namecoalesce-fuzz` arm sat cut to
-    // 250 seeds: restoring those two puts their CPU back into the same fork pool, and the margin
-    // here was measured at 3.3x (9.0 s worst against 30 s) against a contention factor this file
-    // records at 3.4x below. A real hang is still loud, 30 s later.
-  }, 60_000);
+  });
 
   // THE POPULATION THE ONLY UNSOUND GATE MASKS, and the reason this arm exists at all.
   //
@@ -415,8 +418,7 @@ describe.each([
     expect(shipped).toBeDefined();
     expect(judged).toBeGreaterThan(shipped as number);
     expect(bad).toEqual([]);
-    // Same budget and the same reason as the arm above.
-  }, 60_000);
+  });
 });
 
 // The two sound rules this oracle cannot reach, and why — an exemption is a visible act with a
@@ -454,7 +456,6 @@ test('every SOUND gate is load-bearing: dropping it changes what some function d
   }
   expect(inert).toEqual([]);
   expect([...OUT_OF_REACH].filter((id) => !NARROW_LOCAL_GATES.some((g) => g.id === id && g.sound))).toEqual([]);
-  // A full SEEDS sweep per gate: ~8s alone, and this suite forks 160 files in parallel, where the
-  // same loop measured 3.4x its solo cost — past vitest's 5s default, which fails as a timeout
-  // rather than as an inert gate.
+  // The one arm that overrides the file's 60 s: a full SEEDS sweep PER GATE, ~8 s solo, and this
+  // suite forks 160 files in parallel, where the same loop measured 3.4x its solo cost.
 }, 90_000);

--- a/packages/core/test/narrowlocal-fuzz.test.ts
+++ b/packages/core/test/narrowlocal-fuzz.test.ts
@@ -32,10 +32,9 @@ import { BREATHE_EVERY, breathe, mulberry32 } from './helpers';
 // CORPUS-SIZED WORK IN A PARALLEL WORKER POOL, budgeted per FILE — the idiom `carrier-name-fuzz`,
 // `namecoalesce-fuzz`, `locals-written` and `structure-purity` already use. Vitest's 5 s default is
 // a LOAD sensitivity here, not a budget: arm A structures and interprets two trees per judged
-// function and the diamond tail multiplies that twentyfold — 2.2 s solo, 9.0 s worst measured
-// inside a full `pnpm test:offline`, where this file records a contention factor of 3.4x. 60 s is a
-// 6.7x margin on that worst case, and a real hang is still loud, just 60 s later. The one arm that
-// needs more says so at its own call, with its own reason.
+// function and the diamond tail multiplies that twentyfold, ~2.6 s solo against the 3.4x contention
+// this file measures under a full `pnpm test:offline`. A real hang is still loud, just 60 s later.
+// The one arm that needs more says so at its own call, with its own reason.
 vi.setConfig({ testTimeout: 60_000 });
 
 /** A random SSA function whose block parameters are often EXTENDED at their reads — the shape this

--- a/packages/core/test/narrowlocal-fuzz.test.ts
+++ b/packages/core/test/narrowlocal-fuzz.test.ts
@@ -366,8 +366,12 @@ describe.each([
     expect(bad).toEqual([]);
     judgedByShippedArm.set(withLoop, judged);
     // Structuring and interpreting two trees per judged function, and the diamond tail multiplies
-    // that count twentyfold — 2.2s alone, and this suite forks 160 files in parallel.
-  }, 30_000);
+    // that count twentyfold — 2.2s alone, and this suite forks 160 files in parallel. 60 s, not the
+    // 30 s this carried while `carrier-name-fuzz` and the nested `namecoalesce-fuzz` arm sat cut to
+    // 250 seeds: restoring those two puts their CPU back into the same fork pool, and the margin
+    // here was measured at 3.3x (9.0 s worst against 30 s) against a contention factor this file
+    // records at 3.4x below. A real hang is still loud, 30 s later.
+  }, 60_000);
 
   // THE POPULATION THE ONLY UNSOUND GATE MASKS, and the reason this arm exists at all.
   //
@@ -411,7 +415,8 @@ describe.each([
     expect(shipped).toBeDefined();
     expect(judged).toBeGreaterThan(shipped as number);
     expect(bad).toEqual([]);
-  }, 30_000);
+    // Same budget and the same reason as the arm above.
+  }, 60_000);
 });
 
 // The two sound rules this oracle cannot reach, and why — an exemption is a visible act with a


### PR DESCRIPTION
Two differential fuzz sweeps over the name-coalescing pass were cut 16x — `carrier-name-fuzz`
from 4,000 seeds to 250, and `namecoalesce-fuzz`'s nested arm from 4,000 to 250 — in one commit
(#165) whose stated reason was a reporter timeout: `[vitest-worker]: Timeout calling "onTaskUpdate"`,
raised by a single uninterrupted synchronous sweep. #171 removed that reason by yielding every 512
seeds (`breathe()`), and never put the seed counts back. This restores both, and then fixes what
looking at them closely turned up.

## What was verified of the premise, and what turned out false

| claim | verdict |
|---|---|
| `carrier-name-fuzz` sits at `SEEDS = 250`, cut by #165 for the reporter timeout | TRUE |
| #171 removed the reason and left the number | TRUE — `breathe()` is already in both arms |
| "its siblings are unchanged" | **FALSE** — #165 cut two arms; `namecoalesce-fuzz`'s `describe.each` hard-codes the nested one at 250 while the file's `SEEDS` says 4,000 |
| the `loop-escape` finding at seeds 5104/6437 is what the restore buys back | **FALSE, twice.** It belongs to the other file, and no seed count reaches it in either: `namecoalesce-fuzz`'s ablating arm iterates `NAME_COALESCE_GATES.filter((x) => x.sound)` and `loop-escape` is `sound: false`. **The barrier is a predicate, not a range.** Ablating it by name over seeds 1..7000: depth 0 → none, depth 1 → none, depth 2 → exactly 5104 and 6437. |
| the restore is what pays for gate coverage | **FALSE for this file.** At 250, `carrier-name-fuzz` is 4/4 green; what goes red at 250 is `namecoalesce-fuzz`'s arm B, on `sibling-params` (first witness: seed 299). Carrier's 250 → 4,000 buys arm-A breadth, and the comment now says so instead of claiming gate coverage. |

Because no sweep size can reach `loop-escape`, its two witnesses ship as **frozen IR** in
`namecoalesce.test.ts` instead: a seed replay is a live coupling to `generateSsaFn`'s PRNG, and any
edit to the generator would desynchronise the stream and leave the test reading as an inert gate.
Frozen, they run in milliseconds and assert both sides — the escape copy the gate forces at the top
of the outer loop body, and its absence when the gate is dropped. Falsified, not merely asserted:
rewriting the gate to `rejects: () => false` turns them **red in 37 ms** (3 failed / 10 passed);
renaming the test the new `guardedBy` names turns `gate-contract` **red** (1 failed / 73 passed).

`loop-escape` stays `sound: false`: what the witnesses show wrong is the SHAPE it rejects, not the
rule as written, which is blunter than the `carriesPreUpdate` it restates. That argument now lives
once, in `namecoalesce.ts`'s header, where the flag is set.

## Commits

- `d0327ef` — `carrier-name-fuzz` `SEEDS` 250 → 4,000.
- `d5d289e` — `namecoalesce-fuzz`'s nested arm 250 → `SEEDS`; the third `describe.each` column,
  now `SEEDS, SEEDS, SEEDS`, is dropped.
- `2c02232` — the `loop-escape` witnesses pinned, `narrowlocal-fuzz`'s two 30 s test budgets raised
  to 60 s so the restored CPU does not land on them.
- `dc6a273` — the pin moved off the seed replay onto frozen IR, into `namecoalesce.test.ts` beside
  the pass's other named shapes; `guardedBy` added so the gate table points at its guard;
  `narrowlocal-fuzz`'s budget respelled file-level, matching the four-file idiom.
- `1afbeaa` — comment audit. Two files claimed `loop-escape` was "the one gate the sweep cannot
  reach"; `param` is also `sound: false` and `type` is in `OUT_OF_REACH` — declared ten lines below
  one of those claims. Three gates are unreachable; what is unique to `loop-escape` is that
  ablating it changes what a function COMPUTES. Also dropped: the #165 incident retold in three
  places, a two-machine CPU table, and three restatements of the same range fact.

## Cost, measured

Seed counts 250 → 4,000 cost **+3.6 s** CPU on `carrier-name-fuzz` alone and **+8.5 s** across both
fuzz files (10-core laptop, `user` time, same command both arms). 16x the seeds is 8.2x the time,
because the ablating arm stops at the first seed that proves a gate. The suites are green with no
`Errors` line and no `onTaskUpdate`: the longest uninterrupted synchronous stretch is now 512 seeds
(~145 ms), three orders of magnitude under birpc's fixed 60 s.

A number from #165 that does NOT reproduce: it attributed +31.3 s of `test:offline` to these two
arms at 4,000. Restoring only the seed counts costs single-digit seconds here. Most of that 31.3 s
was the arms EXISTING, not their size — different machine, so stated as my measurement, not a
refutation of theirs.

## Bench: run, and it moved nothing

The diff touches two paths `scripts/check-artifact-provenance.sh` measures —
`packages/core/src/structure/namecoalesce.ts` (comments plus a `guardedBy` string, read only by
`gate-contract.test.ts`, never by production code) and `apps/benchmark/dataset/synthetic.ts` (four
lines inside an existing note) — so a full `pnpm bench run` was run rather than argued away:

- `✓ synthetic: 783 results in 336.6s` · `✓ real: 252 results in 2045.4s`, exit 0
- `bench:merge` → 1035 results (783 synthetic + 252 real)
- `bench regression --base origin/main` → **0 lost, 0 missing, 0 gained, 0 other flips** (1035 rows)
- `bench diff --base origin/main` → **0 field changes, 0 added, 0 removed** (1035 base vs 1035 fresh)

The regenerated `results.json` differs from the committed one in exactly two lines, `meta.generatedAt`
and `meta.asmlift.commit` — every row byte-identical. **The artifact is therefore not committed**:
this branch publishes no numbers of its own, and `check-artifact-provenance.sh` reports
`UNKNOWN, not checked` on that basis.

## Reviewer findings declined

- **An `ASMLIFT_FUZZ_SEEDS` env override.** A sweep size read from the environment makes a
  differential fuzz non-reproducible between a laptop and CI, the one property it must have. The
  CI-round-trip worry it hedged against is met directly by the `narrowlocal-fuzz` 60 s raise.
- **"If the justification is the finding, the number is 8,000."** Refuted by measurement: 8,000 buys
  that finding nothing, because arm B skips the gate on `.sound` at any size.
- **Flip `loop-escape` to `sound: true`.** Arm B would then demand a witness inside `SEEDS` and there
  is none at any size it runs — it would go red. The wave-1 decline reason for it ("it edits
  `packages/core/src`, which owes a bench") was itself wrong and is not the reason kept.
- **Move `vi.setConfig` into `vitest.config.ts`.** A global default would weaken hang detection for
  every test to save nine lines; the per-file form shipped instead.
- **Append the re-hunt recipe to the pin's failure message.** Moot — the seed replay that carried
  the misattributing message is gone, and frozen IR cannot desynchronise from its own witness.

One reviewer claim was **refuted**: `narrowlocal-fuzz` was said to have no `vi.setConfig` and to run
on the 5 s default. All three of its tests carried explicit budgets already (30 s, 30 s, 90 s).

## What this does NOT do

No production behaviour changes and no candidate is added or removed — `guardedBy` is metadata no
production code reads. It does not bring `loop-escape` inside the differential sweep (a predicate,
not a range, blocks that), does not relabel it sound, and adds no guard against a future silent
re-cut of the seed counts. It adds no command and no diagnostic, so nothing is owed to the
`match-function` / `attribute-function` briefs.

## Gates

`npx vitest run` 213 files / **3721 passed**, 2 skipped · `pnpm test:matching` 41 files /
**359 passed** · `pnpm exec vitest run apps/benchmark/test` 33 files / **798 passed**, 2 skipped ·
`pnpm typecheck` clean · `pnpm lint` **0 errors** (126 pre-existing `curly` warnings; the diff adds
no `if`) · `pnpm format` no changes · provenance `UNKNOWN, not checked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
