### PR TITLE
Record that a pass may be partially converted to a gate table, provided the residue is named

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -289,7 +289,13 @@ and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier li
    by ablating it and watching the row move, never by reading the source and inferring. A guard
    you did not watch fire is a hypothesis, and one printed as a mechanism aims the next round at
    the wrong guard — a round once attributed a decline to a refusal that fires zero times on the
-   whole corpus.
+   whole corpus. **When you had to patch a refusal to print why it fired, say so in the report and
+   name the pass** — that instrument episode is the ONLY evidence that licenses converting those
+   refusals to a `Gate` table later (`grep -n "THE UNIT OF THAT DECISION" docs/level-tower.md`), and
+   the rounds that pay for it are the ones that never record it. Before you instrument, check the
+   same passage the other way: if the gate is already tabled, `firstRejection` names it for free, and
+   if the first blocker is one a round has already reasoned about beside the gate, cite that instead
+   of re-deriving it.
 3. **Never edit the benchmark to make a row look better** — the reference source defines the
    target; manifests and results are never tuned. Harness defects (a hang, a missing timeout)
    are fixed or documented as their own labelled change.

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -290,16 +290,15 @@ and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier li
    you did not watch fire is a hypothesis, and one printed as a mechanism aims the next round at
    the wrong guard — a round once attributed a decline to a refusal that fires zero times on the
    whole corpus. **When you had to patch a refusal to print why it fired, say so in the PR body
-   (not only in `research/`, whose path nothing may cite) and name the pass** — that instrument
-   episode is the ONLY evidence that licenses converting those refusals to a `Gate` table later
-   (`grep -n "THE UNIT OF THAT DECISION" docs/level-tower.md`), and the rounds that pay for it are the ones that never record it — as is a refusal you come to
-   suspect never fires at all, which that passage records as the other thing worth tabling. Before
-   you instrument, check the same passage the other way: if the pass already exports a census
-   (`arrayShapeRefusals` in `raise/globalshape.ts`) or returns a `refusals` map (`l3/coalesce.ts`,
-   `l3/scopebase.ts`, `structure/namecoalesce.ts`), a test reads the id straight out with no edit to
-   the pass. A table ALONE does not buy that: 21 of the 27 `firstRejection` call sites compare the id
-   to `null` and drop it, so on those you still patch — and adding the map is the ~12-line fix worth
-   more than the patch. If the first blocker is one a round has already reasoned about beside the
+   (not only in `research/`, whose path nothing may cite) and name the pass.** That instrument
+   episode is one of the two things that license converting those refusals to a `Gate` table later
+   (`grep -n "THE UNIT OF THAT DECISION" docs/level-tower.md`); a refusal you come to suspect never
+   fires at all is the other. Before you instrument, check whether you have to: if the pass already
+   exports a census (`arrayShapeRefusals` in `raise/globalshape.ts`) or returns a `refusals` map
+   (`l3/coalesce.ts`, `l3/scopebase.ts`, `structure/namecoalesce.ts`), a test reads the id straight
+   out with no edit to the pass. A table ALONE does not buy that: 21 of the 27 `firstRejection` call
+   sites compare the id to `null` and drop it, so on those you still patch — and adding the map is
+   the smaller change. If the first blocker is one a round has already reasoned about beside the
    gate, cite that instead of re-deriving it.
 3. **Never edit the benchmark to make a row look better** — the reference source defines the
    target; manifests and results are never tuned. Harness defects (a hang, a missing timeout)

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -289,13 +289,18 @@ and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier li
    by ablating it and watching the row move, never by reading the source and inferring. A guard
    you did not watch fire is a hypothesis, and one printed as a mechanism aims the next round at
    the wrong guard — a round once attributed a decline to a refusal that fires zero times on the
-   whole corpus. **When you had to patch a refusal to print why it fired, say so in the report and
-   name the pass** — that instrument episode is the ONLY evidence that licenses converting those
-   refusals to a `Gate` table later (`grep -n "THE UNIT OF THAT DECISION" docs/level-tower.md`), and
-   the rounds that pay for it are the ones that never record it. Before you instrument, check the
-   same passage the other way: if the gate is already tabled, `firstRejection` names it for free, and
-   if the first blocker is one a round has already reasoned about beside the gate, cite that instead
-   of re-deriving it.
+   whole corpus. **When you had to patch a refusal to print why it fired, say so in the PR body
+   (not only in `research/`, whose path nothing may cite) and name the pass** — that instrument
+   episode is the ONLY evidence that licenses converting those refusals to a `Gate` table later
+   (`grep -n "THE UNIT OF THAT DECISION" docs/level-tower.md`), and the rounds that pay for it are the ones that never record it — as is a refusal you come to
+   suspect never fires at all, which that passage records as the other thing worth tabling. Before
+   you instrument, check the same passage the other way: if the pass already exports a census
+   (`arrayShapeRefusals` in `raise/globalshape.ts`) or returns a `refusals` map (`l3/coalesce.ts`,
+   `l3/scopebase.ts`, `structure/namecoalesce.ts`), a test reads the id straight out with no edit to
+   the pass. A table ALONE does not buy that: 21 of the 27 `firstRejection` call sites compare the id
+   to `null` and drop it, so on those you still patch — and adding the map is the ~12-line fix worth
+   more than the patch. If the first blocker is one a round has already reasoned about beside the
+   gate, cite that instead of re-deriving it.
 3. **Never edit the benchmark to make a row look better** — the reference source defines the
    target; manifests and results are never tuned. Harness defects (a hang, a missing timeout)
    are fixed or documented as their own labelled change.

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -96,6 +96,10 @@ Per commit:
   particular **"earn the level"**: do not add a representation, opcode, or pass boundary that has no
   inhabitant. Prefer patterns-as-data over new imperative special cases. Respect the `L1 → L2 → L3`
   stage contracts (`packages/core/src/contracts.ts`) and keep `@asmlift/core` browser-pure.
+- If the step converts a pass's refusals to a `Gate` table — or you are tempted to, because you just
+  patched a `return null` to log why it fired — read "the unit of that decision is the refusal, not
+  the pass" in `docs/level-tower.md` FIRST. It is settled: table the refusals you had to instrument,
+  leave the rest, name the residue. Do not reopen the whole-pass question; three rounds already did.
 - Add unit tests in `packages/core/test/` next to the sibling capability's tests. A capability with
   no test that fails before the change is not done.
 - Gate: `npx vitest run` (NOT `pnpm test:offline` — see Phase 4's fourth bullet: `test:offline`

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -99,10 +99,14 @@ Per commit:
 - If the step converts a pass's refusals to a `Gate` table — or you are tempted to, because you just
   patched a `return null` to log why it fired — read the passage
   `grep -n "THE UNIT OF THAT DECISION" docs/level-tower.md` finds, FIRST. It is settled: table the
-  refusals you had to instrument, leave the rest, name the residue in the table's doc comment.
-  Tabling ALL of a small pass's refusals is that, not a sweep. What is settled is the UNIT — do not
-  re-argue whether a file should adopt `Gate<Ctx>` wholesale; three rounds already did, and each
-  declined on a written reason the passage shows was the wrong one.
+  refusals you had to instrument — or one you suspect never fires, which is the other admission —
+  leave the rest, name the residue in the table's doc comment. Tabling ALL of a small pass's refusals
+  is that, not a sweep. And table it REPORTED: a `Gate` table whose id is compared to `null` and
+  dropped has shortened the instrument loop, not removed it, so return a `refusals` map
+  (`structure/namecoalesce.ts`) or export a census off the table (`arrayShapeRefusals` in
+  `raise/globalshape.ts`) in the same change. What is settled is the UNIT — do not re-argue whether a
+  file should adopt `Gate<Ctx>` wholesale; three rounds already did, and each decline was RIGHT while
+  its written reason was the wrong one.
 - Add unit tests in `packages/core/test/` next to the sibling capability's tests. A capability with
   no test that fails before the change is not done.
 - Gate: `npx vitest run` (NOT `pnpm test:offline` — see Phase 4's fourth bullet: `test:offline`

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -97,9 +97,12 @@ Per commit:
   inhabitant. Prefer patterns-as-data over new imperative special cases. Respect the `L1 → L2 → L3`
   stage contracts (`packages/core/src/contracts.ts`) and keep `@asmlift/core` browser-pure.
 - If the step converts a pass's refusals to a `Gate` table — or you are tempted to, because you just
-  patched a `return null` to log why it fired — read "the unit of that decision is the refusal, not
-  the pass" in `docs/level-tower.md` FIRST. It is settled: table the refusals you had to instrument,
-  leave the rest, name the residue. Do not reopen the whole-pass question; three rounds already did.
+  patched a `return null` to log why it fired — read the passage
+  `grep -n "THE UNIT OF THAT DECISION" docs/level-tower.md` finds, FIRST. It is settled: table the
+  refusals you had to instrument, leave the rest, name the residue in the table's doc comment.
+  Tabling ALL of a small pass's refusals is that, not a sweep. What is settled is the UNIT — do not
+  re-argue whether a file should adopt `Gate<Ctx>` wholesale; three rounds already did, and each
+  declined on a written reason the passage shows was the wrong one.
 - Add unit tests in `packages/core/test/` next to the sibling capability's tests. A capability with
   no test that fails before the change is not done.
 - Gate: `npx vitest run` (NOT `pnpm test:offline` — see Phase 4's fourth bullet: `test:offline`

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -104,9 +104,8 @@ Per commit:
   is that, not a sweep. And table it REPORTED: a `Gate` table whose id is compared to `null` and
   dropped has shortened the instrument loop, not removed it, so return a `refusals` map
   (`structure/namecoalesce.ts`) or export a census off the table (`arrayShapeRefusals` in
-  `raise/globalshape.ts`) in the same change. What is settled is the UNIT — do not re-argue whether a
-  file should adopt `Gate<Ctx>` wholesale; three rounds already did, and each decline was RIGHT while
-  its written reason was the wrong one.
+  `raise/globalshape.ts`) in the same change. What is settled is the UNIT: convert refusals, not
+  files — do not re-open whether a file should adopt `Gate<Ctx>` wholesale.
 - Add unit tests in `packages/core/test/` next to the sibling capability's tests. A capability with
   no test that fails before the change is not done.
 - Gate: `npx vitest run` (NOT `pnpm test:offline` — see Phase 4's fourth bullet: `test:offline`

--- a/apps/benchmark/test/citations.test.ts
+++ b/apps/benchmark/test/citations.test.ts
@@ -52,6 +52,45 @@ const found = SCANNED.flatMap((dir) =>
   ),
 );
 
+/** Prose also cites a place in the SOURCE, and `docs/level-tower.md`'s convention is a findable
+ *  phrase rather than a line number, because a line number rots on the next edit above it and
+ *  nothing notices. The convention only works while the phrase is still there, which is this. A
+ *  `file.ts:N` is deliberately NOT checked: the dated attribution docs are full of them and they
+ *  describe a snapshot, not a rule. */
+const ANCHORED = ['docs', '.claude/commands'];
+const ANCHOR = /grep -n "([^"]+)" ([\w./-]+)/g;
+
+const anchors = ANCHORED.flatMap((dir) =>
+  sourceFiles(join(ROOT, dir)).flatMap((file) =>
+    readFileSync(file, 'utf8')
+      .split('\n')
+      .flatMap((text, i) =>
+        [...text.matchAll(ANCHOR)].map((m) => ({
+          file: file.slice(ROOT.length + 1),
+          line: i + 1,
+          phrase: m[1],
+          target: m[2],
+        })),
+      ),
+  ),
+);
+
+describe('every cited source anchor still hits', () => {
+  it('finds anchors at all', () => {
+    expect(anchors.length).toBeGreaterThan(0);
+  });
+
+  it.each(anchors)('$file:$line anchors on $target', ({ file, line, phrase, target }) => {
+    // The phrase is quoted for a literal `grep`, so a substring test is what the reader will run.
+    expect(
+      readFileSync(join(ROOT, target), 'utf8').includes(phrase),
+      `${file}:${line} tells the reader to find '${phrase}' in ${target}, and it is not there.\n` +
+        `  Reworded? Re-quote the new phrasing here. Moved? Re-point the anchor. Do not replace it\n` +
+        `  with a line number — that is the failure this convention exists to avoid.`,
+    ).toBe(true);
+  });
+});
+
 describe('every cited benchmark row exists', () => {
   it('finds citations at all', () => {
     // Or the suite passes loudest when the scan is broken.

--- a/apps/benchmark/test/citations.test.ts
+++ b/apps/benchmark/test/citations.test.ts
@@ -54,9 +54,8 @@ const found = SCANNED.flatMap((dir) =>
 
 /** Prose also cites a place in the SOURCE, and `docs/level-tower.md`'s convention is a findable
  *  phrase rather than a line number, because a line number rots on the next edit above it and
- *  nothing notices. The convention only works while the phrase is still there, which is this. A
- *  `file.ts:N` is deliberately NOT checked: the dated attribution docs are full of them and they
- *  describe a snapshot, not a rule. */
+ *  nothing notices. This asserts the phrase is still there. A `file.ts:N` is deliberately NOT
+ *  checked: the dated attribution docs are full of them and they describe a snapshot, not a rule. */
 const ANCHORED = ['docs', '.claude/commands'];
 const ANCHOR = /grep -n "([^"]+)" ([\w./-]+)/g;
 

--- a/docs/level-tower.md
+++ b/docs/level-tower.md
@@ -570,10 +570,12 @@ more than three gates pretending to a soundness they do not have.
 
 **THE UNIT OF THAT DECISION IS THE REFUSAL, NOT THE PASS — a pass may be PARTIALLY tabled, provided
 the residue is NAMED.** "Adopt this" is asked about a file, and the answer is almost never all of it,
-which is why three rounds in a row opened "should this pass adopt `Gate<Ctx>`", argued, and declined
-on cost — ten agent-touches that changed nothing, and each decline was right while its written reason
-was wrong. The reason is not cost. Three shipped passes answer the question three different ways and
-none of them is a defect:
+which is why — on the same 2026-09 retrospective the minutes below come from, and no more re-runnable
+from this repo than they are — three rounds in a row opened "should this pass adopt `Gate<Ctx>`",
+argued, and declined on cost: ten agent-touches that changed nothing, and each decline was RIGHT while
+its written reason was wrong. The reason is not cost. Three shipped passes answer the question three
+different ways, none of them a defect — and a fourth entry says what tabling has to INCLUDE either
+way:
 
 - **Partially tabled, residue named.** [`structure/hazards.ts`](../packages/core/src/structure/hazards.ts)
   holds five per-candidate rules in `PREUPDATE_SINK_GATES`. The two SET-level rules — two slots
@@ -583,19 +585,28 @@ none of them is a defect:
   refusal discipline"). That comment is the whole obligation. A partial table with the residue named
   is finished work; a partial table that reads as a complete one is the defect. Note what that
   exclusion is NOT: both rules read `dest`, `names`, `exitArgs` and `sub` at one program point
-  (`hazards.ts:485-488`), so an edge context is perfectly preparable and the next bullet's bar does
-  not touch them. They are outside `PREUPDATE_SINK_GATES` because a `Gate<Ctx>` is per-candidate and
+  (`grep -n "const names = new Set(dest.values())" packages/core/src/structure/hazards.ts`, and the
+  two lines under it), so an edge context is perfectly preparable and the next bullet's bar does not
+  touch them. They are outside `PREUPDATE_SINK_GATES` because a `Gate<Ctx>` is per-candidate and
   these would need a SECOND table over a different `Ctx` — which the paragraph below says to build
   when a round has had to instrument them, and not before.
-- **Not tabled, and the bar is structural rather than economic.** `pointeeElement` in
+- **Not tabled, and the decline left in prose.** `pointeeElement` in
   [`structure/structure.ts`](../packages/core/src/structure/structure.ts) lists its refusals in
   prose and states that it is "NOT a `Gate` table … unlike `FRESH_MERGE_GATES` and
   `CARRIER_NAME_GATES` in this same file: those refusals are predicates over ONE prepared context,
   while these interleave with the computations that produce the values the later ones test […], so
-  building that Ctx would run all of it on inputs the earlier gates reject." **A pass whose refusals
-  cannot be evaluated against one prepared context is not a candidate for the table at any price** —
-  a table over such a pass either changes what it computes or fakes the Ctx, and both are worse than
-  the prose. Rule this out first; it is cheaper to check than the cost argument and it is decisive.
+  building that Ctx would run all of it on inputs the earlier gates reject." Read that reason the way
+  this section reads the other declines: the decline is right and the written reason is the EAGER
+  reading of "prepared", which the same file answers 600 lines further down — `CarrierName`'s fields
+  are getters (`grep -n "THE FIELDS ARE LAZY" packages/core/src/structure/structure.ts`), so a later
+  gate's input is computed only when the earlier ones let it be asked, and blame is unchanged.
+  `pointeeElement` is pure, so each of its refusals is expressible that way too and its interleaving
+  is a cost, not a bar. **The bar that IS structural is the lazy one: a refusal whose input cannot be
+  prepared even as a memoized getter — because preparing it performs an effect, or depends on an
+  order the pass itself establishes — is not a candidate for the table at any price.** Check it in
+  that form, and only in that form; the eager form returns either verdict for the same pass. No pass
+  here is a measured inhabitant of it, `pointeeElement` included: it stays untabled on the paragraph
+  below, which is a reason that can change.
 - **Fully tabled, and its inline conditions are not residue.**
   [`structure/namecoalesce.ts`](../packages/core/src/structure/namecoalesce.ts) has every refusal in
   `NAME_COALESCE_GATES`; the `continue`/`return`s left in `coalesceNames`' walk are the ENUMERATOR —
@@ -603,6 +614,19 @@ none of them is a defect:
   `mayMerge` records that "two loops' variables always escape each other … so the enclosing-loop rule
   needs no gate of its own", which is residue that no longer exists. Counting either as an untabled
   refusal invites a conversion that buys nothing.
+- **Tabled AND REPORTED — the half that actually removes the loop.** A table on its own changes WHAT
+  you patch (one call site instead of four `if`s), not WHETHER you patch. Of the 27 `firstRejection(`
+  call sites outside `l3/gates.ts`, **21 compare the result to `null` on the spot and throw the id
+  away**; six keep it, in the two shipped forms — a `refusals` map in the return value
+  ([`l3/coalesce.ts`](../packages/core/src/l3/coalesce.ts),
+  [`l3/scopebase.ts`](../packages/core/src/l3/scopebase.ts), `structure/namecoalesce.ts`), and a
+  census EXPORT off the shipped table that the shipped path never calls (`arrayShapeRefusals` in
+  [`raise/globalshape.ts`](../packages/core/src/raise/globalshape.ts), whose doc comment states the
+  whole idea: "the one place an attribution is measured rather than asserted"). Neither form leaves
+  `@asmlift/core`: no CLI flag, bench field or env var prints a gate id, so an attribution over the
+  lifted corpus is still a written test — or, on the 21, still a patch. **Tabling a pass and adding
+  neither is half the job**: the missing half is ~12 lines, against the loop the next paragraph
+  prices.
 
 **And converting a pass whose refusals nobody has had to instrument buys nothing.** What a table
 removes is the edit-instrument-revert loop — patch a `return null` to log, re-run, revert — so the
@@ -615,10 +639,15 @@ whose commit body records that the rules "were four `if`s inside a 5000-line fun
 There is exactly one other admission, and it is the mirror of that one — read it together with **A
 GATE CAN ALSO BE STARVED FROM ABOVE** below, which is the incident it comes from. Nobody can have
 paid instrument minutes on a rule nothing reaches, so the trigger above would make a starved gate
-permanently ineligible; but a table is what settles starvation, because it reports WHICH gate refused
-each candidate and a rule that never appears is a rule with no input. **Instrument time is the
-trigger for refusals that fire; a refusal suspected of never firing at all is the other admission,
-and the table is how you prove it.** Neither admission is "this file has a lot of `if`s".
+permanently ineligible; but a table PLUS the bullet above's `refusals` map is what settles
+starvation, because together they report WHICH gate refused each candidate and a rule that never
+appears is a rule with no input. **Instrument time is the trigger for refusals that fire; a refusal
+suspected of never firing at all is the other admission, and the table is how you prove it.** Neither
+admission is "this file has a lot of `if`s". The map is not optional here and the source says so
+already — `coalesceNames`' doc comment in `structure/namecoalesce.ts`: "`refusals` counts which gate
+stopped each rejected pair, so a gate nothing ever reaches shows up as a rule no test can be failing
+on purpose". A round tabling a pass on THIS admission builds the map in the same change, or it has
+proved nothing.
 
 Refusal count predicts none of it, on any way of counting: `structure/switch-recover.ts` has 44
 refusal-shaped exits (`grep -cE 'return (null|false)\b'`) and cost 6.5 instrument-minutes across
@@ -634,14 +663,22 @@ the same spans, which a table removes none of: you still run the bench to get th
 **So this section licenses converting the passes whose refusals a round has actually had to
 instrument, one at a time, each naming its residue. It does not license a sweep**, and a proposal to
 table N passes at once should be read as a proposal to table the one or two of them with measured
-instrument time. In that retrospective those are `l3/unmerge.ts` (47.7 min) and `raise/const.ts`
-(38.6) — the two the reading rule selects, and the answer to "which pass next" for as long as nobody
-measures a third. `raise/magicdiv.ts` — 18 refusal-shaped exits by that same grep, and no instrument
+instrument time. In that retrospective that is `l3/unmerge.ts` (47.7 min, 12 refusal-shaped exits) —
+the answer to "which pass next" for as long as nobody measures a third. `raise/const.ts` (38.6 min)
+is NOT, and it is the standing warning about this selector: the recount above found three of its four
+early exits are the enumerator, so a table over it would hold ONE gate — the conversion the bullet
+above declines. The minutes are priced per FILE and this rule is consumed per REFUSAL; re-read a
+candidate's refusals by the counting rule before selecting it, because `const.ts` is where the two
+readings diverge. `raise/magicdiv.ts` — 18 refusal-shaped exits by that same grep, and no instrument
 event anyone recorded — is the shape a sweep picks first and this rule declines.
 
 One corollary, same economy: a refusal already known and CONTAINED is recorded beside the gate
 together with the argument that contains it, so the next round cites it instead of re-deriving it.
-A containment argument nobody wrote down gets re-proved by every round that reads the gate.
+A containment argument nobody wrote down gets re-proved by every round that reads the gate. Two
+instances of it ship, in the two files the bullets above cite: `structure/hazards.ts` on the third
+parallel-copy question ("needs no rule … Every leaf such an expression could read is already refused
+by a per-candidate gate", then naming all three), and `namecoalesce`'s enclosing-loop derivation. That
+is what this looks like when it is done.
 
 **A gate's PREMISE can be a target capability, and when it is, that is where it belongs.**
 `l3/unreduce.ts` deletes a loop-carried accumulator and re-spells each read as a closed form, which

--- a/docs/level-tower.md
+++ b/docs/level-tower.md
@@ -568,6 +568,56 @@ Adopt this when a pass's refusals are load-bearing — not for every `if` in the
 because a wrong hoist there costs bytes and a match, never meaning, and saying so plainly is worth
 more than three gates pretending to a soundness they do not have.
 
+**THE UNIT OF THAT DECISION IS THE REFUSAL, NOT THE PASS — a pass may be PARTIALLY tabled, provided
+the residue is NAMED.** "Adopt this" is asked about a file, and the answer is almost never all of it,
+which is why three rounds in a row opened "should this pass adopt `Gate<Ctx>`", argued, and declined
+on cost — ten agent-touches that changed nothing, and each decline was right while its written reason
+was wrong. The reason is not cost. Three shipped passes answer the question three different ways and
+none of them is a defect:
+
+- **Partially tabled, residue named.** [`structure/hazards.ts`](../packages/core/src/structure/hazards.ts)
+  holds five per-candidate rules in `PREUPDATE_SINK_GATES`. The two SET-level rules — two slots
+  wanting one name, a slot that stays behind reading a sunk name — are deliberately outside it,
+  because they are properties of the whole edge rather than of a candidate, and the table's own doc
+  comment says both that they exist and where they live (`sinkablePreUpdateSlots`, "with the same
+  refusal discipline"). That comment is the whole obligation. A partial table with the residue named
+  is finished work; a partial table that reads as a complete one is the defect.
+- **Not tabled, and the bar is structural rather than economic.** `pointeeElement` in
+  [`structure/structure.ts`](../packages/core/src/structure/structure.ts) lists its refusals in
+  prose and states that it is "NOT a `Gate` table … unlike `FRESH_MERGE_GATES` and
+  `CARRIER_NAME_GATES` in this same file: those refusals are predicates over ONE prepared context,
+  while these interleave with the computations that produce the values the later ones test […], so
+  building that Ctx would run all of it on inputs the earlier gates reject." **A pass whose refusals
+  cannot be evaluated against one prepared context is not a candidate for the table at any price** —
+  a table over such a pass either changes what it computes or fakes the Ctx, and both are worse than
+  the prose. Rule this out first; it is cheaper to check than the cost argument and it is decisive.
+- **Fully tabled, and its inline conditions are not residue.**
+  [`structure/namecoalesce.ts`](../packages/core/src/structure/namecoalesce.ts) has every refusal in
+  `NAME_COALESCE_GATES`; the `continue`/`return`s left in `coalesceNames`' walk are the ENUMERATOR —
+  which pairs exist to be judged at all — and enumeration is not residue. Nor is a rule DERIVED away:
+  `mayMerge` records that "two loops' variables always escape each other … so the enclosing-loop rule
+  needs no gate of its own", which is residue that no longer exists. Counting either as an untabled
+  refusal invites a conversion that buys nothing.
+
+**And converting a pass whose refusals nobody has had to instrument buys nothing.** What a table
+removes is the edit-instrument-revert loop — patch a `return null` to log, re-run, revert — so the
+trigger to table a pass is that someone has already paid that loop on it, not that the pass has many
+refusals. `CARRIER_NAME_GATES` is the model: it was grafted by the round that needed a rejection
+reason out of `canTakeName` and had resorted to a `globalThis` hack to get one, and it shipped as
+that round's own remediation. Refusal count predicts none of this — `structure/switch-recover.ts`
+carries 44 refusal sites and cost a retrospective-measured 6.5 instrument-minutes across seven
+rounds, while `raise/const.ts` carries four and cost 38.6 — and neither does file size. The same
+retrospective priced the whole edit-and-revert population of those rounds at ~69 minutes against
+~764 minutes of measurement runs in the same spans, which a table removes none of: you still run the
+bench to get the counts. **So this section licenses converting the passes whose refusals a round has
+actually had to instrument, one at a time, each naming its residue. It does not license a sweep**,
+and a proposal to table N passes at once should be read as a proposal to table the one or two of them
+with measured instrument time.
+
+One corollary, same economy: a refusal already known and CONTAINED is recorded beside the gate
+together with the argument that contains it, so the next round cites it instead of re-deriving it.
+A containment argument nobody wrote down gets re-proved by every round that reads the gate.
+
 **A gate's PREMISE can be a target capability, and when it is, that is where it belongs.**
 `l3/unreduce.ts` deletes a loop-carried accumulator and re-spells each read as a closed form, which
 means a memory read in the accumulator's init is evaluated at each read instead of once where the
@@ -702,7 +752,10 @@ followed the second inhabitant, never preceded it.
   It costs a few lines and buys the ablation ("drop this rule and something breaks") as a test
   rather than a claim. A pass whose gates only trade bytes can say so in the table and skip the
   guards; one that declares a gate sound now owes a differential test, and the contract enforces
-  the debt.
+  the debt. Convert the REFUSALS a round has had to instrument, not the file: a partial table whose
+  residue is named is the normal shipped shape here, and a pass whose refusals cannot be judged
+  against one prepared context is not a candidate at all — see "the unit of that decision is the
+  refusal, not the pass" above, which is this bullet's scope statement.
 - Add a **new op / representation** only when a capability genuinely cannot be expressed in the
   current one _and_ the differ can prove the result matches. Constant-offset access did not clear
   that bar; variable indexing did. If the corpus stays leaf/arithmetic-heavy, the tower may never

--- a/docs/level-tower.md
+++ b/docs/level-tower.md
@@ -581,7 +581,12 @@ none of them is a defect:
   because they are properties of the whole edge rather than of a candidate, and the table's own doc
   comment says both that they exist and where they live (`sinkablePreUpdateSlots`, "with the same
   refusal discipline"). That comment is the whole obligation. A partial table with the residue named
-  is finished work; a partial table that reads as a complete one is the defect.
+  is finished work; a partial table that reads as a complete one is the defect. Note what that
+  exclusion is NOT: both rules read `dest`, `names`, `exitArgs` and `sub` at one program point
+  (`hazards.ts:485-488`), so an edge context is perfectly preparable and the next bullet's bar does
+  not touch them. They are outside `PREUPDATE_SINK_GATES` because a `Gate<Ctx>` is per-candidate and
+  these would need a SECOND table over a different `Ctx` — which the paragraph below says to build
+  when a round has had to instrument them, and not before.
 - **Not tabled, and the bar is structural rather than economic.** `pointeeElement` in
   [`structure/structure.ts`](../packages/core/src/structure/structure.ts) lists its refusals in
   prose and states that it is "NOT a `Gate` table … unlike `FRESH_MERGE_GATES` and
@@ -603,16 +608,36 @@ none of them is a defect:
 removes is the edit-instrument-revert loop — patch a `return null` to log, re-run, revert — so the
 trigger to table a pass is that someone has already paid that loop on it, not that the pass has many
 refusals. `CARRIER_NAME_GATES` is the model: it was grafted by the round that needed a rejection
-reason out of `canTakeName` and had resorted to a `globalThis` hack to get one, and it shipped as
-that round's own remediation. Refusal count predicts none of this — `structure/switch-recover.ts`
-carries 44 refusal sites and cost a retrospective-measured 6.5 instrument-minutes across seven
-rounds, while `raise/const.ts` carries four and cost 38.6 — and neither does file size. The same
-retrospective priced the whole edit-and-revert population of those rounds at ~69 minutes against
-~764 minutes of measurement runs in the same spans, which a table removes none of: you still run the
-bench to get the counts. **So this section licenses converting the passes whose refusals a round has
-actually had to instrument, one at a time, each naming its residue. It does not license a sweep**,
-and a proposal to table N passes at once should be read as a proposal to table the one or two of them
-with measured instrument time.
+reason out of `canTakeName`, and it shipped as that round's own remediation — #164 (`428f5706`),
+whose commit body records that the rules "were four `if`s inside a 5000-line function" and that
+"naming which one fires on a given row took an instrumented patch and a revert".
+
+There is exactly one other admission, and it is the mirror of that one — read it together with **A
+GATE CAN ALSO BE STARVED FROM ABOVE** below, which is the incident it comes from. Nobody can have
+paid instrument minutes on a rule nothing reaches, so the trigger above would make a starved gate
+permanently ineligible; but a table is what settles starvation, because it reports WHICH gate refused
+each candidate and a rule that never appears is a rule with no input. **Instrument time is the
+trigger for refusals that fire; a refusal suspected of never firing at all is the other admission,
+and the table is how you prove it.** Neither admission is "this file has a lot of `if`s".
+
+Refusal count predicts none of it, on any way of counting: `structure/switch-recover.ts` has 44
+refusal-shaped exits (`grep -cE 'return (null|false)\b'`) and cost 6.5 instrument-minutes across
+seven rounds, while `raise/const.ts` has **none** by that grep, four early exits in all, and exactly
+ONE refusal by the rule above — the other three are the enumerator, and the file's own comment marks
+the one ("THE REFUSAL: this shape is not a literal being materialised") — and it cost 38.6 minutes.
+Nor does file size. Those minutes are from a 2026-09 retrospective over the CountCollectedGems
+rounds, whose transcripts are not in this repo — treat them as an order of magnitude you cannot
+re-run, not as a measurement you can cite back. The same retrospective priced the whole
+edit-and-revert population of those rounds at ~69 minutes against ~764 minutes of measurement runs in
+the same spans, which a table removes none of: you still run the bench to get the counts.
+
+**So this section licenses converting the passes whose refusals a round has actually had to
+instrument, one at a time, each naming its residue. It does not license a sweep**, and a proposal to
+table N passes at once should be read as a proposal to table the one or two of them with measured
+instrument time. In that retrospective those are `l3/unmerge.ts` (47.7 min) and `raise/const.ts`
+(38.6) — the two the reading rule selects, and the answer to "which pass next" for as long as nobody
+measures a third. `raise/magicdiv.ts` — 18 refusal-shaped exits by that same grep, and no instrument
+event anyone recorded — is the shape a sweep picks first and this rule declines.
 
 One corollary, same economy: a refusal already known and CONTAINED is recorded beside the gate
 together with the argument that contains it, so the next round cites it instead of re-deriving it.
@@ -754,8 +779,8 @@ followed the second inhabitant, never preceded it.
   guards; one that declares a gate sound now owes a differential test, and the contract enforces
   the debt. Convert the REFUSALS a round has had to instrument, not the file: a partial table whose
   residue is named is the normal shipped shape here, and a pass whose refusals cannot be judged
-  against one prepared context is not a candidate at all — see "the unit of that decision is the
-  refusal, not the pass" above, which is this bullet's scope statement.
+  against one prepared context is not a candidate at all. That passage —
+  `grep -n "THE UNIT OF THAT DECISION" docs/level-tower.md` — is this bullet's scope statement.
 - Add a **new op / representation** only when a capability genuinely cannot be expressed in the
   current one _and_ the differ can prove the result matches. Constant-offset access did not clear
   that bar; variable indexing did. If the corpus stays leaf/arithmetic-heavy, the tower may never

--- a/docs/level-tower.md
+++ b/docs/level-tower.md
@@ -569,13 +569,10 @@ because a wrong hoist there costs bytes and a match, never meaning, and saying s
 more than three gates pretending to a soundness they do not have.
 
 **THE UNIT OF THAT DECISION IS THE REFUSAL, NOT THE PASS — a pass may be PARTIALLY tabled, provided
-the residue is NAMED.** "Adopt this" is asked about a file, and the answer is almost never all of it,
-which is why — on the same 2026-09 retrospective the minutes below come from, and no more re-runnable
-from this repo than they are — three rounds in a row opened "should this pass adopt `Gate<Ctx>`",
-argued, and declined on cost: ten agent-touches that changed nothing, and each decline was RIGHT while
-its written reason was wrong. The reason is not cost. Three shipped passes answer the question three
-different ways, none of them a defect — and a fourth entry says what tabling has to INCLUDE either
-way:
+the residue is NAMED.** "Adopt this" is asked about a file, and the answer is almost never all of it.
+Asked file-wide the question gets declined on cost, which is the wrong reason and settles nothing for
+the next round that asks it. Three shipped passes answer it three different ways, none of them a
+defect — and a fourth entry says what tabling has to INCLUDE either way:
 
 - **Partially tabled, residue named.** [`structure/hazards.ts`](../packages/core/src/structure/hazards.ts)
   holds five per-candidate rules in `PREUPDATE_SINK_GATES`. The two SET-level rules — two slots
@@ -584,22 +581,20 @@ way:
   comment says both that they exist and where they live (`sinkablePreUpdateSlots`, "with the same
   refusal discipline"). That comment is the whole obligation. A partial table with the residue named
   is finished work; a partial table that reads as a complete one is the defect. Note what that
-  exclusion is NOT: both rules read `dest`, `names`, `exitArgs` and `sub` at one program point
-  (`grep -n "const names = new Set(dest.values())" packages/core/src/structure/hazards.ts`, and the
-  two lines under it), so an edge context is perfectly preparable and the next bullet's bar does not
-  touch them. They are outside `PREUPDATE_SINK_GATES` because a `Gate<Ctx>` is per-candidate and
-  these would need a SECOND table over a different `Ctx` — which the paragraph below says to build
-  when a round has had to instrument them, and not before.
+  exclusion is NOT: both rules judge one prepared edge
+  (`grep -n "const names = new Set(dest.values())" packages/core/src/structure/hazards.ts`), so the
+  next bullet's bar does not touch them. They are outside `PREUPDATE_SINK_GATES` because a
+  `Gate<Ctx>` is per-candidate and these would need a SECOND table over a different `Ctx` — which the
+  paragraph below says to build when a round has had to instrument them, and not before.
 - **Not tabled, and the decline left in prose.** `pointeeElement` in
   [`structure/structure.ts`](../packages/core/src/structure/structure.ts) lists its refusals in
   prose and states that it is "NOT a `Gate` table … unlike `FRESH_MERGE_GATES` and
   `CARRIER_NAME_GATES` in this same file: those refusals are predicates over ONE prepared context,
   while these interleave with the computations that produce the values the later ones test […], so
-  building that Ctx would run all of it on inputs the earlier gates reject." Read that reason the way
-  this section reads the other declines: the decline is right and the written reason is the EAGER
-  reading of "prepared", which the same file answers 600 lines further down — `CarrierName`'s fields
-  are getters (`grep -n "THE FIELDS ARE LAZY" packages/core/src/structure/structure.ts`), so a later
-  gate's input is computed only when the earlier ones let it be asked, and blame is unchanged.
+  building that Ctx would run all of it on inputs the earlier gates reject." That reason is the EAGER
+  reading of "prepared", which the same file answers in `CarrierName`: its fields are getters
+  (`grep -n "THE FIELDS ARE LAZY" packages/core/src/structure/structure.ts`), so a later gate's input
+  is computed only when the earlier ones let it be asked, and blame is unchanged.
   `pointeeElement` is pure, so each of its refusals is expressible that way too and its interleaving
   is a cost, not a bar. **The bar that IS structural is the lazy one: a refusal whose input cannot be
   prepared even as a memoized getter — because preparing it performs an effect, or depends on an
@@ -625,8 +620,9 @@ way:
   whole idea: "the one place an attribution is measured rather than asserted"). Neither form leaves
   `@asmlift/core`: no CLI flag, bench field or env var prints a gate id, so an attribution over the
   lifted corpus is still a written test — or, on the 21, still a patch. **Tabling a pass and adding
-  neither is half the job**: the missing half is ~12 lines, against the loop the next paragraph
-  prices.
+  neither is half the job**, and the missing half is small: a map, one `set` on the rejection, one
+  field on the return type — six lines in `structure/namecoalesce.ts`, against the loop the next
+  paragraph prices.
 
 **And converting a pass whose refusals nobody has had to instrument buys nothing.** What a table
 removes is the edit-instrument-revert loop — patch a `return null` to log, re-run, revert — so the
@@ -637,17 +633,21 @@ whose commit body records that the rules "were four `if`s inside a 5000-line fun
 "naming which one fires on a given row took an instrumented patch and a revert".
 
 There is exactly one other admission, and it is the mirror of that one — read it together with **A
-GATE CAN ALSO BE STARVED FROM ABOVE** below, which is the incident it comes from. Nobody can have
-paid instrument minutes on a rule nothing reaches, so the trigger above would make a starved gate
-permanently ineligible; but a table PLUS the bullet above's `refusals` map is what settles
-starvation, because together they report WHICH gate refused each candidate and a rule that never
-appears is a rule with no input. **Instrument time is the trigger for refusals that fire; a refusal
-suspected of never firing at all is the other admission, and the table is how you prove it.** Neither
-admission is "this file has a lot of `if`s". The map is not optional here and the source says so
-already — `coalesceNames`' doc comment in `structure/namecoalesce.ts`: "`refusals` counts which gate
-stopped each rejected pair, so a gate nothing ever reaches shows up as a rule no test can be failing
-on purpose". A round tabling a pass on THIS admission builds the map in the same change, or it has
-proved nothing.
+GATE CAN ALSO BE STARVED FROM ABOVE** below. Nobody can have paid instrument minutes on a rule
+nothing reaches, so the trigger above would make a starved gate permanently ineligible. **Instrument
+time is the trigger for refusals that fire; a refusal suspected of never firing at all is the other
+admission.** Neither admission is "this file has a lot of `if`s". A round tabling a pass on THIS
+admission builds the bullet above's `refusals` map in the same change, or it has proved nothing.
+
+**That map is where the starvation proof STARTS, not where it ends.** `firstRejection` returns the
+FIRST gate in table order that rejects, so a rule absent from the census is either starved or
+SHADOWED by an earlier one — and `ADDRESS_GATES`' own dated census
+(`grep -n "ON ITS OWN" packages/core/src/raise/globalshape.ts`) ships two of the second kind
+(`no-subscript` rejects 21 symbols run alone and is first for none of them;
+`stride-is-not-the-element` 25 and none). Telling the two apart takes the other experiment that
+census records, the rule run with the rest of the table EMPTY. A rule that rejects nothing even then
+is a question about what the upstream passes leave in the program, which the section below answers
+with a reach test through the real pipeline, never with a count.
 
 Refusal count predicts none of it, on any way of counting: `structure/switch-recover.ts` has 44
 refusal-shaped exits (`grep -cE 'return (null|false)\b'`) and cost 6.5 instrument-minutes across
@@ -677,8 +677,7 @@ together with the argument that contains it, so the next round cites it instead 
 A containment argument nobody wrote down gets re-proved by every round that reads the gate. Two
 instances of it ship, in the two files the bullets above cite: `structure/hazards.ts` on the third
 parallel-copy question ("needs no rule … Every leaf such an expression could read is already refused
-by a per-candidate gate", then naming all three), and `namecoalesce`'s enclosing-loop derivation. That
-is what this looks like when it is done.
+by a per-candidate gate", then naming all three), and `namecoalesce`'s enclosing-loop derivation.
 
 **A gate's PREMISE can be a target capability, and when it is, that is where it belongs.**
 `l3/unreduce.ts` deletes a loop-carried accumulator and re-spells each read as a closed form, which


### PR DESCRIPTION
## What this is

`docs/level-tower.md` already says to convert a pass's refusals to a `Gate` table "when they are
load-bearing", and says it twice — both times about a FILE. Nothing said a pass may be *partially*
tabled, nothing said the residue has to be named, and nothing said what actually triggers the
conversion. So the question kept being asked file-wide, and file-wide it gets declined on cost —
which settles nothing for the next round that asks it.

This branch writes the rule down and wires it into the two briefs that would otherwise never reach it.

**THE UNIT OF THAT DECISION IS THE REFUSAL, NOT THE PASS.** Four bullets over shipped precedents:

- **Partially tabled, residue named** — `structure/hazards.ts`: five per-candidate rules in
  `PREUPDATE_SINK_GATES`, the two SET-level rules deliberately outside it, and the table's own doc
  comment naming both that they exist and where they live. That comment is the whole obligation.
- **Not tabled, decline in prose** — `pointeeElement` in `structure/structure.ts`. Its shipped
  reason is the EAGER reading of "one prepared context", which the same file refutes 600 lines
  later with `CarrierName`'s lazy getters. The bar that IS structural is stated in its lazy form
  (an input that cannot be prepared even as a memoized getter — it performs an effect, or depends
  on an order the pass establishes), with the admission that **no pass here inhabits it**.
- **Fully tabled, and its inline `continue`s are not residue** — `structure/namecoalesce.ts`: the
  walk's exits are the ENUMERATOR, and a rule DERIVED away is residue that no longer exists.
- **Tabled AND REPORTED** — a table changes WHAT you patch, not WHETHER. 21 of the 27
  `firstRejection(` call sites outside `l3/gates.ts` compare the id to `null` and drop it.

Plus: the trigger (someone already paid the edit-instrument-revert loop), the second admission
(a refusal suspected of never firing — which a starved gate needs, since nobody can have paid
instrument minutes on a rule nothing reaches), the containment corollary, and a "does not license
a sweep" clause naming `l3/unmerge.ts` as the one candidate with measured instrument time.

## Premise verification — what I re-measured, and what was FALSE

Every number in the new prose is re-derived by command in this worktree. Several handed-down ones
did not survive:

| claim as handed down | measured | verdict |
|---|---|---|
| `namecoalesce.ts` "5 tabled and 4 inline" | `NAME_COALESCE_GATES` = 5, and **every refusal is in it** | **refuted** — namecoalesce is the FULLY-tabled precedent; the 4 walk exits enumerate |
| `raise/const.ts` "3 refusal sites" | **four** early exits, of which **exactly one** is a refusal (the file labels it); **zero** by the `return (null\|false)` grep | **refuted three ways** — reviewers' 3 and 3+1 are both wrong |
| `hazards.ts` "7 inline refusals" | not reproducible as a clean count; the residue is **two SET-level rules**, named by the table's own doc comment | **corrected** — the named fact replaced the count |
| counter-example passes for a sweep | `raise/globalaccess.ts` **does not exist**; `raise/divpow2.ts` 3 not 17; `structure/bitfields.ts` 1 not 18 | **refuted** — only `raise/magicdiv.ts` (18) survived and only it is named |
| "a `Gate` table plus a `refusals` map settles starvation" | `firstRejection` returns the FIRST rejecter — an absent rule is starved **or shadowed**. `ADDRESS_GATES`' shipped dated census has two live inhabitants of the second case: `no-subscript` rejects 21 symbols run alone and is first for **none**; `stride-is-not-the-element` 25 and none | **FALSE, and it would have retired two live rules.** Rewritten: the map is where the proof STARTS |
| "the missing half is ~12 lines" | no retrofit exists to measure — all three shipped `refusals` maps landed with their passes | **unmeasured, removed**; replaced with a counted six lines in `structure/namecoalesce.ts` |

Confirmed as handed down: `PREUPDATE_SINK_GATES` = 5 · `switch-recover.ts` 44 · `l3/unmerge.ts` 12 ·
`magicdiv.ts` 18 · 27 `firstRejection(` call sites (6 keep the id, 21 drop it) · #164 (`428f5706`)'s
body quoting "four `if`s inside a 5000-line function … an instrumented patch and a revert".

The retrospective minutes (6.5 / 38.6 / 47.7 / 69 vs 764) come from transcripts that are not in this
repo, and the text says so in place: an order of magnitude you cannot re-run, not a measurement you
can cite back.

## The test

`apps/benchmark/test/citations.test.ts` grows a second scan: every `grep -n "<phrase>" <path>` in
`docs/` and `.claude/commands/` must still hit. This branch introduced that anchor convention as the
replacement for `file.ts:N` (which rots on the next edit above it, silently); the test is what makes
it a convention rather than a hope. Six inhabitants. `file.ts:N` is deliberately NOT checked — the
dated attribution docs are full of them and they describe a snapshot.

Verified LOUD, not assumed: mutating one anchor phrase fails exactly one case, naming doc, phrase
and target. Re-verified in this gate (1 failed / 401 passed), then reverted.

## Wiring — part of the item, not a follow-up

Per the mining round's standing warning ("this project's problem is not missing diagnostics, it is
diagnostics nobody is pointed at"), a passage no brief names does not get read:

- `match-function.md` Phase 3 — read the passage at the moment of temptation (you just patched a
  `return null` to log why it fired), and table it REPORTED.
- `attribute-function.md` hard rule 2 — the SUPPLY side: it is the brief that instructs the
  instrument loop, so it now says to record the episode **in the PR body** (not only in `research/`,
  whose path nothing may cite), and to check first whether the pass already exports a census or a
  `refusals` map, which reads the id with no edit at all.

## Commits

- `b5cf44a9` — the passage in `docs/level-tower.md`, and the existing gate-table bullet citing it as its scope statement.
- `394ebf60` — point `match-function.md` at it before a round re-argues it.
- `371bc053` — say what a starved gate does with the trigger; recount `const.ts` by the rule the section itself states.
- `ee5f2d6e` — tell the brief that GENERATES the instrument evidence to record it, not only the brief that spends it.
- `e3880693` — state the bar in its lazy form, and that a table nobody reads reports nothing.
- `635feca6` — the anchor test.
- `23f9d5ca` — tell the briefs what a tabled refusal costs to read, and where its evidence goes.
- `80cf291f` — a refusals census reports the FIRST rejecter, so an absent rule is starved **or shadowed**.

## No bench, and why

`git diff --name-only origin/main...HEAD` is exactly:

    .claude/commands/attribute-function.md
    .claude/commands/match-function.md
    apps/benchmark/test/citations.test.ts
    docs/level-tower.md

`scripts/check-artifact-provenance.sh` measures `packages/{core,cli,toolchains}/src` and
`apps/benchmark/{src,dataset}`. **None is touched** — `apps/benchmark/test` is not in that set. No
bench run, no artifact commit, no moved rows to inventory. Provenance re-run anyway: exit 0,
"this branch publishes no numbers of its own. UNKNOWN, not checked."

One reviewer expected a comment-only edit under `packages/core/src` to make the branch owe an
artifact check. That was **tested** (probe commit, provenance re-run, `reset --hard`) and is false —
still exit 0, UNKNOWN, because the artifact is byte-identical to the base's.

## Declined findings

- **Write the two "known and contained" standing blockers beside `structure.ts:1187` (`carrier-live`)
  and `:2431` (`seedLoopParams`)** — DECLINED, twice, and both reviewers re-tested and could not
  falsify the decline. For `carrier-live` the note would be **false on arrival**: #164's body records
  that it *was* subsumed by `re-derives` and that the round then made the two rules disjoint; it now
  ships `sound: true` with a fuzz guard, so "known and contained" would contradict the gate. For
  `seedLoopParams` no containment argument exists anywhere readable — the only trace is a phrase in a
  transcript. Writing an argument I cannot verify into the repo is precisely the failure this item
  exists to record. The generalisable half ships as the corollary, with its two shipped inhabitants;
  the two instances belong to whoever holds the arguments.
- **`raise/const.ts` as the named next target** — dropped after the recount: a table over it would
  hold ONE gate, which the `namecoalesce` bullet calls a conversion that buys nothing. It stays in
  the text as the standing warning about the selector, since the retrospective prices minutes per
  FILE while this rule is consumed per REFUSAL, and `const.ts` is where the two readings diverge.
- **A line range for the SET-level rules** — `485-489`, not the `485-488` handed down, and replaced
  with a `grep` anchor rather than corrected. That removes the last `file:line` from
  `docs/level-tower.md`.

## Gates

| gate | result |
|---|---|
| rebase onto `origin/main` | up to date — base did **not** move (`ed3e0bc4`, same commit the branch was cut from) |
| `npx vitest run` | **214 files / 3743 tests passed**, exit 0 |
| `pnpm test:matching` | **36 files passed / 5 skipped, 324 passed / 35 skipped**, exit 0 |
| `pnpm exec vitest run apps/benchmark/test` | **34 files / 820 tests passed**, exit 0 (citations 402) |
| `pnpm typecheck` | exit 0 |
| `pnpm lint` | 0 errors, 126 warnings — all pre-existing, **none** in the new file |
| `pnpm format` | clean, no files rewritten |
| `scripts/check-artifact-provenance.sh` | exit 0, UNKNOWN (no measured path) |
| anchor test is loud | mutated one anchor → 1 failed / 401 passed; reverted |

## What this does NOT do

- It converts no pass. Not one `if` becomes a `Gate`, and no `refusals` map is added.
- It moves no benchmark row, because it changes no code that lifts anything.
- It does not name the next pass to table on evidence anyone can re-run — `l3/unmerge.ts` rests on
  the same non-re-runnable retrospective as the rest of the minutes, and the text hedges it.
- It does not write the `carrier-live` / `seedLoopParams` containment notes.
- It does not make a gate id reachable from outside `@asmlift/core`; the doc records that gap
  (no CLI flag, bench field or env var prints one) without closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
