### PR TITLE
Print one benchmark row's whole candidate fan, instead of computing it and throwing it away

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -39,7 +39,15 @@ one) is an unfinished finding.
    the number every later claim is measured against** — it carries `best …` and the source sha —
    and it goes into your report verbatim, **naming the vehicle**. Never a `[score] … | tail -1`:
    that table is sorted best-first, so the last line is the WORST candidate.
-3. State the baseline in your first user-facing message.
+3. **Read the FAN before you name a missing capability**: `pnpm bench fan $1` prints every
+   candidate spelling the harness ranked for this row — label, score over its own denominator,
+   dropped, withheld — and `--show <label>` prints any one of their SOURCES, which `results.json`
+   does not carry for a non-winner. An attribution that says "asmlift never considers X" is a claim
+   about this list, so read it. `--enumerate` gives the same list in seconds without compiling
+   anything (and still serves `--show`); a fan over 2,000 is refused unless you pass `--force`,
+   because that is a compile each. Unlike the two vehicles above, this one runs in the harness's own
+   configuration by construction — it is the same call `bench run` makes for the row.
+4. State the baseline in your first user-facing message.
 
 ## The denominator moves — so a residual is never a "partition"
 

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -45,9 +45,10 @@ one) is an unfinished finding.
    does not carry for a non-winner. An attribution that says "asmlift never considers X" is a claim
    about this list, so read it. Its `[ranked]` line carries the same `synthesized` count and
    `[asmlift source <sha>]` stamp as the vehicles above, so it is quotable in the same way.
-   `--enumerate` gives the same list without compiling anything (~120 candidates/s, so a huge fan
-   takes minutes to list — that is a big fan, not a hang) and still serves `--show <label>`, though
-   not `--show best`: nothing has been scored, so there is no winner to name. A fan over 2,000 is
+   `--enumerate` lists the same candidates' LABELS without compiling anything — no scores, because
+   nothing was compiled (~120 candidates/s, so a huge fan takes minutes to list: that is a big fan,
+   not a hang). It still serves `--show <label>`, though not `--show best`: nothing has been
+   scored, so there is no winner to name. A fan over 2,000 is
    refused unless you pass `--force`, and the refusal quotes what `--force` would cost on THIS row.
    Unlike the two vehicles above, this one runs in the harness's own configuration by construction
    — it is the same call `bench run` makes for the row.

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -45,7 +45,7 @@ one) is an unfinished finding.
    does not carry for a non-winner. An attribution that says "asmlift never considers X" is a claim
    about this list, so read it. Its `[ranked]` line carries the same `synthesized` count and
    `[asmlift source <sha>]` stamp as the vehicles above, so it is quotable in the same way.
-   `--enumerate` gives the same list without compiling anything (~128 candidates/s, so a huge fan
+   `--enumerate` gives the same list without compiling anything (~120 candidates/s, so a huge fan
    takes minutes to list — that is a big fan, not a hang) and still serves `--show <label>`, though
    not `--show best`: nothing has been scored, so there is no winner to name. A fan over 2,000 is
    refused unless you pass `--force`, and the refusal quotes what `--force` would cost on THIS row.
@@ -53,9 +53,12 @@ one) is an unfinished finding.
    — it is the same call `bench run` makes for the row.
    **A declined row usually has no fan at all** — and that is a finding, not a broken command:
    enumeration throws on the very gap the row declines on (`enumerateCandidates` has no annotate
-   mode), so you get `asmlift: [fan] no fan … enumerating threw — <the gap>` and exit 2, which
-   names your missing capability directly. On a `noncompile` row the `[dropped]` lines are printed
-   in full and they are the row's entire fan.
+   mode), so you get `asmlift: [fan] no fan for <row>: <the gap>` followed by "the gap named above
+   is the one this row DECLINES on", and exit 2 — which names your missing capability directly.
+   That sentence is chosen by the ERROR, so it is the same with or without `--force`. On a
+   `noncompile` row the `[dropped]`/`[withheld]` lines are printed in full and they are the row's
+   entire fan. Anything else that throws is reported as a HARNESS defect, with its stack — read
+   that as the tool being broken, never as this row's outcome.
 4. State the baseline in your first user-facing message.
 
 ## The denominator moves — so a residual is never a "partition"

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -43,10 +43,19 @@ one) is an unfinished finding.
    candidate spelling the harness ranked for this row — label, score over its own denominator,
    dropped, withheld — and `--show <label>` prints any one of their SOURCES, which `results.json`
    does not carry for a non-winner. An attribution that says "asmlift never considers X" is a claim
-   about this list, so read it. `--enumerate` gives the same list in seconds without compiling
-   anything (and still serves `--show`); a fan over 2,000 is refused unless you pass `--force`,
-   because that is a compile each. Unlike the two vehicles above, this one runs in the harness's own
-   configuration by construction — it is the same call `bench run` makes for the row.
+   about this list, so read it. Its `[ranked]` line carries the same `synthesized` count and
+   `[asmlift source <sha>]` stamp as the vehicles above, so it is quotable in the same way.
+   `--enumerate` gives the same list without compiling anything (~128 candidates/s, so a huge fan
+   takes minutes to list — that is a big fan, not a hang) and still serves `--show <label>`, though
+   not `--show best`: nothing has been scored, so there is no winner to name. A fan over 2,000 is
+   refused unless you pass `--force`, and the refusal quotes what `--force` would cost on THIS row.
+   Unlike the two vehicles above, this one runs in the harness's own configuration by construction
+   — it is the same call `bench run` makes for the row.
+   **A declined row usually has no fan at all** — and that is a finding, not a broken command:
+   enumeration throws on the very gap the row declines on (`enumerateCandidates` has no annotate
+   mode), so you get `asmlift: [fan] no fan … enumerating threw — <the gap>` and exit 2, which
+   names your missing capability directly. On a `noncompile` row the `[dropped]` lines are printed
+   in full and they are the row's entire fan.
 4. State the baseline in your first user-facing message.
 
 ## The denominator moves — so a residual is never a "partition"

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -90,17 +90,23 @@ symbol map), so it is comparable with the published row rather than with a check
   to answer "did my new lever produce a candidate at all" — a label that is absent was never
   enumerated, and a lever that THREW prints as `[lever] … threw (no candidate from it)`, which a
   `bench run` does not print anywhere. It is cheap against compiling, not cheap absolutely:
-  ~128 candidates/s measured, so a 225,792-candidate fan is ~30 minutes to list. A long
+  ~120 candidates/s measured, so a 225,792-candidate fan is ~30 minutes to list. A long
   enumeration is a big fan, not a hang.
 
 A fan over 2,000 candidates is refused rather than scored (`--force` overrides): that is a compile
-each, ~60 ms of it, and the refusal quotes the row's own price — 5,952 candidates is ~6 minutes
-(worth `--force`), `LoadBGTilemapData`'s 225,792 is ~4 hours (`--enumerate` is the answer there).
+each, and the refusal quotes the row's own price at its own TIER'S measured rate — 60 ms/candidate
+synthetic, 85 ms real, because a real candidate escalates through up to three preludes where a
+synthetic one is a single small one. So `kleod:CountCollectedGems:agbcc`'s 5,952 is ~8 minutes
+(measured twice at 8.0 and 8.6; worth `--force`), and `LoadBGTilemapData`'s 225,792 is over five
+hours (`--enumerate` is the answer there).
 
 **A declined or noncompile row has NO fan, and the command says so** (`asmlift: [fan] no fan …`,
 exit 2) rather than crashing: enumeration throws on the same gap the row declines on, and on a
-noncompile row every candidate was refused — there the `[dropped]` lines printed above the message
-ARE the fan, and they are the row's whole diagnostic.
+noncompile row every candidate was refused — there the `[dropped]`/`[withheld]` lines printed above
+the message ARE the fan, and they are the row's whole diagnostic. Which of the two you are looking
+at is decided by the ERROR CLASS, not by the flags, so `--force` does not change the answer; a
+throw that is neither is named a HARNESS defect and printed with its stack, and must never be read
+as this row's outcome.
 
 Write the classification down with the evidence that decided it. If it is one of the last two, go
 straight to Phase 7 and report — that is a successful outcome of this command, not a failure.

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -73,6 +73,23 @@ them are not "add a feature":
   not use (the `old_agbcc` class of bug). Then the fix is in the manifest/toolchain, not the
   decompiler, and it may *remove* the row rather than match it.
 
+**"Missing capability" vs "missing lever" is decided by the FAN, and the harness computes it for
+you.** `pnpm bench fan <sym|row-id>` prints every spelling asmlift considered for that row — each
+one's label, its score against its own denominator, the ones the scorer dropped, the ones withheld
+— in the harness's own configuration (the row's target object, prototypes, context compile and
+symbol map), so it is comparable with the published row rather than with a checkout. Two flags:
+
+- `--show <label>` prints that candidate's SOURCE. Nothing else can: `results.json` carries the
+  winner's C and no other's, so "the near-miss spelling is right and only loses on X" is a claim
+  you can now read instead of infer. `--show best` is the winner.
+- `--enumerate` lists the fan without compiling anything (seconds, at any size) and still serves
+  `--show`. Use it to answer "did my new lever produce a candidate at all" — a label that is
+  absent was never enumerated, and a lever that THREW prints as `[lever] … threw (no candidate
+  from it)`, which a `bench run` does not print anywhere.
+
+A fan over 2,000 candidates is refused rather than scored (`--force` overrides): that is a compile
+each, and `LoadBGTilemapData`'s 225,792 is hours. `--enumerate` is the answer there, not `--force`.
+
 Write the classification down with the evidence that decided it. If it is one of the last two, go
 straight to Phase 7 and report — that is a successful outcome of this command, not a failure.
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -81,14 +81,26 @@ symbol map), so it is comparable with the published row rather than with a check
 
 - `--show <label>` prints that candidate's SOURCE. Nothing else can: `results.json` carries the
   winner's C and no other's, so "the near-miss spelling is right and only loses on X" is a claim
-  you can now read instead of infer. `--show best` is the winner.
-- `--enumerate` lists the fan without compiling anything (seconds, at any size) and still serves
-  `--show`. Use it to answer "did my new lever produce a candidate at all" — a label that is
-  absent was never enumerated, and a lever that THREW prints as `[lever] … threw (no candidate
-  from it)`, which a `bench run` does not print anywhere.
+  you can now read instead of infer. `--show best` is the winner (on the SCORED path only — under
+  `--enumerate` nothing has been scored, so `--enumerate --show best` is refused rather than
+  answered with whatever came out of the enumerator first). A DROPPED candidate's source — usually
+  the one worth reading — is reachable only as `--enumerate --show <label>`, and the command says
+  so when you ask for it the other way.
+- `--enumerate` lists the fan without compiling anything and still serves `--show <label>`. Use it
+  to answer "did my new lever produce a candidate at all" — a label that is absent was never
+  enumerated, and a lever that THREW prints as `[lever] … threw (no candidate from it)`, which a
+  `bench run` does not print anywhere. It is cheap against compiling, not cheap absolutely:
+  ~128 candidates/s measured, so a 225,792-candidate fan is ~30 minutes to list. A long
+  enumeration is a big fan, not a hang.
 
 A fan over 2,000 candidates is refused rather than scored (`--force` overrides): that is a compile
-each, and `LoadBGTilemapData`'s 225,792 is hours. `--enumerate` is the answer there, not `--force`.
+each, ~60 ms of it, and the refusal quotes the row's own price — 5,952 candidates is ~6 minutes
+(worth `--force`), `LoadBGTilemapData`'s 225,792 is ~4 hours (`--enumerate` is the answer there).
+
+**A declined or noncompile row has NO fan, and the command says so** (`asmlift: [fan] no fan …`,
+exit 2) rather than crashing: enumeration throws on the same gap the row declines on, and on a
+noncompile row every candidate was refused — there the `[dropped]` lines printed above the message
+ARE the fan, and they are the row's whole diagnostic.
 
 Write the classification down with the evidence that decided it. If it is one of the last two, go
 straight to Phase 7 and report — that is a successful outcome of this command, not a failure.

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -179,6 +179,14 @@ pnpm bench repro <sym|id> --run       # reproduce ONE published row outside the 
                                       #   with this machine's paths filled in, runs it, reports the
                                       #   `[ranked]` line. `bench target` is its step 1, not this.
                                       #   docs/ranked-repro.md is the argument
+pnpm bench fan <sym|id>               # every CANDIDATE the harness ranked for ONE row, not just
+                                      #   the winner it published: the `[score]` table, the
+                                      #   [dropped]/[withheld] lists, the `[ranked]` line.
+                                      #   `--enumerate` lists the fan without compiling anything,
+                                      #   `--show <label>` prints one candidate's C, `--force`
+                                      #   scores a fan over 2,000. Neighbour of `bench repro`:
+                                      #   that one re-runs the row's PUBLISHED script, this one
+                                      #   opens the ranking the script's one line summarises
 pnpm bench verify apps/benchmark/dataset/real/<p>.json   # compile-check loop for manifests
 pnpm bench regression --base origin/main   # gate: exit 1 on any lost match or vanished row --
                                            #   TWICE: once against `--base`, then again over the

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -324,6 +324,7 @@ Host prerequisites (macOS; verified empirically):
 | `toolchains.ts`    | 4 toolchain adapters over `@asmlift/toolchains` (`buildTarget` + `score`)                                                                                                                                        |
 | `decomp-config.ts` | candidate compilation through the real `decomp.yaml` user path                                                                                                                                                   |
 | `cache.ts`         | content-keyed result cache (tmp-then-rename; m2c dirty-checkout fail-closed; versioned key)                                                                                                                      |
+| `asm-scrub.ts`     | the objdump header scrub (`/abs/path/x.o:` -> `target.o:`), one spelling for the runner, the evaluator and `bench fan`                                                                                           |
 
 The result schema is [`@asmlift/bench-schema`](../../packages/bench-schema/README.md) — the ONE
 definition this harness produces and the web Benchmark view consumes, including the closed feature

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -312,18 +312,18 @@ Host prerequisites (macOS; verified empirically):
 
 ## Harness layout (`src/`)
 
-| module             | role                                                                                                                                                                            |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cli.ts`           | THE entry point: one argv parser, subcommand dispatch                                                                                                                           |
-| `config.ts`        | ALL env/path resolution (m2c, cpp, WORKSPACE)                                                                                                                                   |
-| `cases/`           | the `Case` abstraction + both tier providers (`synthetic.ts`, `real.ts`) + manifest loader/validation                                                                           |
-| `compile/`         | one module per toolchain — real-tier build + candidate steps shared (candidate-compile commands live in `dataset/toolchains/`)                                                  |
-| `eval/`            | `evaluate.ts` (both decompilers on one case), `asmlift.ts`, `m2c.ts`, `m2c-normalizer.ts` (objdump-to-GNU-as normalizer), `outcome.ts` (the symmetric classifier), `quality.ts` |
-| `run/`             | `runner.ts` (the ONE case loop), `orchestrate.ts` (spawns the shards, merges their partial results), `fidelity.ts` (the script-fidelity gate), `smoke.ts`, `verify.ts`          |
-| `report/`          | `merge.ts` (pure: tiers -> results.json), `gap-size.ts`, `repro-scripts.ts`, the three gates (`stale-check`/`regression`/`diff`) over `committed.ts`, `publish.ts`              |
-| `toolchains.ts`    | 4 toolchain adapters over `@asmlift/toolchains` (`buildTarget` + `score`)                                                                                                       |
-| `decomp-config.ts` | candidate compilation through the real `decomp.yaml` user path                                                                                                                  |
-| `cache.ts`         | content-keyed result cache (tmp-then-rename; m2c dirty-checkout fail-closed; versioned key)                                                                                     |
+| module             | role                                                                                                                                                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cli.ts`           | THE entry point: one argv parser, subcommand dispatch                                                                                                                                                            |
+| `config.ts`        | ALL env/path resolution (m2c, cpp, WORKSPACE)                                                                                                                                                                    |
+| `cases/`           | the `Case` abstraction + both tier providers (`synthetic.ts`, `real.ts`) + manifest loader/validation                                                                                                            |
+| `compile/`         | one module per toolchain — real-tier build + candidate steps shared (candidate-compile commands live in `dataset/toolchains/`)                                                                                   |
+| `eval/`            | `evaluate.ts` (both decompilers on one case), `asmlift.ts`, `m2c.ts`, `m2c-normalizer.ts` (objdump-to-GNU-as normalizer), `outcome.ts` (the symmetric classifier), `quality.ts`                                  |
+| `run/`             | `runner.ts` (the ONE case loop), `orchestrate.ts` (spawns the shards, merges their partial results), `fidelity.ts` (the script-fidelity gate), `fan.ts` (one row's whole candidate fan), `smoke.ts`, `verify.ts` |
+| `report/`          | `merge.ts` (pure: tiers -> results.json), `gap-size.ts`, `repro-scripts.ts`, the three gates (`stale-check`/`regression`/`diff`) over `committed.ts`, `publish.ts`                                               |
+| `toolchains.ts`    | 4 toolchain adapters over `@asmlift/toolchains` (`buildTarget` + `score`)                                                                                                                                        |
+| `decomp-config.ts` | candidate compilation through the real `decomp.yaml` user path                                                                                                                                                   |
+| `cache.ts`         | content-keyed result cache (tmp-then-rename; m2c dirty-checkout fail-closed; versioned key)                                                                                                                      |
 
 The result schema is [`@asmlift/bench-schema`](../../packages/bench-schema/README.md) — the ONE
 definition this harness produces and the web Benchmark view consumes, including the closed feature

--- a/apps/benchmark/src/asm-scrub.ts
+++ b/apps/benchmark/src/asm-scrub.ts
@@ -1,0 +1,12 @@
+// One rule, three callers: the objdump header line an asm dump starts with names the object's
+// ABSOLUTE path — a per-machine mkdtemp scratch dir or a cache dir — and every consumer of that
+// text wants it byte-stable across machines and cache generations. Published rows, the
+// reproduction scripts, m2c's cache keys and `bench fan`'s re-entry into the ranked call all read
+// the SAME disassembly, so a fourth spelling of the regex is a way for one of them to read a
+// different one.
+/** Replace the leading `/abs/path/to/x.o:` header with `target.o:`. Nothing parses that line — the
+ *  m2c normalizer and `--asm-data` read the tables below it — so this is a stability edit and never
+ *  a semantic one. Idempotent, and a no-op on text that has no such header. */
+export function scrubObjectHeader(asm: string): string {
+  return asm.replace(/^\/\S+\.o:/m, 'target.o:');
+}

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -9,6 +9,11 @@
 //                                        # paths filled in, under the gitignored .local/repro/,
 //                                        # and with --run executes it and reports `[ranked]`
 //   pnpm bench target <id> --out <dir>   # repro-script pre-step: target object + decomp.yaml
+//   pnpm bench fan <row> [--show <label>] [--enumerate] [--force]
+//                                        # ONE row's whole candidate fan — every spelling's label
+//                                        # and score, not just the winner's — in the harness's own
+//                                        # configuration; --show prints a candidate's SOURCE and
+//                                        # --enumerate lists the fan without compiling anything
 //   pnpm bench setup [--project p] [--build]
 //                                        # materialize the BENCH-OWNED project checkouts
 //                                        # (apps/benchmark/checkouts/: clone + baseroms + prepare;
@@ -91,6 +96,11 @@ const { values: opts, positionals } = parseArgs({
     // repro only: which of the row's two scripts, and whether to execute it here.
     tool: { type: 'string' },
     run: { type: 'boolean', default: false },
+    // fan only: which candidate's source to print, listing the fan without compiling it, and the
+    // override for the fan-size refusal.
+    show: { type: 'string' },
+    enumerate: { type: 'boolean', default: false },
+    force: { type: 'boolean', default: false },
   },
 });
 
@@ -362,6 +372,27 @@ switch (command) {
     );
     break;
   }
+  case 'fan': {
+    // fan <row> [--show <label>] [--enumerate] [--force] — print the ranked candidate fan the
+    // harness computes for this row and then discards (eval/asmlift.ts publishes the winner's
+    // label and source plus the two refusal lists; `RankedResult.candidates` is dropped on the
+    // floor). ROW-SCOPED by construction, and that is the point rather than an omission: the
+    // corpus's fan is ~82,756 candidates, so a tier-wide form of this would write tens of
+    // thousands of sources to answer a question that is always about one function.
+    const rowId = positionals[1];
+    if (!rowId) {
+      console.error('usage: pnpm bench fan <sym|project:sym:toolchain> [--show <label>] [--enumerate] [--force]');
+      process.exit(2);
+    }
+    const { fan } = await import('./run/fan');
+    process.exit(
+      fan(rowId, {
+        ...(opts.show ? { show: opts.show } : {}),
+        enumerateOnly: opts.enumerate,
+        force: opts.force,
+      }),
+    );
+  }
   case 'fidelity': {
     const jobs = Number(opts.jobs ?? Math.min(8, cpus().length));
     if (!Number.isInteger(jobs) || jobs < 1) {
@@ -455,7 +486,7 @@ switch (command) {
   }
   default:
     console.error(
-      `usage: bench <run|target|setup|fidelity|merge|publish|baseline|stale-check|regression|diff|smoke|verify|vendor> — got ${JSON.stringify(command)}`,
+      `usage: bench <run|repro|target|fan|setup|fidelity|merge|publish|baseline|stale-check|regression|diff|smoke|verify|vendor> — got ${JSON.stringify(command)}`,
     );
     process.exit(2);
 }

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -385,6 +385,9 @@ switch (command) {
       process.exit(2);
     }
     const { fan } = await import('./run/fan');
+    // `break` under an unconditional `process.exit` is unreachable and stays anyway: every other
+    // case here ends with one, and a `return` added to this block later would otherwise fall
+    // straight through into `case 'fidelity'`.
     process.exit(
       fan(rowId, {
         ...(opts.show ? { show: opts.show } : {}),
@@ -392,6 +395,7 @@ switch (command) {
         force: opts.force,
       }),
     );
+    break;
   }
   case 'fidelity': {
     const jobs = Number(opts.jobs ?? Math.min(8, cpus().length));

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -374,10 +374,8 @@ switch (command) {
   }
   case 'fan': {
     // fan <row> [--show <label>] [--enumerate] [--force] — print the ranked candidate fan the
-    // harness computes for this row and then discards (eval/asmlift.ts publishes the winner's
-    // label and source plus the two refusal lists; `RankedResult.candidates` is dropped on the
-    // floor). ROW-SCOPED by construction, and that is the point rather than an omission: the
-    // corpus's fan is ~82,756 candidates, so a tier-wide form of this would write tens of
+    // harness computes for this row and then discards (run/fan.ts). ROW-SCOPED by construction,
+    // and that is the point rather than an omission: a tier-wide form would write tens of
     // thousands of sources to answer a question that is always about one function.
     const rowId = positionals[1];
     if (!rowId) {
@@ -385,9 +383,6 @@ switch (command) {
       process.exit(2);
     }
     const { fan } = await import('./run/fan');
-    // `break` under an unconditional `process.exit` is unreachable and stays anyway: every other
-    // case here ends with one, and a `return` added to this block later would otherwise fall
-    // straight through into `case 'fidelity'`.
     process.exit(
       fan(rowId, {
         ...(opts.show ? { show: opts.show } : {}),

--- a/apps/benchmark/src/eval/asmlift.ts
+++ b/apps/benchmark/src/eval/asmlift.ts
@@ -37,10 +37,9 @@ export type Scorer = (candC: string, sym: string, obj: string, declarations?: st
  *  measured.
  *
  *  The return type is ANNOTATED rather than inferred, and that annotation is the guard the
- *  paragraph above asks for: an inferred object literal accepts a misspelled option silently (a
- *  `symbolz: 1` typechecked clean here for as long as this function existed), and a mistyped
- *  option is a dropped one. With `RankOptions` named, tsc answers "'symbolz' does not exist in
- *  type 'RankOptions'. Did you mean to write 'symbols'?". */
+ *  paragraph above asks for: an inferred object literal accepts a misspelled option silently, and
+ *  a mistyped option is a dropped one. With `RankOptions` named, tsc answers "'symbolz' does not
+ *  exist in type 'RankOptions'. Did you mean to write 'symbols'?". */
 export function rankOptionsFor(
   tc: Toolchain,
   obj: string,
@@ -77,11 +76,10 @@ export function rankOptionsFor(
  *  the source it was scored from (`Scored extends Candidate`).
  *
  *  `runAsmlift` publishes four facts out of this object — the winner's label and source, the
- *  dropped list and the withheld list — and drops `candidates` on the floor, which is how six
- *  consecutive rounds came to hand-write a script to recompute it. This is that script's one
- *  supported entry point (`bench fan`), and it is deliberately the SAME call the harness makes
- *  rather than a parallel one: `decompileRankedParallel` would reorder nothing but is a different
- *  driver, and a published measurement must not depend on a scheduler. */
+ *  dropped list and the withheld list — and drops `candidates` on the floor. `bench fan` is the
+ *  one supported way to read them, and it is deliberately the SAME call the harness makes rather
+ *  than a parallel one: `decompileRankedParallel` would reorder nothing but is a different driver,
+ *  and a published measurement must not depend on a scheduler. */
 export function asmliftFan(
   tc: Toolchain,
   sym: string,

--- a/apps/benchmark/src/eval/asmlift.ts
+++ b/apps/benchmark/src/eval/asmlift.ts
@@ -4,7 +4,7 @@
 // output is compiled+scored exactly as the target was built.
 import type { DecompilerResult } from '@asmlift/bench-schema';
 import type { CandidateCompiler } from '@asmlift/cli/compile-command';
-import { decompileRanked } from '@asmlift/cli/rank';
+import { type RankOptions, type RankedResult, decompileRanked } from '@asmlift/cli/rank';
 import type { MatchScore } from '@asmlift/cli/score';
 import type { SymbolRef } from '@asmlift/core/l3/symbol-refs';
 import { decompile } from '@asmlift/core/pipeline';
@@ -25,19 +25,23 @@ import { assessQuality } from './quality';
  *  Optional: a scorer whose rows declare nothing ignores it. */
 export type Scorer = (candC: string, sym: string, obj: string, declarations?: string) => MatchScore;
 
-// asmlift runs in its differ-ranked production mode (decompileRanked): genuinely-ambiguous levers
-// (param signedness, divergent-if branch sense) become candidates and the objdiff score picks the
-// winner — single-shot `decompile` would under-score what asmlift can match. decompileRanked
-// scores internally via the target-dispatched `scoreSource` (the same per-toolchain scorer).
-export function runAsmlift(
+/** THE INPUTS one benchmark row hands asmlift — the asm-data side table, the row's prototypes,
+ *  the candidate compiler and the vendored symbol map — as the single options object both phases
+ *  below are driven with.
+ *
+ *  Exported because `bench fan` re-enters the SAME ranked path for one row, and a fan enumerated
+ *  under options assembled a second time is a fan of a different configuration: docs/ranked-repro.md
+ *  documents a 112,896-vs-135,936 spread between two checkouts of one project, and a dropped
+ *  `symbols` here reproduces exactly that class of discrepancy while printing the row's own id
+ *  beside it. Built ONCE, here, and read by every driver that claims to show what the benchmark
+ *  measured. */
+export function rankOptionsFor(
   tc: Toolchain,
-  sym: string,
-  asm: string,
   obj: string,
   prototypes?: Prototypes,
   contextCompile?: CandidateCompiler,
   symbols?: SymbolMap,
-): DecompilerResult {
+) {
   // Side-table: extract the data-section jump table + relocations from the SAME target object so a
   // dense MIPS/PPC switch can recover. Best-effort — a missing/failed objdump (or agbcc, whose
   // table is inline) yields `undefined`.
@@ -53,7 +57,7 @@ export function runAsmlift(
   // On the synthetic tier (no context), the generated decomp.yaml compiler (the unconfigured
   // user path). This is what lets recovered GLOBALS (a bare `gSym`) compile at all.
   const compile = contextCompile ?? benchCompilerFor(tc.id);
-  const opts = {
+  return {
     ...(prototypes ? { prototypes } : {}),
     ...(asmData ? { asmData } : {}),
     ...(compile ? { compile } : {}),
@@ -61,6 +65,41 @@ export function runAsmlift(
     // ranked lever rides along, so a symbol-fed row can never score worse than without.
     ...(symbols ? { symbols } : {}),
   };
+}
+
+/** Phase 2 alone: the row's WHOLE ranked fan, every candidate carrying its label, its score and
+ *  the source it was scored from (`Scored extends Candidate`).
+ *
+ *  `runAsmlift` publishes four facts out of this object — the winner's label and source, the
+ *  dropped list and the withheld list — and drops `candidates` on the floor, which is how six
+ *  consecutive rounds came to hand-write a script to recompute it. This is that script's one
+ *  supported entry point (`bench fan`), and it is deliberately the SAME call the harness makes
+ *  rather than a parallel one: `decompileRankedParallel` would reorder nothing but is a different
+ *  driver, and a published measurement must not depend on a scheduler. */
+export function asmliftFan(
+  tc: Toolchain,
+  sym: string,
+  asm: string,
+  obj: string,
+  opts: ReturnType<typeof rankOptionsFor> & Pick<RankOptions, 'onProgress' | 'onLeverError'>,
+): RankedResult {
+  return decompileRanked(sym, asm, tc.targetDesc, obj, opts);
+}
+
+// asmlift runs in its differ-ranked production mode (decompileRanked): genuinely-ambiguous levers
+// (param signedness, divergent-if branch sense) become candidates and the objdiff score picks the
+// winner — single-shot `decompile` would under-score what asmlift can match. decompileRanked
+// scores internally via the target-dispatched `scoreSource` (the same per-toolchain scorer).
+export function runAsmlift(
+  tc: Toolchain,
+  sym: string,
+  asm: string,
+  obj: string,
+  prototypes?: Prototypes,
+  contextCompile?: CandidateCompiler,
+  symbols?: SymbolMap,
+): DecompilerResult {
+  const opts = rankOptionsFor(tc, obj, prototypes, contextCompile, symbols);
   // Phase 1 — single-shot decompile in annotate mode: every detected gap becomes an inline
   // ASMLIFT_ERROR marker plus a structured diagnostic. Gapped ⇒ outcome "declined", never
   // scored (the marker could compile via an implicit declaration and grade meaningless code).
@@ -105,7 +144,7 @@ export function runAsmlift(
 
   // Phase 2 — rank candidates (compile + objdiff-score each) and take the differ-picked best.
   try {
-    const ranked = decompileRanked(sym, asm, tc.targetDesc, obj, opts);
+    const ranked = asmliftFan(tc, sym, asm, obj, opts);
     const best = ranked.best;
     const s = best.score;
     return {

--- a/apps/benchmark/src/eval/asmlift.ts
+++ b/apps/benchmark/src/eval/asmlift.ts
@@ -34,14 +34,20 @@ export type Scorer = (candC: string, sym: string, obj: string, declarations?: st
  *  documents a 112,896-vs-135,936 spread between two checkouts of one project, and a dropped
  *  `symbols` here reproduces exactly that class of discrepancy while printing the row's own id
  *  beside it. Built ONCE, here, and read by every driver that claims to show what the benchmark
- *  measured. */
+ *  measured.
+ *
+ *  The return type is ANNOTATED rather than inferred, and that annotation is the guard the
+ *  paragraph above asks for: an inferred object literal accepts a misspelled option silently (a
+ *  `symbolz: 1` typechecked clean here for as long as this function existed), and a mistyped
+ *  option is a dropped one. With `RankOptions` named, tsc answers "'symbolz' does not exist in
+ *  type 'RankOptions'. Did you mean to write 'symbols'?". */
 export function rankOptionsFor(
   tc: Toolchain,
   obj: string,
   prototypes?: Prototypes,
   contextCompile?: CandidateCompiler,
   symbols?: SymbolMap,
-) {
+): RankOptions {
   // Side-table: extract the data-section jump table + relocations from the SAME target object so a
   // dense MIPS/PPC switch can recover. Best-effort — a missing/failed objdump (or agbcc, whose
   // table is inline) yields `undefined`.

--- a/apps/benchmark/src/eval/evaluate.ts
+++ b/apps/benchmark/src/eval/evaluate.ts
@@ -7,6 +7,7 @@ import { renderDeclarations } from '@asmlift/core/declare';
 import type { Prototypes } from '@asmlift/core/proto';
 import type { SymbolMap } from '@asmlift/core/symbols';
 
+import { scrubObjectHeader } from '../asm-scrub';
 import { cachedAsmDumpText, cachedM2cResult } from '../cache';
 import { rowFeatures } from '../cases/features';
 import type { Toolchain } from '../toolchains';
@@ -224,7 +225,8 @@ export function evaluate(
     // the dump header names the object's ABSOLUTE path (cache dir — machine-specific); scrub it
     // so published rows and scripts are byte-identical across machines. Nothing parses the
     // header line (the normalizer and --asm-data read the tables below it).
-    asmDump = cachedAsmDumpText(obj, tc.id)?.replace(/^\/\S+\.o:/m, 'target.o:');
+    const dump = cachedAsmDumpText(obj, tc.id);
+    asmDump = dump === undefined ? undefined : scrubObjectHeader(dump);
   } catch {
     // text-only fallback
   }

--- a/apps/benchmark/src/run/fan.ts
+++ b/apps/benchmark/src/run/fan.ts
@@ -1,0 +1,230 @@
+// `pnpm bench fan <row>` — the candidate fan the harness ALREADY computes for one row, printed
+// instead of discarded.
+//
+// `eval/asmlift.ts` ranks every candidate spelling and then publishes four facts out of the
+// result: the winner's label, the winner's source, the dropped list and the withheld list.
+// `RankedResult.candidates` — every OTHER spelling, each carrying its own label, its score and
+// the exact source it was scored from — is computed, paid for, and dropped on the floor. Six
+// consecutive rounds hand-wrote the same ~25-line script to recompute it. This is that script,
+// with a row id instead of a hard-coded symbol.
+//
+// WHY A SUBCOMMAND AND NOT A `bench run` FLAG: the question is always about ONE row, and a flag on
+// `run` prices a one-row question at a full tier (~2,100 s). This builds one target, ranks one
+// function, and exits.
+//
+// WHY IT IS NOT `pnpm asmlift --score-against`: that command prints the same `[score]` table, but
+// it is reached through the PROJECT CHECKOUT and a hand-written `--proto`, and
+// docs/ranked-repro.md is a long document about how easily that configuration drifts from the
+// benchmark's (112,896 vs 135,936 candidates for one function across two checkouts of one
+// project). Here the row IS the configuration: the case's own target object, prototypes, context
+// compiler and vendored symbol map, assembled by the one function the harness assembles them with
+// (`rankOptionsFor`). What this prints is what the benchmark measured, by construction.
+//
+// The line shapes are deliberately the CLI's (`asmlift: [score] …`, `[dropped]`, `[withheld]`,
+// `[ranked]`), so docs/ranked-repro.md's comparison recipe — `grep -F '[score]'` over two runs —
+// works across the two commands without a second recipe to keep in step.
+import type { RankedCandidate, RankedResult } from '@asmlift/cli/rank';
+import { enumerateRanked } from '@asmlift/cli/rank';
+import { scoreOf } from '@asmlift/cli/score-format';
+import { decompile } from '@asmlift/core/pipeline';
+import type { Candidate } from '@asmlift/core/rank';
+
+import { realCases } from '../cases/real';
+import { syntheticCases } from '../cases/synthetic';
+import type { Case } from '../cases/types';
+import { asmliftFan, rankOptionsFor } from '../eval/asmlift';
+
+/** How many candidates this command will COMPILE before refusing without `--force`.
+ *
+ *  The scope guard, and it is not decorative: a fan is a product over enumeration axes, so row
+ *  sizes are not on ONE scale. `synthetic:sizebound:agbcc` enumerates 800 and scores them here in
+ *  **57 s cold, 8 s once the candidate cache holds them** (both measured on this machine) — a fine
+ *  price for a diagnostic, and the limit has to sit well above it or the command refuses the very
+ *  rows it exists for. At the cold rate this limit is about two and a half minutes.
+ *  `LoadBGTilemapData` enumerates 225,792 (docs/ranked-repro.md); the same rate puts its fan at
+ *  FOUR HOURS, which is a run a round starts on purpose or not at all.
+ *
+ *  A one-row diagnostic that can silently become an overnight job is a trap, and the cheap answer
+ *  — `--enumerate`, which compiles nothing and still prints every label and, with `--show`, any
+ *  candidate's source — is one flag away, so the refusal costs seconds and names its own way out. */
+export const FAN_SCORE_LIMIT = 2000;
+
+export interface FanOptions {
+  /** print this candidate's SOURCE (its label, or `best`) after the table */
+  show?: string;
+  /** list the fan without compiling anything — the whole command in seconds, at any fan size */
+  enumerateOnly?: boolean;
+  /** score a fan larger than FAN_SCORE_LIMIT anyway */
+  force?: boolean;
+}
+
+/** Resolve a row the way a reader names one: the exact id first, then a substring of it.
+ *
+ *  Exact-first matters and is not just convenience — `--only` elsewhere in the harness is a
+ *  substring match, so a round that has been typing symbol names all day types one here; but a row
+ *  id that is a substring of another row's id (a symbol and its `_2` sibling) must still resolve to
+ *  itself rather than to an ambiguity error. Returns every match so the caller can print them: a
+ *  command that silently picks one of four toolchains for a symbol answers a question nobody
+ *  asked. */
+export function selectCases(cases: Case[], query: string): Case[] {
+  const exact = cases.filter((c) => c.id === query);
+  return exact.length > 0 ? exact : cases.filter((c) => c.id.includes(query));
+}
+
+/** One candidate as the CLI spells it — through the CLI's OWN renderer, denominator included.
+ *  `scoreOf` exists because a numerator alone reads as a subtraction on a fixed scale and is not
+ *  one (`290/404 → 171/387`, PR #174); a second renderer here would re-open exactly that. */
+export function scoreLine(c: RankedCandidate): string {
+  return `asmlift: [score] ${c.label}: ${scoreOf(c.score)}`;
+}
+
+/** The whole scored fan: every candidate, then the two refusal lists, then the summary line.
+ *
+ *  `dropped` and `withheld` are printed IN FULL here, where the CLI prints a count plus the first
+ *  one. The CLI's line is a footnote under a score a user is reading; this command is the one
+ *  place whose entire purpose is the fan, and "3 candidates failed to score; first: …" is exactly
+ *  the shape that sent rounds back to a hand-written script. */
+export function renderFan(ranked: RankedResult): string {
+  const lines = ranked.candidates.map(scoreLine);
+  for (const d of ranked.dropped) {
+    lines.push(`asmlift: [dropped] ${d.label}: ${d.error.split('\n')[0]}`);
+  }
+  for (const w of ranked.withheld) {
+    lines.push(`asmlift: [withheld] ${w.label} at ${scoreOf(w)}: ${w.why}`);
+  }
+  lines.push(
+    `asmlift: [ranked] ${ranked.candidates.length} candidate(s) scored, ${ranked.dropped.length} dropped, ` +
+      `${ranked.withheld.length} withheld, best ${ranked.best.label}: ${scoreOf(ranked.best.score)}`,
+  );
+  return lines.join('\n');
+}
+
+/** `--show`: the named candidate, or the winner under the reserved name `best`. Undefined ⇒ the
+ *  caller lists what there was, because a typo'd label and a lever that produced no candidate at
+ *  all are the same silence otherwise. */
+export function pickCandidate<C extends Candidate>(candidates: C[], label: string): C | undefined {
+  if (label === 'best') {
+    return candidates[0];
+  }
+  return candidates.find((c) => c.label === label);
+}
+
+/** A candidate's source, with the header that says which spelling it is — a non-winning
+ *  candidate's C is otherwise indistinguishable from the published row's. */
+function showSource(label: string, source: string): string {
+  return `/* candidate ${label} */\n${source.trimEnd()}`;
+}
+
+/** stderr, so `bench fan <row> > fan.txt` keeps the table and drops the noise. */
+function note(s: string): void {
+  console.error(s);
+}
+
+export function fan(rowId: string, o: FanOptions = {}): number {
+  const matches = selectCases([...syntheticCases(), ...realCases()], rowId);
+  if (matches.length === 0) {
+    note(`no such row: ${rowId} (ids are project:sym:toolchain)`);
+    return 2;
+  }
+  if (matches.length > 1) {
+    note(`${rowId} matches ${matches.length} rows — name one:\n${matches.map((c) => `  ${c.id}`).join('\n')}`);
+    return 2;
+  }
+  const c = matches[0];
+  if (!c.toolchain.available()) {
+    note(`${c.id}: toolchain ${c.toolchain.id} unavailable — nothing to enumerate`);
+    return 2;
+  }
+
+  // The runner's own build, header scrub included: the disassembly asmlift sees must be the bytes
+  // the row was measured from, and the scrub is part of them (runner.ts).
+  const { obj, asm: raw } = c.build();
+  const asm = raw.replace(/^\/\S+\.o:/m, 'target.o:');
+  const opts = rankOptionsFor(c.toolchain, obj, c.proto, c.compile, c.symbols);
+  note(`${c.id} — tier ${c.tier}, toolchain ${c.toolchain.id}${c.symbols ? ', symbol map' : ''}`);
+
+  // The harness's PHASE 1 verdict, stated before any number: a gapped row is published `declined`
+  // and its fan is never scored at all, so a reader handed this table without the warning would be
+  // reading candidate scores for a row whose published outcome has no score in it.
+  try {
+    const dec = decompile(c.sym, asm, c.toolchain.targetDesc, { ...opts, onGap: 'annotate' });
+    for (const d of dec.diagnostics) {
+      note(`asmlift: [declined] ${d.stage}: ${d.reason.split('\n')[0].slice(0, 200)}`);
+    }
+    if (dec.diagnostics.length > 0) {
+      note(
+        `asmlift: [declined] this row publishes outcome "declined" — the fan below is what WOULD ` +
+          `be scored if the gap(s) above closed`,
+      );
+    }
+  } catch (e) {
+    note(`asmlift: [declined] annotate pass threw: ${(e as Error).message.split('\n')[0]}`);
+  }
+
+  // A lever that THREW produced no candidate to drop, and the benchmark supplies no sink for that
+  // channel — cli/rank.ts says so at the field: "a whole pre-fan half of a row's fan can still
+  // vanish from a `pnpm bench run` with nothing printed". Here it is printed.
+  const leverErrors = new Map<string, string>();
+  const withLevers = {
+    ...opts,
+    onLeverError: (label: string, error: string) => leverErrors.set(label, error.split('\n')[0]),
+  };
+  const printLevers = (): void => {
+    for (const [label, error] of leverErrors) {
+      note(`asmlift: [lever] ${label} threw (no candidate from it): ${error}`);
+    }
+  };
+
+  // ENUMERATE-ONLY, and also the pre-count the size guard needs. Skipped under `--force`, which
+  // has already answered the question the count would ask — enumeration on the rows this guard
+  // exists for is itself the expensive part.
+  if (o.enumerateOnly || !o.force) {
+    const cands = enumerateRanked(c.sym, asm, c.toolchain.targetDesc, withLevers);
+    printLevers();
+    if (o.enumerateOnly) {
+      console.log(cands.map((cand) => `asmlift: [candidate] ${cand.label}`).join('\n'));
+      console.log(`asmlift: [fan] ${cands.length} candidate(s) enumerated, none scored (--enumerate)`);
+      if (o.show) {
+        const picked = pickCandidate(cands, o.show);
+        if (!picked) {
+          note(`no candidate labelled ${JSON.stringify(o.show)} — see the [candidate] lines above`);
+          return 2;
+        }
+        console.log(showSource(picked.label, picked.source));
+      }
+      return 0;
+    }
+    if (cands.length > FAN_SCORE_LIMIT) {
+      note(
+        `${c.id} enumerates ${cands.length} candidates — over the ${FAN_SCORE_LIMIT} this command will ` +
+          `compile — a compile each, and at this machine's measured rate that is well over an hour. ` +
+          `Re-run with ` +
+          `--enumerate for the labels and sources without compiling, or --force to score them all.`,
+      );
+      return 2;
+    }
+  }
+
+  // …and the scoring pass, through the harness's own driver.
+  const ranked = asmliftFan(c.toolchain, c.sym, asm, obj, {
+    ...withLevers,
+    onProgress: (done, total, bestSoFar) => {
+      const every = Math.max(1, Math.floor(total / 10));
+      if (done === 1 || done === total || done % every === 0) {
+        const best = bestSoFar === undefined ? '' : `, best so far ${scoreOf(bestSoFar)}`;
+        note(`asmlift: [progress] ${done}/${total} candidates scored${best}`);
+      }
+    },
+  });
+  printLevers();
+  console.log(renderFan(ranked));
+  if (o.show) {
+    const picked = pickCandidate(ranked.candidates, o.show);
+    if (!picked) {
+      note(`no candidate labelled ${JSON.stringify(o.show)} — see the [score] lines above`);
+      return 2;
+    }
+    console.log(showSource(picked.label, picked.source));
+  }
+  return 0;
+}

--- a/apps/benchmark/src/run/fan.ts
+++ b/apps/benchmark/src/run/fan.ts
@@ -4,9 +4,8 @@
 // `eval/asmlift.ts` ranks every candidate spelling and then publishes four facts out of the
 // result: the winner's label, the winner's source, the dropped list and the withheld list.
 // `RankedResult.candidates` — every OTHER spelling, each carrying its own label, its score and
-// the exact source it was scored from — is computed, paid for, and dropped on the floor. Six
-// consecutive rounds hand-wrote the same ~25-line script to recompute it. This is that script,
-// with a row id instead of a hard-coded symbol.
+// the exact source it was scored from — is computed, paid for, and dropped on the floor. This is
+// the supported way to read it, taking a row id.
 //
 // WHY A SUBCOMMAND AND NOT A `bench run` FLAG: the question is always about ONE row, and a flag on
 // `run` prices a one-row question at a full tier (~2,100 s). This builds one target, ranks one
@@ -55,9 +54,8 @@ import { asmliftFan, rankOptionsFor } from '../eval/asmlift';
  *  — `--enumerate`, which compiles nothing and still prints every label and, with `--show`, any
  *  candidate's source — is one flag away. It is CHEAP RELATIVE TO COMPILING and not cheap
  *  absolutely: `kleod:CountCollectedGems:agbcc`'s 5,952 labels take 50 s wall, target build
- *  included (~120 candidates/s), so LBG's fan is ~30 minutes to merely LIST — and this guard is checked after the
- *  pre-count enumeration, so the refusal itself pays that. Both prices are stated where they are
- *  paid rather than promised away. */
+ *  included (~120 candidates/s), so LBG's fan is ~30 minutes to merely LIST — and this guard is
+ *  checked after the pre-count enumeration, so the refusal itself pays that. */
 export const FAN_SCORE_LIMIT = 2000;
 
 /** Seconds per candidate on the SCORING path — a compile plus an objdiff alignment — PER TIER,
@@ -75,19 +73,14 @@ export const FAN_SCORE_LIMIT = 2000;
  *  enumeration, and both runs reproduced the published `171/387`. The constant is the middle of
  *  the two; the spread is machine load, and the tier gap is 40% either way.)
  *
- *  One rate for both was wrong by ~35% on the real tier, and wrong in the direction that matters:
- *  the refusal quotes this price to a reader deciding whether to start the run, and it quoted it
- *  on `CountCollectedGems` — a REAL row, and the row six rounds were about. The first spelling
- *  also claimed 60 ms was "the pessimistic end", which the real-tier measurement falsifies.
+ *  ONE rate for both under-prices the real tier by ~35%, and that is the tier the refusal quotes
+ *  on `CountCollectedGems`. The mechanism is in `compile/real.ts`: a real candidate escalates
+ *  through up to three preludes (`makeRealCompile`), where a synthetic one is a single small
+ *  prelude — so the real tier pays more compiler invocations per candidate, and the gap is
+ *  structural rather than noise.
  *
- *  The mechanism is in `compile/real.ts`: a real candidate escalates through up to three preludes
- *  (`makeRealCompile`), where a synthetic one is a single small prelude — so the real tier pays
- *  more compiler invocations per candidate, and the gap is structural rather than noise.
- *
- *  It exists to make the refusal QUOTE A PRICE rather than assert one: the sentence this replaces
- *  said a fan over the limit is "well over an hour" while the constant's own doc-comment two
- *  screens up said two and a half minutes, and the second one was right. A reader who is steered
- *  off `--force` by a number that is wrong by 20x loses the answer the command exists to give. */
+ *  The point of the constant is that the refusal QUOTES a price instead of asserting one: a reader
+ *  steered off `--force` by a wrong number loses the answer the command exists to give. */
 export const SCORE_SECONDS_PER_CANDIDATE: Record<Case['tier'], number> = {
   synthetic: 0.06,
   real: 0.085,
@@ -213,12 +206,11 @@ export function pickCandidate<C extends Candidate>(candidates: C[], label: strin
 /** Flag combinations that cannot mean anything, refused BEFORE the row is built — enumeration on a
  *  big row costs ~46 s, and paying it to be told the flags were nonsense is the worst order.
  *
- *  There is one, and it was shipped working: `--enumerate --show best` printed `candidate
- *  unsigned` on `synthetic:sizebound:agbcc`, whose real winner scores 8/81 while `unsigned` is
- *  near the bottom of the same fan. Nothing had been scored, so `best` resolved to whatever
- *  enumeration emitted first — a near-worst spelling, presented under the name of the winner, to a
- *  round that both briefs had told `--show best` is the winner and `--enumerate` still serves
- *  `--show`. A wrong answer in the shape of a right one is worse than a refusal. */
+ *  There is one: `--enumerate --show best`. Nothing has been scored, so `best` would resolve to
+ *  whatever enumeration emitted first — a near-worst spelling presented under the name of the
+ *  winner, to a round both briefs have told that `--show best` is the winner and that
+ *  `--enumerate` still serves `--show`. A wrong answer in the shape of a right one is worse than
+ *  a refusal. */
 export function optionRefusal(o: FanOptions): string | undefined {
   if (o.enumerateOnly && o.show === 'best') {
     return (
@@ -261,13 +253,9 @@ const stampFrom = (treeBefore: ReturnType<typeof sampleSourceTree>): string =>
  *    (233 of 1,035 rows). Enumeration has no annotate mode, so it throws where the published row
  *    gets an `ASMLIFT_ERROR` marker.
  *
- *  The first shipped version picked its sentence from a `phase` string the CALLER passed, which is
- *  the same "read the label, not the instrument" mistake the `dmanest`/`max3` rounds are
- *  memorialised for — and it was wrong in practice within one commit: `--force` skips the guarded
- *  pre-count enumeration, so a DECLINED row's lift error lands in the scoring catch and got
- *  "every candidate was refused … this is what the published row's noncompile outcome means" under
- *  zero `[dropped]` lines, on a row that publishes `declined`. Both briefs tell a round to pass
- *  `--force`.
+ *  The sentence is chosen by the ERROR and never by which call site caught it: `--force` skips the
+ *  guarded pre-count enumeration, so a declined row's lift error arrives at the scoring catch,
+ *  where a call-site guess would call it `noncompile`. Both briefs tell a round to pass `--force`.
  *
  *  Anything the three tests do not classify is a HARNESS DEFECT and says so, with the stack: a
  *  guard that swallows a `TypeError` into a confident sentence about the row is strictly worse
@@ -319,9 +307,8 @@ export function noFanReport(rowId: string, e: unknown, show?: string): NoFanRepo
     );
   }
 
-  // `--show` on this path was silently dropped by the first version, on exactly the row class
-  // where the flag's advice earns its keep: a noncompile row is the one row where EVERY candidate
-  // is unshowable.
+  // `--show` is answered on this path too — a noncompile row is the one row class where EVERY
+  // candidate is unshowable, which is exactly where the flag's advice earns its keep.
   if (show !== undefined) {
     notes.push(
       dropped.length + withheld.length === 0
@@ -393,9 +380,8 @@ export function fan(rowId: string, o: FanOptions = {}): number {
     return 2;
   }
   // AFTER the row is resolved, and before it is built. A nonsense flag pair is worth refusing
-  // before a 46 s enumeration is paid for it — but not before the command can say the row does not
-  // exist, which was the first spelling's order: `bench fan nosuchrowatall --enumerate --show best`
-  // lectured about the flags. Case selection is in-memory, so this ordering costs nothing.
+  // before a ~46 s enumeration is paid for it — but not before the command can say the row does
+  // not exist. Case selection is in-memory, so this ordering costs nothing.
   const refusal = optionRefusal(o);
   if (refusal !== undefined) {
     note(refusal);
@@ -409,8 +395,7 @@ export function fan(rowId: string, o: FanOptions = {}): number {
   //
   // GUARDED, and it is the one throw on this path that is NOT a fact about the row: a target that
   // will not build is the harness broken (the runner names it the same way — "a HARNESS defect,
-  // not a decompiler outcome"). Unguarded it was a raw Node stack, which is the reading the rest
-  // of this file spends a commit eliminating.
+  // not a decompiler outcome").
   let built: ReturnType<Case['build']>;
   try {
     built = c.build();
@@ -448,9 +433,8 @@ export function fan(rowId: string, o: FanOptions = {}): number {
   const leverErrors = new Map<string, string>();
   // ANNOTATED, for the same reason `rankOptionsFor`'s return type is: a mistyped option key is a
   // SILENTLY DROPPED option, and a dropped `symbols` is the 112,896-vs-135,936 discrepancy class
-  // docs/ranked-repro.md is about. The annotation on `rankOptionsFor` does not reach here — this
-  // object is built by spread, and excess-property checking only fires on a literal that is
-  // itself annotated (verified: `symbolz: 1` in this literal typechecks clean without it).
+  // docs/ranked-repro.md is about. `rankOptionsFor`'s own annotation does not reach here —
+  // excess-property checking fires on a literal only where that literal is itself annotated.
   const withLevers: RankOptions = {
     ...opts,
     onLeverError: (label: string, error: string) => leverErrors.set(label, error.split('\n')[0]),
@@ -474,9 +458,8 @@ export function fan(rowId: string, o: FanOptions = {}): number {
   if (o.enumerateOnly || !o.force) {
     // GUARDED, because `enumerateCandidates` has no annotate mode: the gap the phase-1 pass above
     // turns into an `ASMLIFT_ERROR` marker is a THROW here, and 233 of the corpus's 1,035 rows
-    // publish `declined` on exactly such a gap. Unguarded, this command printed "the fan below is
-    // what WOULD be scored" and then a Node stack trace with no fan below it — on the very rows
-    // `attribute-function.md` sends a round here to read.
+    // publish `declined` on exactly such a gap — the very rows `attribute-function.md` sends a
+    // round here to read.
     let cands: Candidate[];
     try {
       cands = enumerateRanked(c.sym, asm, c.toolchain.targetDesc, withLevers);

--- a/apps/benchmark/src/run/fan.ts
+++ b/apps/benchmark/src/run/fan.ts
@@ -23,12 +23,17 @@
 // The line shapes are deliberately the CLI's (`asmlift: [score] …`, `[dropped]`, `[withheld]`,
 // `[ranked]`), so docs/ranked-repro.md's comparison recipe — `grep -F '[score]'` over two runs —
 // works across the two commands without a second recipe to keep in step.
+import { declaredBlock } from '@asmlift/cli/declare';
+import { bakedBuild, sampleSourceTree, sourceStamp } from '@asmlift/cli/provenance';
 import type { RankedCandidate, RankedResult } from '@asmlift/cli/rank';
 import { enumerateRanked } from '@asmlift/cli/rank';
-import { scoreOf } from '@asmlift/cli/score-format';
+import { rankedSummaryLine, scoreOf } from '@asmlift/cli/score-format';
+import type { SymbolRef } from '@asmlift/core/l3/symbol-refs';
 import { decompile } from '@asmlift/core/pipeline';
-import type { Candidate } from '@asmlift/core/rank';
+import type { Candidate, DroppedCandidate, WithheldCandidate } from '@asmlift/core/rank';
+import { NoScorableCandidateError } from '@asmlift/core/rank';
 
+import { scrubObjectHeader } from '../asm-scrub';
 import { realCases } from '../cases/real';
 import { syntheticCases } from '../cases/synthetic';
 import type { Case } from '../cases/types';
@@ -38,21 +43,51 @@ import { asmliftFan, rankOptionsFor } from '../eval/asmlift';
  *
  *  The scope guard, and it is not decorative: a fan is a product over enumeration axes, so row
  *  sizes are not on ONE scale. `synthetic:sizebound:agbcc` enumerates 800 and scores them here in
- *  **57 s cold, 8 s once the candidate cache holds them** (both measured on this machine) — a fine
- *  price for a diagnostic, and the limit has to sit well above it or the command refuses the very
- *  rows it exists for. At the cold rate this limit is about two and a half minutes.
+ *  **48 s cold, 10 s once the candidate cache holds them** (both measured on this machine) — a
+ *  fine price for a diagnostic, and the limit has to sit well above it or the command refuses the
+ *  very rows it exists for. At the cold rate this limit is about two minutes, and the refusal says
+ *  so with the row's own count rather than a fixed scare sentence (`SCORE_SECONDS_PER_CANDIDATE`).
  *  `LoadBGTilemapData` enumerates 225,792 (docs/ranked-repro.md); the same rate puts its fan at
- *  FOUR HOURS, which is a run a round starts on purpose or not at all.
+ *  nearly FOUR HOURS, which is a run a round starts on purpose or not at all.
  *
  *  A one-row diagnostic that can silently become an overnight job is a trap, and the cheap answer
  *  — `--enumerate`, which compiles nothing and still prints every label and, with `--show`, any
- *  candidate's source — is one flag away, so the refusal costs seconds and names its own way out. */
+ *  candidate's source — is one flag away. It is CHEAP RELATIVE TO COMPILING and not cheap
+ *  absolutely: enumeration ran at 128 candidates/s on `kleod:CountCollectedGems:agbcc` (5,952 in
+ *  46 s), so LBG's fan is ~30 minutes to merely LIST — and this guard is checked after the
+ *  pre-count enumeration, so the refusal itself pays that. Both prices are stated where they are
+ *  paid rather than promised away. */
 export const FAN_SCORE_LIMIT = 2000;
+
+/** Seconds per candidate on the SCORING path — a compile plus an objdiff alignment — from the
+ *  slowest cold measurement on this machine: `synthetic:sizebound:agbcc`, 800 candidates in 47.9 s
+ *  with `ASMLIFT_CANDCACHE=0`. (`kleod:SetupBG3WindowOverlay`'s 1,024 ran at ~29 ms each, so this
+ *  is the pessimistic end; a warm candidate cache is ~5x faster again.)
+ *
+ *  It exists to make the refusal QUOTE A PRICE rather than assert one: the sentence this replaces
+ *  said a fan over the limit is "well over an hour" while the constant's own doc-comment two
+ *  screens up said two and a half minutes, and the second one was right. A reader who is steered
+ *  off `--force` by a number that is wrong by 20x loses the answer the command exists to give. */
+export const SCORE_SECONDS_PER_CANDIDATE = 0.06;
+
+/** The price of scoring `n` candidates, rounded to a unit a reader can act on. Never a bare
+ *  second-count above a minute: the decision this informs is "do I start this now", and 357 s is a
+ *  number one has to divide before it means anything. */
+export function estimatedScoreTime(n: number): string {
+  const seconds = n * SCORE_SECONDS_PER_CANDIDATE;
+  if (seconds < 90) {
+    return `about ${Math.max(1, Math.round(seconds))} s`;
+  }
+  const minutes = seconds / 60;
+  return minutes < 90 ? `about ${Math.round(minutes)} min` : `about ${(minutes / 60).toFixed(1)} h`;
+}
 
 export interface FanOptions {
   /** print this candidate's SOURCE (its label, or `best`) after the table */
   show?: string;
-  /** list the fan without compiling anything — the whole command in seconds, at any fan size */
+  /** List the fan without compiling anything. Cheap against the scoring pass and not free:
+   *  enumeration ran at 128 candidates/s here (`kleod:CountCollectedGems:agbcc`, 5,952 in 46 s),
+   *  so the biggest fans take minutes to merely list. */
   enumerateOnly?: boolean;
   /** score a fan larger than FAN_SCORE_LIMIT anyway */
   force?: boolean;
@@ -78,35 +113,98 @@ export function scoreLine(c: RankedCandidate): string {
   return `asmlift: [score] ${c.label}: ${scoreOf(c.score)}`;
 }
 
-/** The whole scored fan: every candidate, then the two refusal lists, then the summary line.
- *
- *  `dropped` and `withheld` are printed IN FULL here, where the CLI prints a count plus the first
+/** The two refusal lists, one line each and IN FULL — where the CLI prints a count plus the first
  *  one. The CLI's line is a footnote under a score a user is reading; this command is the one
  *  place whose entire purpose is the fan, and "3 candidates failed to score; first: …" is exactly
- *  the shape that sent rounds back to a hand-written script. */
-export function renderFan(ranked: RankedResult): string {
+ *  the shape that sent rounds back to a hand-written script.
+ *
+ *  Separate from `renderFan` because they are also the ONLY output a row whose every candidate
+ *  failed to compile has: `rankBy` throws there rather than returning, so the fan reaches the
+ *  reader through the thrown error's own lists (`NoScorableCandidateError`). One spelling for both
+ *  paths. */
+export const dropLine = (d: DroppedCandidate): string => `asmlift: [dropped] ${d.label}: ${d.error.split('\n')[0]}`;
+export const withheldLine = (w: WithheldCandidate): string =>
+  `asmlift: [withheld] ${w.label} at ${scoreOf(w)}: ${w.why}`;
+
+/** The whole scored fan: every candidate, then the two refusal lists, then the `[declared]` block
+ *  and the summary line.
+ *
+ *  `synthesized` and `stamp` are ARGUMENTS rather than something computed here because they are
+ *  not facts about the fan: the first is a claim about the world the candidates compiled in (the
+ *  caller knows the row's tier), the second about the tree that produced them. They are on the
+ *  line because the line is what a round pastes — see `rankedSummaryLine`, which both this command
+ *  and the CLI's own ranked run now render through. */
+export function renderFan(ranked: RankedResult, a: { synthesized: SymbolRef[]; stamp: string }): string {
   const lines = ranked.candidates.map(scoreLine);
-  for (const d of ranked.dropped) {
-    lines.push(`asmlift: [dropped] ${d.label}: ${d.error.split('\n')[0]}`);
-  }
-  for (const w of ranked.withheld) {
-    lines.push(`asmlift: [withheld] ${w.label} at ${scoreOf(w)}: ${w.why}`);
+  lines.push(...ranked.dropped.map(dropLine), ...ranked.withheld.map(withheldLine));
+  if (a.synthesized.length > 0) {
+    lines.push(declaredBlock(a.synthesized).trimEnd());
   }
   lines.push(
-    `asmlift: [ranked] ${ranked.candidates.length} candidate(s) scored, ${ranked.dropped.length} dropped, ` +
-      `${ranked.withheld.length} withheld, best ${ranked.best.label}: ${scoreOf(ranked.best.score)}`,
+    rankedSummaryLine({
+      scored: ranked.candidates.length,
+      dropped: ranked.dropped.length,
+      withheld: ranked.withheld.length,
+      synthesized: a.synthesized.length,
+      best: ranked.best,
+      stamp: a.stamp,
+    }),
   );
   return lines.join('\n');
 }
 
+/** WHICH of the winner's declarations asmlift INVENTED, in the world this row is scored in — the
+ *  list the `[declared]` block names and the count the `[ranked]` line carries.
+ *
+ *  The CLI asks its compiler seam (`compilers.selfDeclared()`); the benchmark cannot — its
+ *  `benchCompilerFor` hands back the bare compile function and drops the probe's verdict. The row
+ *  itself answers instead, and the answer is the tier: a REAL row is compiled through
+ *  `makeRealCompile`, whose every rung is a headers world ("the rest of the synthesized block
+ *  stays dropped: the context owns it", compile/real.ts) — so no score there rests on an invented
+ *  declaration, and the count is 0. A SYNTHETIC row has no project context, so the block is the
+ *  only declaration its candidates have.
+ *
+ *  Wrong in ONE direction only, and deliberately: a synthetic toolchain whose prelude probe fails
+ *  would make this over-report, which prints declarations to check that turn out to have been
+ *  ignored. Under-reporting would publish a `(match)` resting on declarations nobody was told
+ *  about. */
+export function synthesizedRefs(tier: Case['tier'], best: RankedCandidate): SymbolRef[] {
+  return tier === 'real' ? [] : (best.symbolRefs ?? []).filter((r) => r.synthesized);
+}
+
 /** `--show`: the named candidate, or the winner under the reserved name `best`. Undefined ⇒ the
  *  caller lists what there was, because a typo'd label and a lever that produced no candidate at
- *  all are the same silence otherwise. */
+ *  all are the same silence otherwise.
+ *
+ *  `best` IS `candidates[0]` and only because the caller hands it a SCORED list: `rankBy` sorts
+ *  best-first (core rank.ts `compareScored`). An enumerated list is in enumeration order and has
+ *  no best at all, so that combination is refused before any work happens — see `optionRefusal`,
+ *  which exists because this function cannot tell the two arrays apart. */
 export function pickCandidate<C extends Candidate>(candidates: C[], label: string): C | undefined {
   if (label === 'best') {
     return candidates[0];
   }
   return candidates.find((c) => c.label === label);
+}
+
+/** Flag combinations that cannot mean anything, refused BEFORE the row is built — enumeration on a
+ *  big row costs ~46 s, and paying it to be told the flags were nonsense is the worst order.
+ *
+ *  There is one, and it was shipped working: `--enumerate --show best` printed `candidate
+ *  unsigned` on `synthetic:sizebound:agbcc`, whose real winner scores 8/81 while `unsigned` is
+ *  near the bottom of the same fan. Nothing had been scored, so `best` resolved to whatever
+ *  enumeration emitted first — a near-worst spelling, presented under the name of the winner, to a
+ *  round that both briefs had told `--show best` is the winner and `--enumerate` still serves
+ *  `--show`. A wrong answer in the shape of a right one is worse than a refusal. */
+export function optionRefusal(o: FanOptions): string | undefined {
+  if (o.enumerateOnly && o.show === 'best') {
+    return (
+      `--show best names the WINNER and --enumerate scores nothing, so there is no winner to name ` +
+      `(an enumerated fan is in enumeration order, not score order). Drop --enumerate to score the ` +
+      `fan and get a real best, or pass --show <label> for a spelling you can name.`
+    );
+  }
+  return undefined;
 }
 
 /** A candidate's source, with the header that says which spelling it is — a non-winning
@@ -120,7 +218,70 @@ function note(s: string): void {
   console.error(s);
 }
 
+/** The stamp the `[ranked]` line carries: which tree produced these numbers. Two samples, before
+ *  and after the run — see provenance.ts for why one is not enough. */
+const stampFrom = (treeBefore: ReturnType<typeof sampleSourceTree>): string =>
+  sourceStamp(treeBefore, sampleSourceTree(), bakedBuild());
+
+/** THERE IS NO FAN, as an ANSWER rather than a crash — the command's own exit 2 and a sentence,
+ *  never a Node stack trace.
+ *
+ *  Both of the ranked path's calls can throw, and each throw is a fact about the ROW rather than a
+ *  harness defect: enumeration throws on the unmodelled construct that made the row `declined`
+ *  (233 rows), and scoring throws when every spelling failed to compile (the 4 `noncompile` rows).
+ *  Shipped unguarded, both printed a stack trace and exited 1 — indistinguishable, to a script or
+ *  a fresh agent, from the harness being broken, which is exactly the reading that sends a round
+ *  back to the hand-written script this command replaced.
+ *
+ *  On the scoring failure the DROP LIST is printed in full: `rankBy` has no result to return, so
+ *  those lines are the whole fan, and the one line the exception itself carries is the LAST
+ *  spelling refused — neither the first nor a representative one. */
+function noFan(c: Case, e: unknown, phase: 'enumerating' | 'scoring'): number {
+  const dropped = e instanceof NoScorableCandidateError ? e.dropped : [];
+  const withheld = e instanceof NoScorableCandidateError ? e.withheld : [];
+  if (dropped.length > 0 || withheld.length > 0) {
+    console.log([...dropped.map(dropLine), ...withheld.map(withheldLine)].join('\n'));
+  }
+  const first = ((e as Error).message ?? String(e)).split('\n')[0];
+  note(`asmlift: [fan] no fan for ${c.id}: ${phase} threw — ${first}`);
+  note(
+    phase === 'enumerating'
+      ? `asmlift: [fan] the gap named above is the one this row DECLINES on: enumeration has no ` +
+          `annotate mode, so it throws where the published row gets an ASMLIFT_ERROR marker. Close ` +
+          `the gap and the fan exists; until then there is nothing to score.`
+      : `asmlift: [fan] every candidate was refused, so there is no ranking — the ${dropped.length} ` +
+          `[dropped] line(s) above ARE this row's fan. This is what the published row's ` +
+          `"noncompile" outcome means.`,
+  );
+  return 2;
+}
+
+/** `--show <label>` on a label that IS in the fan but carries no scored source. A dropped
+ *  candidate never compiled and a withheld one was refused publication; neither is in
+ *  `[score]`, so "see the [score] lines above" sends the reader to look for a line that will
+ *  never be there. `--enumerate` carries every candidate's source, including these, and is the
+ *  answer — the source of the spelling that FAILED to compile is usually the one worth reading. */
+export function unshowable(label: string, ranked: RankedResult): string {
+  const where = ranked.dropped.some((d) => d.label === label)
+    ? 'was dropped (it did not compile), so it has no scored source'
+    : ranked.withheld.some((w) => w.label === label)
+      ? 'was withheld (it scored but is unpublishable), so it is not in the [score] table'
+      : undefined;
+  return where === undefined
+    ? `no candidate labelled ${JSON.stringify(label)} — see the [score] lines above`
+    : `${JSON.stringify(label)} ${where}. Its source is still readable: re-run with --enumerate --show ${label}`;
+}
+
 export function fan(rowId: string, o: FanOptions = {}): number {
+  const refusal = optionRefusal(o);
+  if (refusal !== undefined) {
+    note(refusal);
+    return 2;
+  }
+  // The tree BEFORE the run, for the stamp on the `[ranked]` line. A pair of samples, as
+  // provenance.ts requires: one reading is blind to any edit not standing at that instant, and a
+  // parallel round editing `packages/` is the normal state of this machine.
+  const treeBefore = sampleSourceTree();
   const matches = selectCases([...syntheticCases(), ...realCases()], rowId);
   if (matches.length === 0) {
     note(`no such row: ${rowId} (ids are project:sym:toolchain)`);
@@ -137,9 +298,11 @@ export function fan(rowId: string, o: FanOptions = {}): number {
   }
 
   // The runner's own build, header scrub included: the disassembly asmlift sees must be the bytes
-  // the row was measured from, and the scrub is part of them (runner.ts).
+  // the row was measured from, and the scrub is part of them — through `scrubObjectHeader`, the
+  // one spelling the runner and the evaluator use, so this command cannot drift from the run it
+  // claims to reproduce.
   const { obj, asm: raw } = c.build();
-  const asm = raw.replace(/^\/\S+\.o:/m, 'target.o:');
+  const asm = scrubObjectHeader(raw);
   const opts = rankOptionsFor(c.toolchain, obj, c.proto, c.compile, c.symbols);
   note(`${c.id} — tier ${c.tier}, toolchain ${c.toolchain.id}${c.symbols ? ', symbol map' : ''}`);
 
@@ -153,8 +316,8 @@ export function fan(rowId: string, o: FanOptions = {}): number {
     }
     if (dec.diagnostics.length > 0) {
       note(
-        `asmlift: [declined] this row publishes outcome "declined" — the fan below is what WOULD ` +
-          `be scored if the gap(s) above closed`,
+        `asmlift: [declined] this row publishes outcome "declined" — a fan below, IF enumeration ` +
+          `reaches one, is what WOULD be scored once the gap(s) above closed`,
       );
     }
   } catch (e) {
@@ -169,9 +332,16 @@ export function fan(rowId: string, o: FanOptions = {}): number {
     ...opts,
     onLeverError: (label: string, error: string) => leverErrors.set(label, error.split('\n')[0]),
   };
+  // ONCE PER LABEL. Both the pre-count enumeration and the scoring pass enumerate, and each
+  // re-runs every lever, so a lever that throws throws twice — reported twice, it reads as two
+  // broken levers.
+  const printedLevers = new Set<string>();
   const printLevers = (): void => {
     for (const [label, error] of leverErrors) {
-      note(`asmlift: [lever] ${label} threw (no candidate from it): ${error}`);
+      if (!printedLevers.has(label)) {
+        printedLevers.add(label);
+        note(`asmlift: [lever] ${label} threw (no candidate from it): ${error}`);
+      }
     }
   };
 
@@ -179,7 +349,18 @@ export function fan(rowId: string, o: FanOptions = {}): number {
   // has already answered the question the count would ask — enumeration on the rows this guard
   // exists for is itself the expensive part.
   if (o.enumerateOnly || !o.force) {
-    const cands = enumerateRanked(c.sym, asm, c.toolchain.targetDesc, withLevers);
+    // GUARDED, because `enumerateCandidates` has no annotate mode: the gap the phase-1 pass above
+    // turns into an `ASMLIFT_ERROR` marker is a THROW here, and 233 of the corpus's 1,035 rows
+    // publish `declined` on exactly such a gap. Unguarded, this command printed "the fan below is
+    // what WOULD be scored" and then a Node stack trace with no fan below it — on the very rows
+    // `attribute-function.md` sends a round here to read.
+    let cands: Candidate[];
+    try {
+      cands = enumerateRanked(c.sym, asm, c.toolchain.targetDesc, withLevers);
+    } catch (e) {
+      printLevers();
+      return noFan(c, e, 'enumerating');
+    }
     printLevers();
     if (o.enumerateOnly) {
       console.log(cands.map((cand) => `asmlift: [candidate] ${cand.label}`).join('\n'));
@@ -197,31 +378,41 @@ export function fan(rowId: string, o: FanOptions = {}): number {
     if (cands.length > FAN_SCORE_LIMIT) {
       note(
         `${c.id} enumerates ${cands.length} candidates — over the ${FAN_SCORE_LIMIT} this command will ` +
-          `compile — a compile each, and at this machine's measured rate that is well over an hour. ` +
-          `Re-run with ` +
-          `--enumerate for the labels and sources without compiling, or --force to score them all.`,
+          `compile without being told to. That is a compile each: ${estimatedScoreTime(cands.length)} at ` +
+          `this machine's measured cold rate (${SCORE_SECONDS_PER_CANDIDATE * 1000} ms/candidate, and ` +
+          `several times faster warm). Re-run with --enumerate for the labels and sources without ` +
+          `compiling, or --force to score them all.`,
       );
       return 2;
     }
   }
 
-  // …and the scoring pass, through the harness's own driver.
-  const ranked = asmliftFan(c.toolchain, c.sym, asm, obj, {
-    ...withLevers,
-    onProgress: (done, total, bestSoFar) => {
-      const every = Math.max(1, Math.floor(total / 10));
-      if (done === 1 || done === total || done % every === 0) {
-        const best = bestSoFar === undefined ? '' : `, best so far ${scoreOf(bestSoFar)}`;
-        note(`asmlift: [progress] ${done}/${total} candidates scored${best}`);
-      }
-    },
-  });
+  // …and the scoring pass, through the harness's own driver. GUARDED for the same reason as the
+  // enumeration and a different failure: `rankBy` throws when EVERY candidate was refused, which
+  // is what the corpus's four `noncompile` rows are — and the drop list it throws with is that
+  // row's entire fan, i.e. precisely what a reader came here for.
+  let ranked: RankedResult;
+  try {
+    ranked = asmliftFan(c.toolchain, c.sym, asm, obj, {
+      ...withLevers,
+      onProgress: (done, total, bestSoFar) => {
+        const every = Math.max(1, Math.floor(total / 10));
+        if (done === 1 || done === total || done % every === 0) {
+          const best = bestSoFar === undefined ? '' : `, best so far ${scoreOf(bestSoFar)}`;
+          note(`asmlift: [progress] ${done}/${total} candidates scored${best}`);
+        }
+      },
+    });
+  } catch (e) {
+    printLevers();
+    return noFan(c, e, 'scoring');
+  }
   printLevers();
-  console.log(renderFan(ranked));
+  console.log(renderFan(ranked, { synthesized: synthesizedRefs(c.tier, ranked.best), stamp: stampFrom(treeBefore) }));
   if (o.show) {
     const picked = pickCandidate(ranked.candidates, o.show);
     if (!picked) {
-      note(`no candidate labelled ${JSON.stringify(o.show)} — see the [score] lines above`);
+      note(unshowable(o.show, ranked));
       return 2;
     }
     console.log(showSource(picked.label, picked.source));

--- a/apps/benchmark/src/run/fan.ts
+++ b/apps/benchmark/src/run/fan.ts
@@ -24,14 +24,15 @@
 // `[ranked]`), so docs/ranked-repro.md's comparison recipe — `grep -F '[score]'` over two runs —
 // works across the two commands without a second recipe to keep in step.
 import { declaredBlock } from '@asmlift/cli/declare';
+import { isDecline } from '@asmlift/cli/decline';
 import { bakedBuild, sampleSourceTree, sourceStamp } from '@asmlift/cli/provenance';
-import type { RankedCandidate, RankedResult } from '@asmlift/cli/rank';
+import type { RankOptions, RankedCandidate, RankedResult } from '@asmlift/cli/rank';
 import { enumerateRanked } from '@asmlift/cli/rank';
 import { rankedSummaryLine, scoreOf } from '@asmlift/cli/score-format';
 import type { SymbolRef } from '@asmlift/core/l3/symbol-refs';
 import { decompile } from '@asmlift/core/pipeline';
 import type { Candidate, DroppedCandidate, WithheldCandidate } from '@asmlift/core/rank';
-import { NoScorableCandidateError } from '@asmlift/core/rank';
+import { NoScorableCandidateError, NoSpellableCandidateError } from '@asmlift/core/rank';
 
 import { scrubObjectHeader } from '../asm-scrub';
 import { realCases } from '../cases/real';
@@ -47,34 +48,56 @@ import { asmliftFan, rankOptionsFor } from '../eval/asmlift';
  *  fine price for a diagnostic, and the limit has to sit well above it or the command refuses the
  *  very rows it exists for. At the cold rate this limit is about two minutes, and the refusal says
  *  so with the row's own count rather than a fixed scare sentence (`SCORE_SECONDS_PER_CANDIDATE`).
- *  `LoadBGTilemapData` enumerates 225,792 (docs/ranked-repro.md); the same rate puts its fan at
- *  nearly FOUR HOURS, which is a run a round starts on purpose or not at all.
+ *  `LoadBGTilemapData` enumerates 225,792 (docs/ranked-repro.md) and is a REAL row, so at that
+ *  tier's measured rate its fan is over FIVE HOURS — a run a round starts on purpose or not at all.
  *
  *  A one-row diagnostic that can silently become an overnight job is a trap, and the cheap answer
  *  — `--enumerate`, which compiles nothing and still prints every label and, with `--show`, any
  *  candidate's source — is one flag away. It is CHEAP RELATIVE TO COMPILING and not cheap
- *  absolutely: enumeration ran at 128 candidates/s on `kleod:CountCollectedGems:agbcc` (5,952 in
- *  46 s), so LBG's fan is ~30 minutes to merely LIST — and this guard is checked after the
+ *  absolutely: `kleod:CountCollectedGems:agbcc`'s 5,952 labels take 50 s wall, target build
+ *  included (~120 candidates/s), so LBG's fan is ~30 minutes to merely LIST — and this guard is checked after the
  *  pre-count enumeration, so the refusal itself pays that. Both prices are stated where they are
  *  paid rather than promised away. */
 export const FAN_SCORE_LIMIT = 2000;
 
-/** Seconds per candidate on the SCORING path — a compile plus an objdiff alignment — from the
- *  slowest cold measurement on this machine: `synthetic:sizebound:agbcc`, 800 candidates in 47.9 s
- *  with `ASMLIFT_CANDCACHE=0`. (`kleod:SetupBG3WindowOverlay`'s 1,024 ran at ~29 ms each, so this
- *  is the pessimistic end; a warm candidate cache is ~5x faster again.)
+/** Seconds per candidate on the SCORING path — a compile plus an objdiff alignment — PER TIER,
+ *  because the two tiers do not compile the same thing.
+ *
+ *  Both numbers are cold measurements on this machine with `ASMLIFT_CANDCACHE=0`:
+ *
+ *  | tier | row | candidates | SCORING wall | per candidate |
+ *  |---|---|---|---|---|
+ *  | synthetic | `synthetic:sizebound:agbcc` | 800 | 47.9 s | 60 ms |
+ *  | real | `kleod:CountCollectedGems:agbcc` | 5,952 | 518 s | 87 ms |
+ *  | real | the same row, a second run on a quieter machine | 5,952 | 483 s | 81 ms |
+ *
+ *  (Both real-tier walls are the total minus a separately measured 50 s of target build plus
+ *  enumeration, and both runs reproduced the published `171/387`. The constant is the middle of
+ *  the two; the spread is machine load, and the tier gap is 40% either way.)
+ *
+ *  One rate for both was wrong by ~35% on the real tier, and wrong in the direction that matters:
+ *  the refusal quotes this price to a reader deciding whether to start the run, and it quoted it
+ *  on `CountCollectedGems` — a REAL row, and the row six rounds were about. The first spelling
+ *  also claimed 60 ms was "the pessimistic end", which the real-tier measurement falsifies.
+ *
+ *  The mechanism is in `compile/real.ts`: a real candidate escalates through up to three preludes
+ *  (`makeRealCompile`), where a synthetic one is a single small prelude — so the real tier pays
+ *  more compiler invocations per candidate, and the gap is structural rather than noise.
  *
  *  It exists to make the refusal QUOTE A PRICE rather than assert one: the sentence this replaces
  *  said a fan over the limit is "well over an hour" while the constant's own doc-comment two
  *  screens up said two and a half minutes, and the second one was right. A reader who is steered
  *  off `--force` by a number that is wrong by 20x loses the answer the command exists to give. */
-export const SCORE_SECONDS_PER_CANDIDATE = 0.06;
+export const SCORE_SECONDS_PER_CANDIDATE: Record<Case['tier'], number> = {
+  synthetic: 0.06,
+  real: 0.085,
+};
 
-/** The price of scoring `n` candidates, rounded to a unit a reader can act on. Never a bare
- *  second-count above a minute: the decision this informs is "do I start this now", and 357 s is a
- *  number one has to divide before it means anything. */
-export function estimatedScoreTime(n: number): string {
-  const seconds = n * SCORE_SECONDS_PER_CANDIDATE;
+/** The price of scoring `n` candidates of this row's tier, rounded to a unit a reader can act on.
+ *  Never a bare second-count above a minute: the decision this informs is "do I start this now",
+ *  and 357 s is a number one has to divide before it means anything. */
+export function estimatedScoreTime(n: number, tier: Case['tier']): string {
+  const seconds = n * SCORE_SECONDS_PER_CANDIDATE[tier];
   if (seconds < 90) {
     return `about ${Math.max(1, Math.round(seconds))} s`;
   }
@@ -86,7 +109,7 @@ export interface FanOptions {
   /** print this candidate's SOURCE (its label, or `best`) after the table */
   show?: string;
   /** List the fan without compiling anything. Cheap against the scoring pass and not free:
-   *  enumeration ran at 128 candidates/s here (`kleod:CountCollectedGems:agbcc`, 5,952 in 46 s),
+   *  5,952 labels took 50 s wall here (`kleod:CountCollectedGems:agbcc`, target build included),
    *  so the biggest fans take minutes to merely list. */
   enumerateOnly?: boolean;
   /** score a fan larger than FAN_SCORE_LIMIT anyway */
@@ -224,35 +247,105 @@ const stampFrom = (treeBefore: ReturnType<typeof sampleSourceTree>): string =>
   sourceStamp(treeBefore, sampleSourceTree(), bakedBuild());
 
 /** THERE IS NO FAN, as an ANSWER rather than a crash — the command's own exit 2 and a sentence,
- *  never a Node stack trace.
+ *  never a Node stack trace, and the sentence is chosen BY THE ERROR.
  *
- *  Both of the ranked path's calls can throw, and each throw is a fact about the ROW rather than a
- *  harness defect: enumeration throws on the unmodelled construct that made the row `declined`
- *  (233 rows), and scoring throws when every spelling failed to compile (the 4 `noncompile` rows).
- *  Shipped unguarded, both printed a stack trace and exited 1 — indistinguishable, to a script or
- *  a fresh agent, from the harness being broken, which is exactly the reading that sends a round
- *  back to the hand-written script this command replaced.
+ *  Three different facts arrive at this function's two call sites, and they are not the same fact:
  *
- *  On the scoring failure the DROP LIST is printed in full: `rankBy` has no result to return, so
- *  those lines are the whole fan, and the one line the exception itself carries is the LAST
- *  spelling refused — neither the first nor a representative one. */
-function noFan(c: Case, e: unknown, phase: 'enumerating' | 'scoring'): number {
-  const dropped = e instanceof NoScorableCandidateError ? e.dropped : [];
-  const withheld = e instanceof NoScorableCandidateError ? e.withheld : [];
-  if (dropped.length > 0 || withheld.length > 0) {
-    console.log([...dropped.map(dropLine), ...withheld.map(withheldLine)].join('\n'));
+ *  - `NoScorableCandidateError` — every spelling compiled-and-failed. That is `noncompile`, and
+ *    the drop list riding on the error IS the row's whole fan, so it is printed in full: the one
+ *    line the exception itself carries is the LAST spelling refused, neither the first nor a
+ *    representative one.
+ *  - `NoSpellableCandidateError` — the backend refused every tree before any compile. Nothing was
+ *    dropped because nothing was ever built.
+ *  - a DECLINE (`isDecline`) — the unmodelled construct that makes the published row `declined`
+ *    (233 of 1,035 rows). Enumeration has no annotate mode, so it throws where the published row
+ *    gets an `ASMLIFT_ERROR` marker.
+ *
+ *  The first shipped version picked its sentence from a `phase` string the CALLER passed, which is
+ *  the same "read the label, not the instrument" mistake the `dmanest`/`max3` rounds are
+ *  memorialised for — and it was wrong in practice within one commit: `--force` skips the guarded
+ *  pre-count enumeration, so a DECLINED row's lift error lands in the scoring catch and got
+ *  "every candidate was refused … this is what the published row's noncompile outcome means" under
+ *  zero `[dropped]` lines, on a row that publishes `declined`. Both briefs tell a round to pass
+ *  `--force`.
+ *
+ *  Anything the three tests do not classify is a HARNESS DEFECT and says so, with the stack: a
+ *  guard that swallows a `TypeError` into a confident sentence about the row is strictly worse
+ *  than the crash it replaced. */
+export interface NoFanReport {
+  /** the two refusal lists — on stdout, because on this path they ARE the fan */
+  fan: string[];
+  /** the diagnosis — on stderr, so `bench fan <row> > fan.txt` keeps the fan and drops the prose */
+  notes: string[];
+  /** unclassified: the caller prints the raw error too, stack and all */
+  harnessDefect: boolean;
+}
+
+export function noFanReport(rowId: string, e: unknown, show?: string): NoFanReport {
+  const nsc = e instanceof NoScorableCandidateError ? e : undefined;
+  const dropped: DroppedCandidate[] = nsc?.dropped ?? [];
+  const withheld: WithheldCandidate[] = nsc?.withheld ?? [];
+  const message = e instanceof Error ? e.message : String(e);
+  const first = message.split('\n')[0];
+
+  const notes: string[] = [];
+  const harnessDefect = nsc === undefined && !(e instanceof NoSpellableCandidateError) && !isDecline(e);
+  notes.push(`asmlift: [fan] no fan for ${rowId}: ${first}`);
+  if (nsc !== undefined) {
+    // Count BOTH lists. `rankBy` has a reachable all-withheld branch ("N candidate(s) withheld,
+    // none scored"), where a dropped-only count reads "the 0 [dropped] line(s) above ARE this
+    // row's fan" printed under N withheld lines.
+    notes.push(
+      `asmlift: [fan] every candidate was refused, so there is no ranking — the ` +
+        `${dropped.length} [dropped] and ${withheld.length} [withheld] line(s) above ARE this ` +
+        `row's fan. This is what the published row's "noncompile" outcome means.`,
+    );
+  } else if (e instanceof NoSpellableCandidateError) {
+    notes.push(
+      `asmlift: [fan] the backend refused every spelling this row enumerates, before anything was ` +
+        `compiled — so the fan is empty by construction and nothing was dropped. The line above is ` +
+        `the LAST refusal, not the only one.`,
+    );
+  } else if (isDecline(e)) {
+    notes.push(
+      `asmlift: [fan] the gap named above is the one this row DECLINES on: enumeration has no ` +
+        `annotate mode, so it throws where the published row gets an ASMLIFT_ERROR marker. Close ` +
+        `the gap and the fan exists; until then there is nothing to score.`,
+    );
+  } else {
+    notes.push(
+      `asmlift: [fan] that is not a decline and not an empty fan — it is a HARNESS defect, not a ` +
+        `fact about this row. The stack follows; do not read it as the row's outcome.`,
+    );
   }
-  const first = ((e as Error).message ?? String(e)).split('\n')[0];
-  note(`asmlift: [fan] no fan for ${c.id}: ${phase} threw — ${first}`);
-  note(
-    phase === 'enumerating'
-      ? `asmlift: [fan] the gap named above is the one this row DECLINES on: enumeration has no ` +
-          `annotate mode, so it throws where the published row gets an ASMLIFT_ERROR marker. Close ` +
-          `the gap and the fan exists; until then there is nothing to score.`
-      : `asmlift: [fan] every candidate was refused, so there is no ranking — the ${dropped.length} ` +
-          `[dropped] line(s) above ARE this row's fan. This is what the published row's ` +
-          `"noncompile" outcome means.`,
-  );
+
+  // `--show` on this path was silently dropped by the first version, on exactly the row class
+  // where the flag's advice earns its keep: a noncompile row is the one row where EVERY candidate
+  // is unshowable.
+  if (show !== undefined) {
+    notes.push(
+      dropped.length + withheld.length === 0
+        ? `--show ${JSON.stringify(show)} cannot be answered: this row produced no candidates at ` +
+            `all, so there is no source to print.`
+        : unshowable(show, { dropped, withheld }, 'the [dropped]/[withheld] lines above — this row scored nothing'),
+    );
+  }
+  return { fan: [...dropped.map(dropLine), ...withheld.map(withheldLine)], notes, harnessDefect };
+}
+
+/** `noFanReport`, printed. Exit 2 — the command's own "I have no answer", distinct from the
+ *  ranked path's 0. */
+function noFan(c: Case, e: unknown, show?: string): number {
+  const r = noFanReport(c.id, e, show);
+  if (r.fan.length > 0) {
+    console.log(r.fan.join('\n'));
+  }
+  for (const n of r.notes) {
+    note(n);
+  }
+  if (r.harnessDefect) {
+    console.error(e);
+  }
   return 2;
 }
 
@@ -260,24 +353,27 @@ function noFan(c: Case, e: unknown, phase: 'enumerating' | 'scoring'): number {
  *  candidate never compiled and a withheld one was refused publication; neither is in
  *  `[score]`, so "see the [score] lines above" sends the reader to look for a line that will
  *  never be there. `--enumerate` carries every candidate's source, including these, and is the
- *  answer — the source of the spelling that FAILED to compile is usually the one worth reading. */
-export function unshowable(label: string, ranked: RankedResult): string {
-  const where = ranked.dropped.some((d) => d.label === label)
+ *  answer — the source of the spelling that FAILED to compile is usually the one worth reading.
+ *
+ *  `listedIn` is a parameter because this serves TWO tables: the scored one, and the drop list a
+ *  `noncompile` row reaches through `noFanReport`, where there are no `[score]` lines to send a
+ *  reader to. That row class is precisely where every candidate is unshowable. */
+export function unshowable(
+  label: string,
+  fan: { dropped: DroppedCandidate[]; withheld: WithheldCandidate[] },
+  listedIn = 'the [score] lines above',
+): string {
+  const where = fan.dropped.some((d) => d.label === label)
     ? 'was dropped (it did not compile), so it has no scored source'
-    : ranked.withheld.some((w) => w.label === label)
+    : fan.withheld.some((w) => w.label === label)
       ? 'was withheld (it scored but is unpublishable), so it is not in the [score] table'
       : undefined;
   return where === undefined
-    ? `no candidate labelled ${JSON.stringify(label)} — see the [score] lines above`
+    ? `no candidate labelled ${JSON.stringify(label)} — see ${listedIn}`
     : `${JSON.stringify(label)} ${where}. Its source is still readable: re-run with --enumerate --show ${label}`;
 }
 
 export function fan(rowId: string, o: FanOptions = {}): number {
-  const refusal = optionRefusal(o);
-  if (refusal !== undefined) {
-    note(refusal);
-    return 2;
-  }
   // The tree BEFORE the run, for the stamp on the `[ranked]` line. A pair of samples, as
   // provenance.ts requires: one reading is blind to any edit not standing at that instant, and a
   // parallel round editing `packages/` is the normal state of this machine.
@@ -296,12 +392,34 @@ export function fan(rowId: string, o: FanOptions = {}): number {
     note(`${c.id}: toolchain ${c.toolchain.id} unavailable — nothing to enumerate`);
     return 2;
   }
+  // AFTER the row is resolved, and before it is built. A nonsense flag pair is worth refusing
+  // before a 46 s enumeration is paid for it — but not before the command can say the row does not
+  // exist, which was the first spelling's order: `bench fan nosuchrowatall --enumerate --show best`
+  // lectured about the flags. Case selection is in-memory, so this ordering costs nothing.
+  const refusal = optionRefusal(o);
+  if (refusal !== undefined) {
+    note(refusal);
+    return 2;
+  }
 
   // The runner's own build, header scrub included: the disassembly asmlift sees must be the bytes
   // the row was measured from, and the scrub is part of them — through `scrubObjectHeader`, the
   // one spelling the runner and the evaluator use, so this command cannot drift from the run it
   // claims to reproduce.
-  const { obj, asm: raw } = c.build();
+  //
+  // GUARDED, and it is the one throw on this path that is NOT a fact about the row: a target that
+  // will not build is the harness broken (the runner names it the same way — "a HARNESS defect,
+  // not a decompiler outcome"). Unguarded it was a raw Node stack, which is the reading the rest
+  // of this file spends a commit eliminating.
+  let built: ReturnType<Case['build']>;
+  try {
+    built = c.build();
+  } catch (e) {
+    note(`${c.id}: building the target threw — a HARNESS defect, not a decompiler outcome:`);
+    console.error(e);
+    return 2;
+  }
+  const { obj, asm: raw } = built;
   const asm = scrubObjectHeader(raw);
   const opts = rankOptionsFor(c.toolchain, obj, c.proto, c.compile, c.symbols);
   note(`${c.id} — tier ${c.tier}, toolchain ${c.toolchain.id}${c.symbols ? ', symbol map' : ''}`);
@@ -328,7 +446,12 @@ export function fan(rowId: string, o: FanOptions = {}): number {
   // channel — cli/rank.ts says so at the field: "a whole pre-fan half of a row's fan can still
   // vanish from a `pnpm bench run` with nothing printed". Here it is printed.
   const leverErrors = new Map<string, string>();
-  const withLevers = {
+  // ANNOTATED, for the same reason `rankOptionsFor`'s return type is: a mistyped option key is a
+  // SILENTLY DROPPED option, and a dropped `symbols` is the 112,896-vs-135,936 discrepancy class
+  // docs/ranked-repro.md is about. The annotation on `rankOptionsFor` does not reach here — this
+  // object is built by spread, and excess-property checking only fires on a literal that is
+  // itself annotated (verified: `symbolz: 1` in this literal typechecks clean without it).
+  const withLevers: RankOptions = {
     ...opts,
     onLeverError: (label: string, error: string) => leverErrors.set(label, error.split('\n')[0]),
   };
@@ -359,7 +482,7 @@ export function fan(rowId: string, o: FanOptions = {}): number {
       cands = enumerateRanked(c.sym, asm, c.toolchain.targetDesc, withLevers);
     } catch (e) {
       printLevers();
-      return noFan(c, e, 'enumerating');
+      return noFan(c, e, o.show);
     }
     printLevers();
     if (o.enumerateOnly) {
@@ -378,9 +501,10 @@ export function fan(rowId: string, o: FanOptions = {}): number {
     if (cands.length > FAN_SCORE_LIMIT) {
       note(
         `${c.id} enumerates ${cands.length} candidates — over the ${FAN_SCORE_LIMIT} this command will ` +
-          `compile without being told to. That is a compile each: ${estimatedScoreTime(cands.length)} at ` +
-          `this machine's measured cold rate (${SCORE_SECONDS_PER_CANDIDATE * 1000} ms/candidate, and ` +
-          `several times faster warm). Re-run with --enumerate for the labels and sources without ` +
+          `compile without being told to. That is a compile each: ${estimatedScoreTime(cands.length, c.tier)} ` +
+          `at this machine's measured cold rate for the ${c.tier} tier ` +
+          `(${SCORE_SECONDS_PER_CANDIDATE[c.tier] * 1000} ms/candidate, and several times faster warm). ` +
+          `Re-run with --enumerate for the labels and sources without ` +
           `compiling, or --force to score them all.`,
       );
       return 2;
@@ -405,7 +529,7 @@ export function fan(rowId: string, o: FanOptions = {}): number {
     });
   } catch (e) {
     printLevers();
-    return noFan(c, e, 'scoring');
+    return noFan(c, e, o.show);
   }
   printLevers();
   console.log(renderFan(ranked, { synthesized: synthesizedRefs(c.tier, ranked.best), stamp: stampFrom(treeBefore) }));

--- a/apps/benchmark/src/run/runner.ts
+++ b/apps/benchmark/src/run/runner.ts
@@ -4,6 +4,7 @@
 import type { BenchMeta, BenchOutput, DecompilerResult, FunctionResult } from '@asmlift/bench-schema';
 import { writeFileSync } from 'node:fs';
 
+import { scrubObjectHeader } from '../asm-scrub';
 import type { Case } from '../cases/types';
 import { type EvalSpec, evaluate } from '../eval/evaluate';
 import { asmliftProvenance } from '../provenance';
@@ -119,7 +120,7 @@ export function runCases(
       // machine-specific); scrub it so targetAsm — and everything embedding it (scripts, m2c
       // cache keys) — is byte-stable across machines and cache generations. No parser reads
       // the header line.
-      asm = asm.replace(/^\/\S+\.o:/m, 'target.o:');
+      asm = scrubObjectHeader(asm);
     } catch (e) {
       // couldn't produce the scoring target — a HARNESS defect, not a decompiler outcome.
       // Finish the shard (keep the other rows), then fail loudly below: a case with no row

--- a/apps/benchmark/test/fan.test.ts
+++ b/apps/benchmark/test/fan.test.ts
@@ -145,10 +145,10 @@ it('will score a fan the size of the largest row measured through it', () => {
   expect(FAN_SCORE_LIMIT).toBeGreaterThan(800);
 });
 
-// F1: the `[ranked]` line is the one line the briefs tell a round to PASTE, and it now has two
-// producers — the CLI's ranked run and this command. The fields at risk are the ones that are not
-// counts of the fan: `synthesized` (the score rests on declarations asmlift invented) and the
-// source stamp (which tree produced it). The first spelling of this line here dropped both.
+// The `[ranked]` line is the one line the briefs tell a round to PASTE, and it has two producers —
+// the CLI's ranked run and this command. The fields at risk are the ones that are not counts of the
+// fan, because a hand-spelling drops them: `synthesized` (the score rests on declarations asmlift
+// invented) and the source stamp (which tree produced it).
 describe('the [ranked] line', () => {
   const ranked = (over: Partial<RankedResult> = {}): RankedResult =>
     ({
@@ -210,9 +210,9 @@ describe('synthesizedRefs', () => {
   });
 });
 
-// F2 / the breaker's SHOULD-FIX: `--enumerate --show best` printed `unsigned` on
-// `synthetic:sizebound:agbcc`, a near-worst spelling in a fan whose winner scores 8/81 — under the
-// name of the winner, to a round both briefs had told that `--show best` is the winner.
+// Under `--enumerate` nothing is scored, so `best` would name whatever enumeration emitted first —
+// a near-worst spelling under the winner's name, to a round both briefs have told that `--show
+// best` is the winner.
 describe('optionRefusal', () => {
   it('refuses --show best under --enumerate, where nothing has been scored', () => {
     expect(optionRefusal({ enumerateOnly: true, show: 'best' })).toContain('no winner to name');
@@ -227,10 +227,9 @@ describe('optionRefusal', () => {
   });
 });
 
-// The refusal's job is to price the run it is refusing. The sentence this replaces said "well over
-// an hour" for any fan over 2,000 while the same file's doc-comment said two and a half minutes;
-// measured, 800 candidates score in 47.9 s cold, so the doc-comment was right and the refusal was
-// wrong by ~20x — steering a reader off `--force` on a row that answers in minutes.
+// The refusal's job is to price the run it is refusing, from this row's own count and tier. A fan
+// at the limit answers in minutes (800 candidates score in 47.9 s cold), and a scare sentence that
+// calls that "well over an hour" steers a reader off `--force` on a row that would have answered.
 describe('estimatedScoreTime', () => {
   it('prices the limit itself in minutes, not hours', () => {
     expect(estimatedScoreTime(FAN_SCORE_LIMIT, 'synthetic')).toBe('about 2 min');
@@ -255,13 +254,13 @@ describe('estimatedScoreTime', () => {
   });
 
   // LoadBGTilemapData: the row this guard exists for, and the run nobody starts by accident. It is
-  // a REAL row, so it is priced at the real rate — the synthetic one called it 3.8 h.
+  // a REAL row, so it is priced at the real rate; the synthetic rate would call it 3.8 h.
   it('prices LoadBGTilemapData`s fan in hours', () => {
     expect(estimatedScoreTime(225792, 'real')).toBe('about 5.3 h');
   });
 });
 
-// F4: a dropped candidate's source is what a reader most wants (it is the spelling that failed to
+// A dropped candidate's source is what a reader most wants (it is the spelling that failed to
 // compile) and it is the one `--show` cannot reach — `DroppedCandidate` carries no source at all.
 // Sending them to the `[score]` lines for it is sending them to look for a line that is not there.
 describe('unshowable', () => {
@@ -286,19 +285,18 @@ describe('unshowable', () => {
   });
 
   // …and on a row where nothing scored there ARE no `[score]` lines, so the caller names the list
-  // that does exist. Hard-coding one table's name is what made the first spelling send a reader
-  // looking for a line that could not be there.
+  // that does exist. Hard-coding one table's name sends a reader to look for a line that cannot
+  // be there.
   it('names the list it was given, not always the [score] table', () => {
     expect(unshowable('nope', ranked, 'the [dropped] lines above')).toContain('the [dropped] lines above');
   });
 });
 
-// The blocker fix's SECOND spelling, and the reason it needed one: the first chose its sentence
-// from a `phase` string the CALL SITE passed, so `--force` — which skips the guarded pre-count
-// enumeration — sent a DECLINED row's lift error into the scoring catch and printed "every
-// candidate was refused … this is what the published row's noncompile outcome means", under zero
-// `[dropped]` lines, on a row that publishes `declined`. Both briefs tell a round to pass
-// `--force`. The sentence is now chosen by the ERROR, and that is what these pin.
+// The sentence is chosen by the ERROR, never by which call site caught it, and that is what these
+// pin: `--force` skips the guarded pre-count enumeration, so a DECLINED row's lift error arrives at
+// the scoring catch — where a call-site guess prints "every candidate was refused … this is what
+// the published row's noncompile outcome means" under zero `[dropped]` lines. Both briefs tell a
+// round to pass `--force`.
 describe('noFanReport', () => {
   const dropped = [{ label: 'unsigned', error: 'agbcc failed: c.c:12' }];
   const withheld = [{ label: 'unreduce', score: 2, why: 'needs a byte-exact proof' }];

--- a/apps/benchmark/test/fan.test.ts
+++ b/apps/benchmark/test/fan.test.ts
@@ -1,0 +1,124 @@
+import type { RankedCandidate, RankedResult } from '@asmlift/cli/rank';
+import { describe, expect, it } from 'vitest';
+
+import type { Case } from '../src/cases/types';
+import { FAN_SCORE_LIMIT, pickCandidate, renderFan, scoreLine, selectCases } from '../src/run/fan';
+
+const row = (id: string): Case => ({ id }) as Case;
+
+const cand = (label: string, score: number, rows: number, match = false): RankedCandidate =>
+  ({
+    label,
+    source: `/* ${label} */`,
+    group: 0,
+    score: { symbol: 'f', score, rows, match, matching: rows - score, breakdown: {} },
+  }) as unknown as RankedCandidate;
+
+describe('selectCases', () => {
+  // `--only` elsewhere in the harness is a substring match, so a round types a symbol name here.
+  it('takes a substring of the row id', () => {
+    const cases = [row('kleod:Foo:agbcc'), row('pokeemerald:Bar:agbcc')];
+    expect(selectCases(cases, 'Foo').map((c) => c.id)).toEqual(['kleod:Foo:agbcc']);
+  });
+
+  // The case a bare substring match gets wrong: one row's whole id is a substring of another's, so
+  // naming a row EXACTLY has to resolve to that row rather than to an ambiguity error the caller
+  // cannot escape — there is no longer id to type.
+  it('prefers an exact id over the longer ids that contain it', () => {
+    const cases = [row('kleod:Sub:agbcc'), row('kleod:Sub_2:agbcc')];
+    expect(selectCases(cases, 'kleod:Sub:agbcc').map((c) => c.id)).toEqual(['kleod:Sub:agbcc']);
+  });
+
+  // …and one symbol across four toolchains is four DIFFERENT measurements. Every match comes back
+  // so the caller can print them; silently picking one answers a question nobody asked.
+  it('returns every match, so an ambiguous name can be reported rather than guessed', () => {
+    const cases = [row('synthetic:dma_wait:agbcc'), row('synthetic:dma_wait:mwcc_242_81')];
+    expect(selectCases(cases, 'dma_wait')).toHaveLength(2);
+  });
+
+  it('returns nothing for a name no row carries', () => {
+    expect(selectCases([row('kleod:Foo:agbcc')], 'Nope')).toEqual([]);
+  });
+});
+
+describe('scoreLine', () => {
+  // PR #174's rule, in the new surface: a score prints against the denominator it was measured
+  // against, because two candidates of one row do not share a scale. Measured on
+  // `pokeemerald:MathUtil_Mul16:agbcc`, whose fan contains both `3/12` and `3/13`.
+  it('carries the denominator and the match flag, through the CLI renderer', () => {
+    expect(scoreLine(cand('unsigned', 3, 12))).toBe('asmlift: [score] unsigned: 3/12');
+    expect(scoreLine(cand('unsigned/flip-join', 3, 13))).toBe('asmlift: [score] unsigned/flip-join: 3/13');
+    expect(scoreLine(cand('unsigned/regcopy-ret', 0, 12, true))).toBe(
+      'asmlift: [score] unsigned/regcopy-ret: 0/12 (match)',
+    );
+  });
+});
+
+describe('renderFan', () => {
+  const ranked = (over: Partial<RankedResult> = {}): RankedResult =>
+    ({
+      best: cand('a', 0, 12, true),
+      candidates: [cand('a', 0, 12, true), cand('b', 3, 12), cand('c', 4, 13)],
+      dropped: [],
+      withheld: [],
+      ...over,
+    }) as RankedResult;
+
+  // THE POINT OF THE COMMAND. `eval/asmlift.ts` publishes the winner and discards
+  // `RankedResult.candidates`; six rounds hand-wrote a script to get the rest back.
+  it('prints every candidate, not only the winner', () => {
+    const out = renderFan(ranked());
+    expect(out).toContain('asmlift: [score] a: 0/12 (match)');
+    expect(out).toContain('asmlift: [score] b: 3/12');
+    expect(out).toContain('asmlift: [score] c: 4/13');
+    expect(out).toContain('asmlift: [ranked] 3 candidate(s) scored, 0 dropped, 0 withheld, best a: 0/12 (match)');
+  });
+
+  // The CLI prints "N candidate(s) failed to score; first: …" — a footnote under a score someone
+  // is reading. Here the fan IS the output, and "first: …" is precisely the shape that sent rounds
+  // back to a hand-written script, so both refusal lists are printed whole.
+  it('lists every dropped and every withheld candidate, not a count and the first', () => {
+    const out = renderFan(
+      ranked({
+        dropped: [
+          { label: 'd1', error: 'error: x undeclared\nmore' },
+          { label: 'd2', error: 'error: y undeclared' },
+        ],
+        withheld: [
+          { label: 'w1', score: 2, why: 'needs a byte-exact proof' },
+          { label: 'w2', score: 5, why: 'needs a byte-exact proof' },
+        ],
+      }),
+    );
+    expect(out).toContain('asmlift: [dropped] d1: error: x undeclared');
+    expect(out).toContain('asmlift: [dropped] d2: error: y undeclared');
+    expect(out).toContain('asmlift: [withheld] w1 at 2: needs a byte-exact proof');
+    expect(out).toContain('asmlift: [withheld] w2 at 5: needs a byte-exact proof');
+    // …and only the first line of a multi-line compiler error, so one drop cannot flood the table
+    expect(out).not.toContain('more');
+  });
+});
+
+describe('pickCandidate', () => {
+  const cands = [cand('a', 0, 12, true), cand('b', 3, 12)];
+
+  it('finds a candidate by its exact label — the whole `--show` feature', () => {
+    expect(pickCandidate(cands, 'b')?.source).toBe('/* b */');
+  });
+
+  it('spells the winner `best`, so the published row can be quoted without knowing its label', () => {
+    expect(pickCandidate(cands, 'best')?.label).toBe('a');
+  });
+
+  // A typo'd label and a lever that produced no candidate at all are the same silence otherwise.
+  it('returns undefined for a label nothing carries, so the caller can say so', () => {
+    expect(pickCandidate(cands, 'nope')).toBeUndefined();
+  });
+});
+
+// The scope guard, pinned against the measurement that set it: `synthetic:sizebound:agbcc`
+// enumerates 800 candidates and scores them in 57 s cold. A limit at or below that refuses a row
+// this command is FOR, so tightening it has to come with a new measurement rather than a hunch.
+it('will score a fan the size of the largest row measured through it', () => {
+  expect(FAN_SCORE_LIMIT).toBeGreaterThan(800);
+});

--- a/apps/benchmark/test/fan.test.ts
+++ b/apps/benchmark/test/fan.test.ts
@@ -1,5 +1,7 @@
 import type { RankedCandidate, RankedResult } from '@asmlift/cli/rank';
 import { rankedSummaryLine } from '@asmlift/cli/score-format';
+import { FrontendUnsupportedError } from '@asmlift/core/frontend/errors';
+import { NoScorableCandidateError, NoSpellableCandidateError } from '@asmlift/core/rank';
 import { describe, expect, it } from 'vitest';
 
 import type { Case } from '../src/cases/types';
@@ -7,6 +9,7 @@ import {
   FAN_SCORE_LIMIT,
   SCORE_SECONDS_PER_CANDIDATE,
   estimatedScoreTime,
+  noFanReport,
   optionRefusal,
   pickCandidate,
   renderFan,
@@ -136,7 +139,7 @@ describe('pickCandidate', () => {
 });
 
 // The scope guard, pinned against the measurement that set it: `synthetic:sizebound:agbcc`
-// enumerates 800 candidates and scores them in 57 s cold. A limit at or below that refuses a row
+// enumerates 800 candidates and scores them in 47.9 s cold. A limit at or below that refuses a row
 // this command is FOR, so tightening it has to come with a new measurement rather than a hunch.
 it('will score a fan the size of the largest row measured through it', () => {
   expect(FAN_SCORE_LIMIT).toBeGreaterThan(800);
@@ -230,17 +233,31 @@ describe('optionRefusal', () => {
 // wrong by ~20x — steering a reader off `--force` on a row that answers in minutes.
 describe('estimatedScoreTime', () => {
   it('prices the limit itself in minutes, not hours', () => {
-    expect(estimatedScoreTime(FAN_SCORE_LIMIT)).toBe('about 2 min');
+    expect(estimatedScoreTime(FAN_SCORE_LIMIT, 'synthetic')).toBe('about 2 min');
   });
 
   it('is the measured cold rate, and the constant is what was measured', () => {
-    expect(SCORE_SECONDS_PER_CANDIDATE * 800).toBeCloseTo(48, 0);
-    expect(estimatedScoreTime(800)).toBe('about 48 s');
+    expect(SCORE_SECONDS_PER_CANDIDATE.synthetic * 800).toBeCloseTo(48, 0);
+    expect(estimatedScoreTime(800, 'synthetic')).toBe('about 48 s');
   });
 
-  // LoadBGTilemapData: the row this guard exists for, and the run nobody starts by accident.
+  // The second measurement, and the reason the constant is a per-tier record: ONE rate priced
+  // `kleod:CountCollectedGems:agbcc` — a REAL row, and the row the refusal's own example is — at
+  // 6 min, against two cold runs of 518 s and 483 s of scoring. A real candidate escalates through
+  // up to three preludes in `makeRealCompile`; a synthetic one is one small prelude, so the gap is
+  // structural. The bound is the two measurements, not a third decimal place.
+  it('prices a REAL row at the real tier`s rate, which is the slower one', () => {
+    expect(SCORE_SECONDS_PER_CANDIDATE.real).toBeGreaterThan(SCORE_SECONDS_PER_CANDIDATE.synthetic);
+    const priced = SCORE_SECONDS_PER_CANDIDATE.real * 5952;
+    expect(priced).toBeGreaterThanOrEqual(483);
+    expect(priced).toBeLessThanOrEqual(518);
+    expect(estimatedScoreTime(5952, 'real')).toBe('about 8 min');
+  });
+
+  // LoadBGTilemapData: the row this guard exists for, and the run nobody starts by accident. It is
+  // a REAL row, so it is priced at the real rate — the synthetic one called it 3.8 h.
   it('prices LoadBGTilemapData`s fan in hours', () => {
-    expect(estimatedScoreTime(225792)).toBe('about 3.8 h');
+    expect(estimatedScoreTime(225792, 'real')).toBe('about 5.3 h');
   });
 });
 
@@ -266,5 +283,85 @@ describe('unshowable', () => {
 
   it('falls back to the fan listing for a label nothing carries', () => {
     expect(unshowable('nope', ranked)).toContain('see the [score] lines above');
+  });
+
+  // …and on a row where nothing scored there ARE no `[score]` lines, so the caller names the list
+  // that does exist. Hard-coding one table's name is what made the first spelling send a reader
+  // looking for a line that could not be there.
+  it('names the list it was given, not always the [score] table', () => {
+    expect(unshowable('nope', ranked, 'the [dropped] lines above')).toContain('the [dropped] lines above');
+  });
+});
+
+// The blocker fix's SECOND spelling, and the reason it needed one: the first chose its sentence
+// from a `phase` string the CALL SITE passed, so `--force` — which skips the guarded pre-count
+// enumeration — sent a DECLINED row's lift error into the scoring catch and printed "every
+// candidate was refused … this is what the published row's noncompile outcome means", under zero
+// `[dropped]` lines, on a row that publishes `declined`. Both briefs tell a round to pass
+// `--force`. The sentence is now chosen by the ERROR, and that is what these pin.
+describe('noFanReport', () => {
+  const dropped = [{ label: 'unsigned', error: 'agbcc failed: c.c:12' }];
+  const withheld = [{ label: 'unreduce', score: 2, why: 'needs a byte-exact proof' }];
+
+  it('reads NOTHING SCORED off the error class, and prints the drop list that rides on it', () => {
+    const e = new NoScorableCandidateError("no scorable candidate for 'f': agbcc failed", dropped, []);
+    const r = noFanReport('sa3:f:agbcc', e);
+    expect(r.fan).toEqual(['asmlift: [dropped] unsigned: agbcc failed: c.c:12']);
+    expect(r.notes.join('\n')).toContain('"noncompile"');
+    expect(r.harnessDefect).toBe(false);
+  });
+
+  // The all-withheld branch of core's `rankBy` ("N candidate(s) withheld, none scored") is
+  // reachable, and a dropped-only count reads "the 0 [dropped] line(s) above ARE this row's fan"
+  // printed directly under N withheld lines.
+  it('counts BOTH refusal lists, not just the dropped one', () => {
+    const e = new NoScorableCandidateError("no scorable candidate for 'f': 1 withheld", [], withheld);
+    const r = noFanReport('sa3:f:agbcc', e);
+    expect(r.fan).toHaveLength(1);
+    expect(r.notes.join('\n')).toContain('0 [dropped] and 1 [withheld]');
+  });
+
+  // THE REGRESSION. A decline reaching the scoring catch must still read as a decline.
+  it('reads a DECLINE as the row`s gap, from whichever call site caught it', () => {
+    const e = new FrontendUnsupportedError("cannot lift 'absi': unmodelled control transfer 'bltzl'");
+    const r = noFanReport('synthetic:absi:gcc2.7.2kmc', e);
+    const notes = r.notes.join('\n');
+    expect(notes).toContain('DECLINES on');
+    expect(notes).not.toContain('noncompile');
+    expect(notes).not.toContain('every candidate was refused');
+    expect(r.fan).toEqual([]);
+    expect(r.harnessDefect).toBe(false);
+  });
+
+  it('reads a BACKEND refusal as its own fact — nothing was spelled, so nothing was dropped', () => {
+    const r = noFanReport('synthetic:f:agbcc', new NoSpellableCandidateError("no spellable candidate for 'f': x"));
+    expect(r.notes.join('\n')).toContain('before anything was');
+    expect(r.harnessDefect).toBe(false);
+  });
+
+  // The guard must not become a story generator: an unclassified throw is the harness, and saying
+  // so with the stack is the whole point of the class-based branch. A `TypeError` silently
+  // reported as this row's outcome is worse than the crash the guard replaced.
+  it('calls an unclassified throw a HARNESS defect, and asks the caller for the stack', () => {
+    const r = noFanReport('sa3:f:agbcc', new TypeError('x is not a function'));
+    expect(r.harnessDefect).toBe(true);
+    expect(r.notes.join('\n')).toContain('HARNESS defect');
+  });
+
+  // A thrown `null` turned the no-fan ANSWER back into the crash it replaced.
+  it('survives a throw that is not an Error at all', () => {
+    expect(() => noFanReport('sa3:f:agbcc', null)).not.toThrow();
+  });
+
+  // `--show` was silently dropped here — on a `noncompile` row, i.e. the one row class where
+  // EVERY candidate is unshowable and the advice earns its keep.
+  it('answers --show instead of ignoring it, and names --enumerate for a dropped label', () => {
+    const e = new NoScorableCandidateError("no scorable candidate for 'f': agbcc failed", dropped, []);
+    expect(noFanReport('sa3:f:agbcc', e, 'unsigned').notes.join('\n')).toContain('--enumerate --show unsigned');
+  });
+
+  it('says --show cannot be answered when the row produced no candidates at all', () => {
+    const e = new FrontendUnsupportedError('cannot lift');
+    expect(noFanReport('synthetic:absi:gcc2.7.2kmc', e, 'unsigned').notes.join('\n')).toContain('cannot be answered');
   });
 });

--- a/apps/benchmark/test/fan.test.ts
+++ b/apps/benchmark/test/fan.test.ts
@@ -1,10 +1,26 @@
 import type { RankedCandidate, RankedResult } from '@asmlift/cli/rank';
+import { rankedSummaryLine } from '@asmlift/cli/score-format';
 import { describe, expect, it } from 'vitest';
 
 import type { Case } from '../src/cases/types';
-import { FAN_SCORE_LIMIT, pickCandidate, renderFan, scoreLine, selectCases } from '../src/run/fan';
+import {
+  FAN_SCORE_LIMIT,
+  SCORE_SECONDS_PER_CANDIDATE,
+  estimatedScoreTime,
+  optionRefusal,
+  pickCandidate,
+  renderFan,
+  scoreLine,
+  selectCases,
+  synthesizedRefs,
+  unshowable,
+} from '../src/run/fan';
 
 const row = (id: string): Case => ({ id }) as Case;
+
+/** A fan whose winner rests on no invented declaration, from a named tree — the two fields the
+ *  `[ranked]` line carries that are claims rather than counts. */
+const NO_DECLS = { synthesized: [], stamp: 'asmlift source deadbee' };
 
 const cand = (label: string, score: number, rows: number, match = false): RankedCandidate =>
   ({
@@ -67,11 +83,13 @@ describe('renderFan', () => {
   // THE POINT OF THE COMMAND. `eval/asmlift.ts` publishes the winner and discards
   // `RankedResult.candidates`; six rounds hand-wrote a script to get the rest back.
   it('prints every candidate, not only the winner', () => {
-    const out = renderFan(ranked());
+    const out = renderFan(ranked(), NO_DECLS);
     expect(out).toContain('asmlift: [score] a: 0/12 (match)');
     expect(out).toContain('asmlift: [score] b: 3/12');
     expect(out).toContain('asmlift: [score] c: 4/13');
-    expect(out).toContain('asmlift: [ranked] 3 candidate(s) scored, 0 dropped, 0 withheld, best a: 0/12 (match)');
+    expect(out).toContain(
+      'asmlift: [ranked] 3 candidate(s) scored, 0 dropped, 0 withheld, 0 synthesized, best a: 0/12 (match) [asmlift source deadbee]',
+    );
   });
 
   // The CLI prints "N candidate(s) failed to score; first: …" — a footnote under a score someone
@@ -89,6 +107,7 @@ describe('renderFan', () => {
           { label: 'w2', score: 5, why: 'needs a byte-exact proof' },
         ],
       }),
+      NO_DECLS,
     );
     expect(out).toContain('asmlift: [dropped] d1: error: x undeclared');
     expect(out).toContain('asmlift: [dropped] d2: error: y undeclared');
@@ -121,4 +140,131 @@ describe('pickCandidate', () => {
 // this command is FOR, so tightening it has to come with a new measurement rather than a hunch.
 it('will score a fan the size of the largest row measured through it', () => {
   expect(FAN_SCORE_LIMIT).toBeGreaterThan(800);
+});
+
+// F1: the `[ranked]` line is the one line the briefs tell a round to PASTE, and it now has two
+// producers — the CLI's ranked run and this command. The fields at risk are the ones that are not
+// counts of the fan: `synthesized` (the score rests on declarations asmlift invented) and the
+// source stamp (which tree produced it). The first spelling of this line here dropped both.
+describe('the [ranked] line', () => {
+  const ranked = (over: Partial<RankedResult> = {}): RankedResult =>
+    ({
+      best: cand('a', 0, 12, true),
+      candidates: [cand('a', 0, 12, true), cand('b', 3, 12)],
+      dropped: [],
+      withheld: [],
+      ...over,
+    }) as RankedResult;
+
+  it('is rendered by the one shared renderer, so the two producers cannot drift', () => {
+    const out = renderFan(ranked(), NO_DECLS);
+    expect(out.split('\n').at(-1)).toBe(
+      rankedSummaryLine({
+        scored: 2,
+        dropped: 0,
+        withheld: 0,
+        synthesized: 0,
+        best: cand('a', 0, 12, true),
+        stamp: 'asmlift source deadbee',
+      }),
+    );
+  });
+
+  // A `(match)` fitted to the target's own asm by declarations asmlift invented is publishable by
+  // pasting this line, unless the line says so.
+  it('carries the synthesized count and names the declarations it counted', () => {
+    const refs = [{ name: 'gFoo', synthesized: true, info: { kind: 'scalar', width: 4, signed: false } }];
+    const out = renderFan(ranked(), {
+      synthesized: refs as unknown as Parameters<typeof renderFan>[1]['synthesized'],
+      stamp: 'asmlift source deadbee+dirty',
+    });
+    expect(out).toContain('asmlift: [declared] 1 declaration(s) synthesized from the target asm');
+    expect(out).toContain('gFoo');
+    expect(out.split('\n').at(-1)).toContain('1 synthesized');
+    // …and the tree, on the same line, because a stamp anywhere else is a stamp nobody pastes.
+    expect(out.split('\n').at(-1)).toContain('[asmlift source deadbee+dirty]');
+  });
+});
+
+// The world a row's candidates compile in decides whether an invented declaration can affect the
+// score at all: a real row is compiled through the project's headers (compile/real.ts drops the
+// block), a synthetic row has nothing but the block.
+describe('synthesizedRefs', () => {
+  const withRefs = {
+    label: 'a',
+    symbolRefs: [
+      { name: 'gA', synthesized: true },
+      { name: 'gB', synthesized: false },
+    ],
+  } as unknown as RankedCandidate;
+
+  it('counts an invented declaration on a synthetic row, where nothing else declares the name', () => {
+    expect(synthesizedRefs('synthetic', withRefs).map((r) => r.name)).toEqual(['gA']);
+  });
+
+  it('counts none on a real row, whose every scoring rung is the project`s own headers', () => {
+    expect(synthesizedRefs('real', withRefs)).toEqual([]);
+  });
+});
+
+// F2 / the breaker's SHOULD-FIX: `--enumerate --show best` printed `unsigned` on
+// `synthetic:sizebound:agbcc`, a near-worst spelling in a fan whose winner scores 8/81 — under the
+// name of the winner, to a round both briefs had told that `--show best` is the winner.
+describe('optionRefusal', () => {
+  it('refuses --show best under --enumerate, where nothing has been scored', () => {
+    expect(optionRefusal({ enumerateOnly: true, show: 'best' })).toContain('no winner to name');
+  });
+
+  it('allows --show <label> under --enumerate — an enumerated candidate carries its source', () => {
+    expect(optionRefusal({ enumerateOnly: true, show: 'unsigned' })).toBeUndefined();
+  });
+
+  it('allows --show best on the scored path, which is sorted best-first', () => {
+    expect(optionRefusal({ show: 'best' })).toBeUndefined();
+  });
+});
+
+// The refusal's job is to price the run it is refusing. The sentence this replaces said "well over
+// an hour" for any fan over 2,000 while the same file's doc-comment said two and a half minutes;
+// measured, 800 candidates score in 47.9 s cold, so the doc-comment was right and the refusal was
+// wrong by ~20x — steering a reader off `--force` on a row that answers in minutes.
+describe('estimatedScoreTime', () => {
+  it('prices the limit itself in minutes, not hours', () => {
+    expect(estimatedScoreTime(FAN_SCORE_LIMIT)).toBe('about 2 min');
+  });
+
+  it('is the measured cold rate, and the constant is what was measured', () => {
+    expect(SCORE_SECONDS_PER_CANDIDATE * 800).toBeCloseTo(48, 0);
+    expect(estimatedScoreTime(800)).toBe('about 48 s');
+  });
+
+  // LoadBGTilemapData: the row this guard exists for, and the run nobody starts by accident.
+  it('prices LoadBGTilemapData`s fan in hours', () => {
+    expect(estimatedScoreTime(225792)).toBe('about 3.8 h');
+  });
+});
+
+// F4: a dropped candidate's source is what a reader most wants (it is the spelling that failed to
+// compile) and it is the one `--show` cannot reach — `DroppedCandidate` carries no source at all.
+// Sending them to the `[score]` lines for it is sending them to look for a line that is not there.
+describe('unshowable', () => {
+  const ranked = {
+    candidates: [],
+    dropped: [{ label: 'raw-globals', error: 'gFoo undeclared' }],
+    withheld: [{ label: 'unreduce', score: 2, why: 'needs a byte-exact proof' }],
+  } as unknown as RankedResult;
+
+  it('says a label was DROPPED, and names the flag that can still print its source', () => {
+    const msg = unshowable('raw-globals', ranked);
+    expect(msg).toContain('was dropped');
+    expect(msg).toContain('--enumerate --show raw-globals');
+  });
+
+  it('says a label was WITHHELD — it scored, so `no such candidate` would be a lie', () => {
+    expect(unshowable('unreduce', ranked)).toContain('was withheld');
+  });
+
+  it('falls back to the fan listing for a label nothing carries', () => {
+    expect(unshowable('nope', ranked)).toContain('see the [score] lines above');
+  });
 });

--- a/apps/web/src/data/summary.json
+++ b/apps/web/src/data/summary.json
@@ -4,7 +4,7 @@
     "asmlift": 598,
     "m2c": 412
   },
-  "commit": "ce2860dec8bedfac2653f691228f5ec5bfc807ac",
+  "commit": "48c5f78c7fee580601b0cdebed60d34f9d95be8f",
   "m2cCommit": "ad5c529a65ca1e5191b00a4a7b4cbfe79a7b45a0",
   "dirty": false
 }

--- a/apps/web/src/pages/playground/rank.worker.ts
+++ b/apps/web/src/pages/playground/rank.worker.ts
@@ -4,6 +4,8 @@
 // RankRequest and receives a RankResponse. The H1 stale-guard (discarding a superseded response)
 // is enforced by the MAIN thread against the echoed `reqId` — the worker just processes each
 // request and echoes its id back.
+import { NoScorableCandidateError } from '@asmlift/core/rank';
+
 import { throttleProgress, whileCurrent } from './rank-progress';
 import {
   type RankInbound,
@@ -55,11 +57,30 @@ self.onmessage = async (e: MessageEvent<RankInbound>) => {
     const result = await rankCandidatesInBrowser(name, asm, target, symbols, post);
     postMessage({ kind: 'result', reqId, ok: true, result } satisfies RankResponse);
   } catch (err) {
+    // ONLY A STRING CROSSES THIS BOUNDARY, so the refusal lists a total failure carries
+    // (`NoScorableCandidateError.dropped`/`.withheld` — on that row they ARE the whole fan) die
+    // here unless they are folded INTO the string. A `structuredClone` of the error drops the
+    // subclass fields anyway, and a fan-sized list is not a toast; the counts plus the first few
+    // labels are what turns "ranking unavailable" from a dead end into a place to look.
     postMessage({
       kind: 'result',
       reqId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: err instanceof Error ? `${err.message}${refusalSummary(err)}` : String(err),
     } satisfies RankResponse);
   }
 };
+
+/** The counts and a first few labels off a total refusal, appended to the message because the
+ *  message is all the worker protocol carries. Empty for every other error. */
+function refusalSummary(err: Error): string {
+  if (!(err instanceof NoScorableCandidateError)) {
+    return '';
+  }
+  const labels = [...err.dropped.map((d) => d.label), ...err.withheld.map((w) => w.label)];
+  const shown = labels.slice(0, 3).join(', ');
+  return (
+    ` (${err.dropped.length} dropped, ${err.withheld.length} withheld` +
+    `${shown === '' ? '' : `: ${shown}${labels.length > 3 ? `, +${labels.length - 3} more` : ''}`})`
+  );
+}

--- a/apps/web/src/pages/playground/score-wasm.ts
+++ b/apps/web/src/pages/playground/score-wasm.ts
@@ -326,11 +326,10 @@ export async function rankCandidatesInBrowser(
   emit({ phase: 'ranking' });
   if (results.length === 0) {
     const why = lastErr instanceof Error ? lastErr.message.split('\n')[0] : String(lastErr ?? 'no candidate produced');
-    // The ERROR CLASS is imported for the third time in this function, and for the same reason as
-    // `compareScored` and `withheldReason`: the two lists are the whole fan on a row where nothing
-    // scored, and a bare `Error` drops them on the floor. Core's `rankBy` carries them; this
-    // driver used not to, which made the playground's "ranking unavailable" toast the one place
-    // a drop list dies. The message is byte-identical either way.
+    // CORE'S CLASS, for the same reason this driver borrows `compareScored` and `withheldReason`:
+    // on a row where nothing scored the two lists are the whole fan, and a bare `Error` drops them
+    // on the floor — leaving the playground's "ranking unavailable" toast with nothing behind it.
+    // The message is byte-identical either way.
     throw new NoScorableCandidateError(`no scorable candidate for '${name}': ${why}`, dropped, withheld, {
       cause: lastErr,
     });

--- a/apps/web/src/pages/playground/score-wasm.ts
+++ b/apps/web/src/pages/playground/score-wasm.ts
@@ -18,6 +18,7 @@ import { cBackend } from '@asmlift/core/backend/c';
 import { selfDeclaredContextFor } from '@asmlift/core/declare';
 import {
   type DroppedCandidate,
+  NoScorableCandidateError,
   type RankedResult,
   type RefusedDeclarationReason,
   type Scored,
@@ -325,7 +326,14 @@ export async function rankCandidatesInBrowser(
   emit({ phase: 'ranking' });
   if (results.length === 0) {
     const why = lastErr instanceof Error ? lastErr.message.split('\n')[0] : String(lastErr ?? 'no candidate produced');
-    throw new Error(`no scorable candidate for '${name}': ${why}`, { cause: lastErr });
+    // The ERROR CLASS is imported for the third time in this function, and for the same reason as
+    // `compareScored` and `withheldReason`: the two lists are the whole fan on a row where nothing
+    // scored, and a bare `Error` drops them on the floor. Core's `rankBy` carries them; this
+    // driver used not to, which made the playground's "ranking unavailable" toast the one place
+    // a drop list dies. The message is byte-identical either way.
+    throw new NoScorableCandidateError(`no scorable candidate for '${name}': ${why}`, dropped, withheld, {
+      cause: lastErr,
+    });
   }
   results.sort(compareScored);
   return { best: results[0], candidates: results.map(({ order: _order, ...c }) => c), dropped, withheld, refused };

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -188,7 +188,9 @@ compile and vendored symbol map, assembled by the single function `bench run` as
 arise — there is no second tree to be in.
 
 It prints the `[score]` table this file's comparison recipe is written for, then `[dropped]`,
-`[withheld]` and `[ranked]`, all through the CLI's own renderer, denominators included. Measured on
+`[withheld]`, the `[declared]` block and `[ranked]` — all through the CLI's own renderers, the same
+functions `pnpm asmlift` prints them with, so the `[ranked]` line here carries the `synthesized`
+count and the `[asmlift source <sha>]` stamp this file tells you to quote. Measured on
 `kleod:StrCpy:agbcc`: `unsigned: 5/8` in **7.0 s**, the published row exactly, and
 `--show best` printed the published source byte-for-byte.
 
@@ -198,16 +200,33 @@ Two things it can do that nothing else can:
   C and no other's, and `RankedResult.candidates` — every other spelling, each with its own
   `source` — was computed and discarded on every run until this command read it. "The near-miss
   spelling is right and only loses on X" is now a thing to read rather than infer.
-- **`--enumerate` lists the fan without compiling anything**, in seconds at any fan size, and still
-  serves `--show`. That is the cheap configuration-identification this file's "Getting the fan
-  alone is cheap" section describes, without the kill-it-after-the-first-`[progress]`-line trick.
+- **`--enumerate` lists the fan without compiling anything**, and still serves `--show <label>`
+  (not `--show best` — nothing is scored, so there is no winner to name, and that combination is
+  refused rather than answered with whatever enumeration emitted first). That is the cheap
+  configuration-identification this file's "Getting the fan alone is cheap" section describes,
+  without the kill-it-after-the-first-`[progress]`-line trick. **Cheap relative to compiling, not
+  cheap absolutely**: measured at 128 candidates/s (`kleod:CountCollectedGems:agbcc`, 5,952 in
+  46 s), so `LoadBGTilemapData`'s 225,792 is ~30 minutes just to LIST. Read a long enumeration as
+  a big fan, not as a hang.
+
   It also prints `[lever] <label> threw (no candidate from it)`, a channel `bench run` supplies no
   sink for at all — so a whole pre-fan half of a row's fan can vanish from a benchmark run with
   nothing printed, and here it does not.
 
-**A fan over 2,000 candidates is refused, not scored** (`--force` overrides). Scoring is a compile
-each: `synthetic:sizebound:agbcc`'s 800 take 57 s cold, and `LoadBGTilemapData`'s 225,792 is a
-four-hour run at that rate. `--enumerate` is the answer at that size, not `--force`.
+**A fan over 2,000 candidates is refused, not scored** (`--force` overrides), and the refusal
+prices the run it is refusing from the row's own count. Scoring is a compile each:
+`synthetic:sizebound:agbcc`'s 800 take **48 s cold** (10 s warm), so the limit is ~2 minutes and
+`kleod:CountCollectedGems:agbcc`'s 5,952 is ~6 minutes — a `--force` worth typing, not an hour.
+`LoadBGTilemapData`'s 225,792 is a ~4-hour run at that rate; `--enumerate` is the answer at THAT
+size, and note the guard is checked after the pre-count enumeration, so the refusal itself pays the
+enumeration price above.
+
+**A row with no fan says so, and exits 2.** Neither of the ranked path's two calls can be assumed
+to return: on a `declined` row (233 of 1,035) enumeration THROWS on the same gap the published row
+annotates — `enumerateCandidates` has no annotate mode — and on a `noncompile` row every candidate
+is refused, so there is no ranking to print. Both are answered with `asmlift: [fan] no fan …` and
+exit 2, and the noncompile case prints the whole `[dropped]` list first, because on that row the
+drops ARE the fan.
 
 What it is NOT: a reproduction. It runs asmlift in-process from this repo's sources, so it proves
 nothing about the published script, and `pnpm bench fidelity` still re-runs the scripts rather than

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -64,6 +64,7 @@ checkout (below).
 | ---------------------------------------------------------------------------------------------------------------------- | --------------: | ----------------------------------- |
 | the command above: `asm/matchings/system/StrCpy.s`, the checkout's `decomp.yaml`, `--score-against build/src/system.o` | `unsigned: 6/9` | `u8 *StrCpy(…) { … return v2; }`    |
 | `pnpm bench repro kleod:StrCpy:agbcc --run` (the row's own script)                                                     | `unsigned: 5/8` | byte-identical to the published row |
+| `pnpm bench fan kleod:StrCpy:agbcc` (the harness's own call, no script)                                                | `unsigned: 5/8` | byte-identical to the published row |
 | the published row, `apps/benchmark/results/results.json`                                                               |           `5/8` | —                                   |
 
 Different score, a different denominator, and a different C spelling — on a seven-instruction
@@ -172,6 +173,46 @@ consulted only for a row `results.json` does not carry at all. So after a `bench
 --only <sym>` moves your row, the reproduction still replays the rung the published source pins.
 That is right for reproducing a published row and wrong for watching your own change land: for
 that, the number is `bench run`'s.
+
+#### The whole FAN, and any candidate's source: `pnpm bench fan`
+
+```sh
+pnpm bench fan <sym|project:sym:toolchain> [--show <label>] [--enumerate] [--force]
+```
+
+The third vehicle, and the only one that answers **"which spellings did asmlift consider"** rather
+than "what did this row score". It is not a script and writes no directory: it re-enters the
+harness's own ranked call for one row, with the row's own target object, prototypes, context
+compile and vendored symbol map, assembled by the single function `bench run` assembles them with
+(`eval/asmlift.ts`'s `rankOptionsFor`). So the checkout question this whole file is about does not
+arise — there is no second tree to be in.
+
+It prints the `[score]` table this file's comparison recipe is written for, then `[dropped]`,
+`[withheld]` and `[ranked]`, all through the CLI's own renderer, denominators included. Measured on
+`kleod:StrCpy:agbcc`: `unsigned: 5/8` in **7.0 s**, the published row exactly, and
+`--show best` printed the published source byte-for-byte.
+
+Two things it can do that nothing else can:
+
+- **`--show <label>` prints a NON-WINNING candidate's source.** `results.json` carries the winner's
+  C and no other's, and `RankedResult.candidates` — every other spelling, each with its own
+  `source` — was computed and discarded on every run until this command read it. "The near-miss
+  spelling is right and only loses on X" is now a thing to read rather than infer.
+- **`--enumerate` lists the fan without compiling anything**, in seconds at any fan size, and still
+  serves `--show`. That is the cheap configuration-identification this file's "Getting the fan
+  alone is cheap" section describes, without the kill-it-after-the-first-`[progress]`-line trick.
+  It also prints `[lever] <label> threw (no candidate from it)`, a channel `bench run` supplies no
+  sink for at all — so a whole pre-fan half of a row's fan can vanish from a benchmark run with
+  nothing printed, and here it does not.
+
+**A fan over 2,000 candidates is refused, not scored** (`--force` overrides). Scoring is a compile
+each: `synthetic:sizebound:agbcc`'s 800 take 57 s cold, and `LoadBGTilemapData`'s 225,792 is a
+four-hour run at that rate. `--enumerate` is the answer at that size, not `--force`.
+
+What it is NOT: a reproduction. It runs asmlift in-process from this repo's sources, so it proves
+nothing about the published script, and `pnpm bench fidelity` still re-runs the scripts rather than
+this. When you need to quote a number a reader can re-derive from a published artifact, that is
+`bench repro`; when you need to know what asmlift thought about, it is this.
 
 ### What this vehicle does NOT reproduce: your CHANGED asmlift
 

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -205,8 +205,9 @@ Two things it can do that nothing else can:
   refused rather than answered with whatever enumeration emitted first). That is the cheap
   configuration-identification this file's "Getting the fan alone is cheap" section describes,
   without the kill-it-after-the-first-`[progress]`-line trick. **Cheap relative to compiling, not
-  cheap absolutely**: measured at 128 candidates/s (`kleod:CountCollectedGems:agbcc`, 5,952 in
-  46 s), so `LoadBGTilemapData`'s 225,792 is ~30 minutes just to LIST. Read a long enumeration as
+  cheap absolutely**: `kleod:CountCollectedGems:agbcc`'s 5,952 labels take 50 s wall with the
+  target build included (~120 candidates/s), so `LoadBGTilemapData`'s 225,792 is ~30 minutes just
+  to LIST. Read a long enumeration as
   a big fan, not as a hang.
 
   It also prints `[lever] <label> threw (no candidate from it)`, a channel `bench run` supplies no
@@ -214,19 +215,32 @@ Two things it can do that nothing else can:
   nothing printed, and here it does not.
 
 **A fan over 2,000 candidates is refused, not scored** (`--force` overrides), and the refusal
-prices the run it is refusing from the row's own count. Scoring is a compile each:
-`synthetic:sizebound:agbcc`'s 800 take **48 s cold** (10 s warm), so the limit is ~2 minutes and
-`kleod:CountCollectedGems:agbcc`'s 5,952 is ~6 minutes — a `--force` worth typing, not an hour.
-`LoadBGTilemapData`'s 225,792 is a ~4-hour run at that rate; `--enumerate` is the answer at THAT
-size, and note the guard is checked after the pre-count enumeration, so the refusal itself pays the
-enumeration price above.
+prices the run it is refusing from the row's own count AND ITS OWN TIER. Scoring is a compile each,
+and the two tiers do not compile the same thing: `synthetic:sizebound:agbcc`'s 800 take **48 s
+cold** (10 s warm, 60 ms each), while `kleod:CountCollectedGems:agbcc`'s 5,952 took **518 s and
+483 s** on two cold runs (85 ms each, both reproducing the published `171/387`) — a real candidate
+escalates through up to three preludes in `compile/real.ts`, a synthetic one through a single small
+prelude. One rate for both under-priced the real tier by ~35%, on the row the refusal's own example
+is. So the limit is ~2 minutes of synthetic scoring, `CountCollectedGems` is ~8 minutes — a
+`--force` worth typing, not an hour — and `LoadBGTilemapData`'s 225,792 is a five-hour run;
+`--enumerate` is the answer at THAT size, and note the guard is checked after the pre-count
+enumeration, so the refusal itself pays the enumeration price above.
 
 **A row with no fan says so, and exits 2.** Neither of the ranked path's two calls can be assumed
 to return: on a `declined` row (233 of 1,035) enumeration THROWS on the same gap the published row
 annotates — `enumerateCandidates` has no annotate mode — and on a `noncompile` row every candidate
 is refused, so there is no ranking to print. Both are answered with `asmlift: [fan] no fan …` and
-exit 2, and the noncompile case prints the whole `[dropped]` list first, because on that row the
-drops ARE the fan.
+exit 2, and the noncompile case prints the whole `[dropped]`/`[withheld]` list first, because on
+that row the refusals ARE the fan.
+
+**Which of the two you are looking at is decided by the ERROR, never by which call site caught it.**
+That is not a style point: the first spelling picked its sentence from the phase, and `--force`
+skips the pre-count enumeration, so a DECLINED row's lift error landed in the scoring catch and was
+reported as `noncompile` with a `0 [dropped] line(s) above ARE this row's fan` under no lines at
+all. `NoScorableCandidateError` (nothing SCORED) and `NoSpellableCandidateError` (nothing SPELLED —
+the backend refused every tree) are separate classes for this reason, and a throw that is neither
+of them nor a decline is reported as a HARNESS defect with its stack rather than dressed up as a
+fact about the row.
 
 What it is NOT: a reproduction. It runs asmlift in-process from this repo's sources, so it proves
 nothing about the published script, and `pnpm bench fidelity` still re-runs the scripts rather than

--- a/docs/ranked-repro.md
+++ b/docs/ranked-repro.md
@@ -191,24 +191,23 @@ It prints the `[score]` table this file's comparison recipe is written for, then
 `[withheld]`, the `[declared]` block and `[ranked]` — all through the CLI's own renderers, the same
 functions `pnpm asmlift` prints them with, so the `[ranked]` line here carries the `synthesized`
 count and the `[asmlift source <sha>]` stamp this file tells you to quote. Measured on
-`kleod:StrCpy:agbcc`: `unsigned: 5/8` in **7.0 s**, the published row exactly, and
-`--show best` printed the published source byte-for-byte.
+`kleod:StrCpy:agbcc`: `unsigned: 5/8` in **9 s**, the published row exactly, and `--show best`
+printed the published source byte-for-byte.
 
 Two things it can do that nothing else can:
 
 - **`--show <label>` prints a NON-WINNING candidate's source.** `results.json` carries the winner's
-  C and no other's, and `RankedResult.candidates` — every other spelling, each with its own
-  `source` — was computed and discarded on every run until this command read it. "The near-miss
-  spelling is right and only loses on X" is now a thing to read rather than infer.
+  C and no other's, while `RankedResult.candidates` — every other spelling, each with its own
+  `source` — is computed on every run and discarded. "The near-miss spelling is right and only
+  loses on X" is a thing to read here rather than infer.
 - **`--enumerate` lists the fan without compiling anything**, and still serves `--show <label>`
   (not `--show best` — nothing is scored, so there is no winner to name, and that combination is
   refused rather than answered with whatever enumeration emitted first). That is the cheap
   configuration-identification this file's "Getting the fan alone is cheap" section describes,
-  without the kill-it-after-the-first-`[progress]`-line trick. **Cheap relative to compiling, not
+  without killing the run after its first `[progress]` line. **Cheap relative to compiling, not
   cheap absolutely**: `kleod:CountCollectedGems:agbcc`'s 5,952 labels take 50 s wall with the
   target build included (~120 candidates/s), so `LoadBGTilemapData`'s 225,792 is ~30 minutes just
-  to LIST. Read a long enumeration as
-  a big fan, not as a hang.
+  to LIST. Read a long enumeration as a big fan, not as a hang.
 
   It also prints `[lever] <label> threw (no candidate from it)`, a channel `bench run` supplies no
   sink for at all — so a whole pre-fan half of a row's fan can vanish from a benchmark run with
@@ -220,7 +219,7 @@ and the two tiers do not compile the same thing: `synthetic:sizebound:agbcc`'s 8
 cold** (10 s warm, 60 ms each), while `kleod:CountCollectedGems:agbcc`'s 5,952 took **518 s and
 483 s** on two cold runs (85 ms each, both reproducing the published `171/387`) — a real candidate
 escalates through up to three preludes in `compile/real.ts`, a synthetic one through a single small
-prelude. One rate for both under-priced the real tier by ~35%, on the row the refusal's own example
+prelude; one rate for both under-prices the real tier by ~35%, on the row the refusal's own example
 is. So the limit is ~2 minutes of synthetic scoring, `CountCollectedGems` is ~8 minutes — a
 `--force` worth typing, not an hour — and `LoadBGTilemapData`'s 225,792 is a five-hour run;
 `--enumerate` is the answer at THAT size, and note the guard is checked after the pre-count
@@ -233,14 +232,13 @@ is refused, so there is no ranking to print. Both are answered with `asmlift: [f
 exit 2, and the noncompile case prints the whole `[dropped]`/`[withheld]` list first, because on
 that row the refusals ARE the fan.
 
-**Which of the two you are looking at is decided by the ERROR, never by which call site caught it.**
-That is not a style point: the first spelling picked its sentence from the phase, and `--force`
-skips the pre-count enumeration, so a DECLINED row's lift error landed in the scoring catch and was
-reported as `noncompile` with a `0 [dropped] line(s) above ARE this row's fan` under no lines at
-all. `NoScorableCandidateError` (nothing SCORED) and `NoSpellableCandidateError` (nothing SPELLED —
-the backend refused every tree) are separate classes for this reason, and a throw that is neither
-of them nor a decline is reported as a HARNESS defect with its stack rather than dressed up as a
-fact about the row.
+**Which of the two you are looking at is decided by the ERROR, never by which call site caught it**,
+so `--force` does not change the answer — it skips the pre-count enumeration, and a declined row's
+lift error then arrives at the scoring catch, where a call-site guess would report it as
+`noncompile` under no `[dropped]` lines at all. `NoScorableCandidateError` (nothing SCORED) and
+`NoSpellableCandidateError` (nothing SPELLED — the backend refused every tree) are separate classes
+for this reason, and a throw that is neither of them nor a decline is reported as a HARNESS defect
+with its stack rather than dressed up as a fact about the row.
 
 What it is NOT: a reproduction. It runs asmlift in-process from this repo's sources, so it proves
 nothing about the published script, and `pnpm bench fidelity` still re-runs the scripts rather than

--- a/packages/cli/src/declare.ts
+++ b/packages/cli/src/declare.ts
@@ -1,6 +1,34 @@
 // asmlift cli — declaration synthesis re-export. The renderer itself lives in @asmlift/core
 // (core/src/declare.ts — browser-pure) so the webapp's wasm scorer prepends the SAME
 // declarations the cli's Node/objdiff scorer does; this module only preserves the cli's
-// historical import path. No behavior of its own — the A/B matching suite
-// (test/matching/self-declared-ab.test.ts) pins the compiled bytes either way.
+// historical import path — the A/B matching suite (test/matching/self-declared-ab.test.ts) pins
+// the compiled bytes either way. What it DOES own is how a synthesized declaration is REPORTED
+// (`declaredBlock`): that is a claim about what a score rests on, so it needs exactly one spelling
+// across every command that prints one.
+import { renderDeclarations } from '@asmlift/core/declare';
+
 export { macroDefinesOf, renderDeclarations, selfDeclaredContext } from '@asmlift/core/declare';
+
+/** A declaration block as stderr lines: rendered, blank lines dropped, each one under the
+ *  `asmlift:` prefix that separates this tool's output from the compiler's in a shared log. */
+export const indentedDeclarations = (refs: Parameters<typeof renderDeclarations>[0]): string =>
+  renderDeclarations(refs)
+    .split('\n')
+    .filter((l) => l.trim() !== '')
+    .map((l) => `asmlift:   ${l}\n`)
+    .join('');
+
+/** THE `[declared]` BLOCK of a ranked run — the declarations asmlift INVENTED for the winner,
+ *  named so the score can be checked against the reader's own headers.
+ *
+ *  One owner because it has two producers now: the CLI's ranked run and the benchmark's `bench
+ *  fan`, which prints one row's whole fan and must not describe a synthesized declaration in
+ *  different words than the command whose numbers it reproduces. Empty for an empty list — a
+ *  block that says "0 declaration(s)" reads as a finding. */
+export const declaredBlock = (refs: Parameters<typeof renderDeclarations>[0]): string =>
+  refs.length === 0
+    ? ''
+    : `asmlift: [declared] ${refs.length} declaration(s) synthesized from the target asm — no symbol ` +
+      `map knows these names, so the score is about this block plus the source; check it against your ` +
+      `headers:\n` +
+      indentedDeclarations(refs);

--- a/packages/cli/src/decline.ts
+++ b/packages/cli/src/decline.ts
@@ -4,13 +4,12 @@
 // decompiler does not model, and is a fact about the ROW; anything else is a fact about the
 // TOOL. Both exit 1 from the CLI, so the only thing that separates them for a reader is the
 // prefix the surface prints — and a surface that guesses the prefix from which call site caught
-// prints a confident wrong sentence, which is worse than the crash it replaced (`bench fan`
-// shipped exactly that: `--force` on a declined row reported it as `noncompile`).
+// prints a confident wrong sentence, which is worse than the crash it replaces.
 //
-// It lives in its own leaf, and not in `main.ts` where it was born, because there are now TWO
-// surfaces that must agree about it — the CLI's `[declined]`/`[internal error]` prefix and the
-// benchmark's `bench fan`, which has to tell a row with no fan apart from a broken harness. A
-// per-surface copy of this list is a per-surface answer to the same question.
+// It is its own leaf because TWO surfaces must agree about it — the CLI's
+// `[declined]`/`[internal error]` prefix and the benchmark's `bench fan`, which has to tell a row
+// with no fan apart from a broken harness. A per-surface copy of this list is a per-surface answer
+// to the same question.
 import { ContractError } from '@asmlift/core/contracts';
 import { FrontendUnsupportedError } from '@asmlift/core/frontend/errors';
 import { VerifyError } from '@asmlift/core/ir/verify';

--- a/packages/cli/src/decline.ts
+++ b/packages/cli/src/decline.ts
@@ -1,0 +1,30 @@
+// WHICH errors are the pipeline REFUSING TO GUESS, and which are a bug.
+//
+// The distinction is the whole of asmlift's failure contract: a decline names a construct the
+// decompiler does not model, and is a fact about the ROW; anything else is a fact about the
+// TOOL. Both exit 1 from the CLI, so the only thing that separates them for a reader is the
+// prefix the surface prints — and a surface that guesses the prefix from which call site caught
+// prints a confident wrong sentence, which is worse than the crash it replaced (`bench fan`
+// shipped exactly that: `--force` on a declined row reported it as `noncompile`).
+//
+// It lives in its own leaf, and not in `main.ts` where it was born, because there are now TWO
+// surfaces that must agree about it — the CLI's `[declined]`/`[internal error]` prefix and the
+// benchmark's `bench fan`, which has to tell a row with no fan apart from a broken harness. A
+// per-surface copy of this list is a per-surface answer to the same question.
+import { ContractError } from '@asmlift/core/contracts';
+import { FrontendUnsupportedError } from '@asmlift/core/frontend/errors';
+import { VerifyError } from '@asmlift/core/ir/verify';
+import { RaiseUnsupportedError } from '@asmlift/core/raise/errors';
+import { StructureError } from '@asmlift/core/structure/structure';
+
+/** The principled declines, in pipeline order. Nothing else in this list is a decline: an error
+ *  class not named here is a defect until someone adds it here on purpose. */
+export const DECLINE_ERRORS = [
+  FrontendUnsupportedError,
+  RaiseUnsupportedError,
+  StructureError,
+  ContractError,
+  VerifyError,
+] as const;
+
+export const isDecline = (e: unknown): boolean => DECLINE_ERRORS.some((c) => e instanceof c);

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -13,16 +13,11 @@
 // this file returns and a status the README documents cannot drift apart.
 import { cBackend } from '@asmlift/core/backend/c';
 import { pascalBackend } from '@asmlift/core/backend/pascal';
-import { ContractError } from '@asmlift/core/contracts';
 import { detectName } from '@asmlift/core/detect';
 import { type AsmData, parseAsmData } from '@asmlift/core/frontend/asmdata';
-import { FrontendUnsupportedError } from '@asmlift/core/frontend/errors';
-import { VerifyError } from '@asmlift/core/ir/verify';
 import type { LanguageBackend } from '@asmlift/core/l3/ast';
 import { type OnGap, decompile } from '@asmlift/core/pipeline';
 import { type Prototypes, validatePrototypes } from '@asmlift/core/proto';
-import { RaiseUnsupportedError } from '@asmlift/core/raise/errors';
-import { StructureError } from '@asmlift/core/structure/structure';
 import { type SymbolMap, asIfUndecompiled } from '@asmlift/core/symbols';
 import { ARMV4T_AGBCC, MIPS_GCC, MIPS_IDO, PPC_MWCC, type TargetDescription } from '@asmlift/core/target';
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
@@ -41,6 +36,7 @@ import {
 import { type CommandCompilers, compilersFromCommand } from './compile-command';
 import { type AsmliftToolConfig, loadDecompConfig, resolveTarget } from './config';
 import { declaredBlock, indentedDeclarations } from './declare';
+import { isDecline } from './decline';
 import { ObjectInputUnsupportedError, asmDataForObject, disasmObject, isElfObject } from './objfile';
 import { PhaseClock } from './phase';
 import { bakedBuild, sampleSourceTree, sourceStamp } from './provenance';
@@ -161,11 +157,6 @@ Gaps are annotated in-source as ASMLIFT_ERROR markers, diagnostics on stderr.
 Exit codes: 0 clean/match · 1 gaps/declined/nonmatch · 3 the candidate-object cache served
             bytes a fresh compile disagrees with · 64 usage · 66 unreadable input.
 Full reference (flags, decomp.yaml integration): the @asmlift/cli README.`;
-
-// A principled decline (the pipeline refusing to guess) vs an internal error (a bug) must be
-// distinguishable at the CLI surface — both exit 1, but the prefix names which one happened.
-const DECLINE_ERRORS = [FrontendUnsupportedError, RaiseUnsupportedError, StructureError, ContractError, VerifyError];
-const isDecline = (e: unknown) => DECLINE_ERRORS.some((c) => e instanceof c);
 
 // The object-input seam, injectable so the offline CLI tests can fake the objdump spawns.
 export interface ObjInput {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -40,7 +40,7 @@ import {
 } from './candcache';
 import { type CommandCompilers, compilersFromCommand } from './compile-command';
 import { type AsmliftToolConfig, loadDecompConfig, resolveTarget } from './config';
-import { renderDeclarations } from './declare';
+import { declaredBlock, indentedDeclarations } from './declare';
 import { ObjectInputUnsupportedError, asmDataForObject, disasmObject, isElfObject } from './objfile';
 import { PhaseClock } from './phase';
 import { bakedBuild, sampleSourceTree, sourceStamp } from './provenance';
@@ -53,7 +53,7 @@ import type { RankedResult } from './rank';
 // must be able to reach it without importing this argv entry point — and `./score` is no home for
 // it either, because that module pulls objdiff-wasm and the note above `./rank` is about exactly
 // that edge.
-import { scoreOf } from './score-format';
+import { rankedSummaryLine, scoreOf } from './score-format';
 
 export { scoreOf } from './score-format';
 
@@ -96,15 +96,6 @@ const candCacheLine = (): string => {
         `asmlift: [candcache] ${cacheMismatches()} STORED ANSWER(S) DISAGREED WITH A FRESH COMPILE — ` +
         `the store is serving objects this toolchain no longer produces. See ${MISMATCH_LOG}\n`;
 };
-
-/** A declaration block as stderr lines: rendered, blank lines dropped, each one under the
- *  `asmlift:` prefix that separates this tool's output from the compiler's in a shared log. */
-const indentedDeclarations = (refs: Parameters<typeof renderDeclarations>[0]): string =>
-  renderDeclarations(refs)
-    .split('\n')
-    .filter((l) => l.trim() !== '')
-    .map((l) => `asmlift:   ${l}\n`)
-    .join('');
 
 export { detectName };
 
@@ -236,13 +227,7 @@ function rankedStderr(a: {
   // COUNT is zero there whatever the fan named.
   const assumed = (ranked.best.symbolRefs ?? []).filter((r) => r.synthesized);
   const synthesized = a.selfDeclared ? assumed.length : 0;
-  const declared =
-    synthesized > 0
-      ? `asmlift: [declared] ${synthesized} declaration(s) synthesized from the target asm — no symbol ` +
-        `map knows these names, so the score is about this block plus the source; check it against your ` +
-        `headers:\n` +
-        indentedDeclarations(assumed)
-      : '';
+  const declared = synthesized > 0 ? declaredBlock(assumed) : '';
   // The counts docs/ranked-repro.md requires beside every ranked score, as ONE line that is
   // ALWAYS PRESENT. AN ABSENT LINE IS NOT EVIDENCE: a clean run, a truncated log and a killed
   // run are indistinguishable to a reader counting `[dropped]` lines that are not there, and
@@ -256,11 +241,18 @@ function rankedStderr(a: {
   // indistinguishable from a clean one (provenance.ts). On the same line as the score
   // deliberately: the doc tells readers to quote this one line, so a stamp anywhere else is a
   // stamp nobody pastes.
-  const summary =
-    `asmlift: [ranked] ${ranked.candidates.length} candidate(s) scored, ${ranked.dropped.length} dropped, ` +
-    `${ranked.withheld.length} withheld, ${synthesized} synthesized, ` +
-    `best ${ranked.best.label}: ${scoreOf(ranked.best.score)} ` +
-    `[${a.stamp}]\n`;
+  //
+  // SPELLED IN score-format.ts, not here: the benchmark's `bench fan` prints this same line for
+  // one row, and a second hand-spelling of it had already lost `synthesized` and the stamp — the
+  // two fields that are claims rather than counts.
+  const summary = `${rankedSummaryLine({
+    scored: ranked.candidates.length,
+    dropped: ranked.dropped.length,
+    withheld: ranked.withheld.length,
+    synthesized,
+    best: ranked.best,
+    stamp: a.stamp,
+  })}\n`;
   // …and where the time went, ABOVE the line readers paste, so `[ranked]` and its `[proto]`
   // tail stay adjacent.
   return (

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -48,6 +48,14 @@ import { bakedBuild, sampleSourceTree, sourceStamp } from './provenance';
 // through a dynamic `import()` on the ranked path alone so a plain decompile stays toolchain-light.
 // An `import type` is erased outright and adds no runtime edge.
 import type { RankedResult } from './rank';
+// Re-exported rather than defined here: `scoreOf` is the one renderer for every score any asmlift
+// command prints, and the benchmark's `bench fan` prints the same four lines. A second consumer
+// must be able to reach it without importing this argv entry point — and `./score` is no home for
+// it either, because that module pulls objdiff-wasm and the note above `./rank` is about exactly
+// that edge.
+import { scoreOf } from './score-format';
+
+export { scoreOf } from './score-format';
 
 /** Every status this CLI returns, named. `CACHE_MISMATCH_EXIT` (3) is candcache.ts's and is
  *  imported rather than restated, because the code that DETECTS a mismatch is what should own the
@@ -172,28 +180,6 @@ const isDecline = (e: unknown) => DECLINE_ERRORS.some((c) => e instanceof c);
 export interface ObjInput {
   disasm: typeof disasmObject;
   asmData: typeof asmDataForObject;
-}
-
-/** A score as `<score>/<rows>` — the numerator over the denominator it was measured against.
- *
- *  THE ONE RENDERER FOR EVERY SCORE THIS CLI PRINTS: the `[score]` table, the `[ranked]` line's
- *  `best …`, the `[withheld]` line and the `[progress]` line. A reader comparing two runs cannot
- *  be asked to know which lines carry a denominator.
- *
- *  `rows` is objdiff's total row count for THIS candidate's alignment against the target, so it is
- *  a property of the candidate and not of the target: a different spelling aligns differently and
- *  is scored on a different scale. Two runs' `[score]` lines are the project's standard
- *  before/after comparison (docs/ranked-repro.md), and printing the numerator alone makes that
- *  comparison read as a subtraction on a fixed scale. It is not one — `kleod:CountCollectedGems`
- *  went 290/404 → 171/387 across two committed artifacts, 17 points of which were the scale, and
- *  an attribution round was spent explaining the difference.
- *
- *  Both fields are OPTIONAL, and each absence means one thing. No `rows`: the scorer that produced
- *  this score supplied none (core rank.ts's `WithheldCandidate` types it optional for exactly
- *  that), so the numerator prints alone rather than against an invented denominator — never a `0`,
- *  which would read as a real scale. No `match`: the caller does not know, so nothing is claimed. */
-export function scoreOf(s: { score: number; rows?: number; match?: boolean }): string {
-  return `${s.score}${s.rows === undefined ? '' : `/${s.rows}`}${s.match === true ? ' (match)' : ''}`;
 }
 
 export interface CliResult {

--- a/packages/cli/src/rank.ts
+++ b/packages/cli/src/rank.ts
@@ -65,7 +65,13 @@ const declarationsOf = (cand: Candidate): string | undefined =>
 
 // ONE enumeration for both drivers below: they must rank the same candidate set, or the pooled
 // run would be answering a different question than the serial one.
-const enumerate = (name: string, asm: string, target: TargetDescription, opts: RankOptions): Candidate[] =>
+//
+// EXPORTED because there is now a third caller that must not drift from those two: `bench fan
+// --enumerate` lists a row's fan without compiling anything, and a fan listed by a second mapping
+// of `RankOptions` onto `enumerateCandidates` (forgetting `backend`, say, or `symbols`) would be a
+// different fan wearing the same name — which is the failure docs/ranked-repro.md is entirely
+// about. One function, three callers.
+export const enumerateRanked = (name: string, asm: string, target: TargetDescription, opts: RankOptions): Candidate[] =>
   enumerateCandidates(name, asm, target, {
     patterns: opts.patterns,
     backend: opts.backend ?? cBackend,
@@ -108,7 +114,7 @@ export function decompileRanked(
   opts: RankOptions = {},
 ): RankedResult {
   const backend = opts.backend ?? cBackend;
-  const candidates = timed(opts.clock, 'enumerate', () => enumerate(name, asm, target, opts));
+  const candidates = timed(opts.clock, 'enumerate', () => enumerateRanked(name, asm, target, opts));
   // The compile happens INSIDE scoreSource here, so it is charged from the compiler itself and the
   // `score` frame around the call keeps the rest. The pooled driver awaits the two separately.
   const compile: SyncCompiler | undefined =
@@ -165,7 +171,7 @@ export async function decompileRankedParallel(
   if (clock) {
     clock.workers = Math.max(1, opts.jobs);
   }
-  const candidates = timed(clock, 'enumerate', () => enumerate(name, asm, target, opts));
+  const candidates = timed(clock, 'enumerate', () => enumerateRanked(name, asm, target, opts));
   // keyed by source, which core's enumeration has already deduped on — so it identifies a candidate
   const scored = new Map<string, MatchScore | Error>();
   let next = 0;

--- a/packages/cli/src/score-format.ts
+++ b/packages/cli/src/score-format.ts
@@ -1,0 +1,26 @@
+// The one place a score becomes text. A LEAF module by design: it imports nothing, so every
+// consumer — this CLI's argv entry point, the benchmark's `bench fan` — reaches the renderer
+// without dragging objdiff-wasm (or anything else) in behind it. `main.ts` re-exports it, which is
+// where the offline suite reaches it.
+/** A score as `<score>/<rows>` — the numerator over the denominator it was measured against.
+ *
+ *  THE ONE RENDERER FOR EVERY SCORE ANY asmlift COMMAND PRINTS: the CLI's `[score]` table, the
+ *  `[ranked]` line's `best …`, the `[withheld]` line, the `[progress]` line — and the benchmark's
+ *  `bench fan`, which prints those same four for one row. A reader comparing two runs cannot be
+ *  asked to know which lines carry a denominator, and the harness is where two runs get compared.
+ *
+ *  `rows` is objdiff's total row count for THIS candidate's alignment against the target, so it is
+ *  a property of the candidate and not of the target: a different spelling aligns differently and
+ *  is scored on a different scale. Two runs' `[score]` lines are the project's standard
+ *  before/after comparison (docs/ranked-repro.md), and printing the numerator alone makes that
+ *  comparison read as a subtraction on a fixed scale. It is not one — `kleod:CountCollectedGems`
+ *  went 290/404 → 171/387 across two committed artifacts, 17 points of which were the scale, and
+ *  an attribution round was spent explaining the difference.
+ *
+ *  Both fields are OPTIONAL, and each absence means one thing. No `rows`: the scorer that produced
+ *  this score supplied none (core rank.ts's `WithheldCandidate` types it optional for exactly
+ *  that), so the numerator prints alone rather than against an invented denominator — never a `0`,
+ *  which would read as a real scale. No `match`: the caller does not know, so nothing is claimed. */
+export function scoreOf(s: { score: number; rows?: number; match?: boolean }): string {
+  return `${s.score}${s.rows === undefined ? '' : `/${s.rows}`}${s.match === true ? ' (match)' : ''}`;
+}

--- a/packages/cli/src/score-format.ts
+++ b/packages/cli/src/score-format.ts
@@ -2,10 +2,9 @@
 // paste is spelled. Its consumers today are this CLI's argv entry point and the benchmark's
 // `bench fan`; `main.ts` re-exports `scoreOf`, which is where the offline suite reaches it.
 //
-// It imports nothing, but do not read that as a CONSTRAINT that buys anything today: both current
-// consumers already pull `./score` (and objdiff-wasm behind it) on the line above, so the leafness
-// has no beneficiary yet. What this module owns is the SPELLING — the same line rendered by two
-// commands — and that is the property to preserve when adding to it.
+// It imports nothing, and that leafness buys nothing today: both consumers already pull `./score`
+// (and objdiff-wasm behind it). What this module owns is the SPELLING — the same line rendered by
+// two commands — and that is the property to preserve when adding to it.
 /** A score as `<score>/<rows>` — the numerator over the denominator it was measured against.
  *
  *  THE ONE RENDERER FOR EVERY SCORE ANY asmlift COMMAND PRINTS: the CLI's `[score]` table, the
@@ -33,9 +32,8 @@ export function scoreOf(s: { score: number; rows?: number; match?: boolean }): s
  *  paste as the measurement every later claim is compared against. It lives here, beside `scoreOf`
  *  and in the same leaf module, because it now has TWO producers: the CLI's own ranked run
  *  (`main.ts`) and the benchmark's `bench fan`, which re-enters the harness's ranked call for one
- *  row. A second hand-spelling of it was the actual bug this function replaces — the copy had
- *  dropped `synthesized` and the source stamp, i.e. exactly the two fields that are not counts of
- *  the fan but claims about what the score RESTS ON:
+ *  row. Two fields on it are not counts of the fan but claims about what the score RESTS ON, and
+ *  they are the ones a hand-spelling drops:
  *
  *  - `synthesized` — how many of the winner's declarations asmlift invented from the target's own
  *    asm. Such a declaration is fitted to the bytes it is scored against: it cannot lose score,
@@ -45,9 +43,9 @@ export function scoreOf(s: { score: number; rows?: number; match?: boolean }): s
  *    indistinguishable from a clean one (provenance.ts), and a stamp anywhere but on the pasted
  *    line is a stamp nobody pastes.
  *
- *  Structural parameter types, not the CLI's `RankedResult`: importing that type would make this
- *  module reach `./rank` → `./score` → objdiff-wasm, which is the one thing its leafness buys.
- *  No trailing newline — the caller owns line separation. */
+ *  Structural parameter types, not the CLI's `RankedResult`: the benchmark assembles the same six
+ *  fields from its own row and its own stamp, and neither caller should have to build a
+ *  `RankedResult` to render one line. No trailing newline — the caller owns line separation. */
 export function rankedSummaryLine(a: {
   scored: number;
   dropped: number;

--- a/packages/cli/src/score-format.ts
+++ b/packages/cli/src/score-format.ts
@@ -1,8 +1,11 @@
 // The one place a score becomes text, and the one place the `[ranked]` line a round is told to
-// paste is spelled. A LEAF module by design: it imports nothing, so every consumer — this CLI's
-// argv entry point, the benchmark's `bench fan` — reaches the renderers without dragging
-// objdiff-wasm (or anything else) in behind it. `main.ts` re-exports `scoreOf`, which is where the
-// offline suite reaches it.
+// paste is spelled. Its consumers today are this CLI's argv entry point and the benchmark's
+// `bench fan`; `main.ts` re-exports `scoreOf`, which is where the offline suite reaches it.
+//
+// It imports nothing, but do not read that as a CONSTRAINT that buys anything today: both current
+// consumers already pull `./score` (and objdiff-wasm behind it) on the line above, so the leafness
+// has no beneficiary yet. What this module owns is the SPELLING — the same line rendered by two
+// commands — and that is the property to preserve when adding to it.
 /** A score as `<score>/<rows>` — the numerator over the denominator it was measured against.
  *
  *  THE ONE RENDERER FOR EVERY SCORE ANY asmlift COMMAND PRINTS: the CLI's `[score]` table, the

--- a/packages/cli/src/score-format.ts
+++ b/packages/cli/src/score-format.ts
@@ -1,7 +1,8 @@
-// The one place a score becomes text. A LEAF module by design: it imports nothing, so every
-// consumer — this CLI's argv entry point, the benchmark's `bench fan` — reaches the renderer
-// without dragging objdiff-wasm (or anything else) in behind it. `main.ts` re-exports it, which is
-// where the offline suite reaches it.
+// The one place a score becomes text, and the one place the `[ranked]` line a round is told to
+// paste is spelled. A LEAF module by design: it imports nothing, so every consumer — this CLI's
+// argv entry point, the benchmark's `bench fan` — reaches the renderers without dragging
+// objdiff-wasm (or anything else) in behind it. `main.ts` re-exports `scoreOf`, which is where the
+// offline suite reaches it.
 /** A score as `<score>/<rows>` — the numerator over the denominator it was measured against.
  *
  *  THE ONE RENDERER FOR EVERY SCORE ANY asmlift COMMAND PRINTS: the CLI's `[score]` table, the
@@ -23,4 +24,39 @@
  *  which would read as a real scale. No `match`: the caller does not know, so nothing is claimed. */
 export function scoreOf(s: { score: number; rows?: number; match?: boolean }): string {
   return `${s.score}${s.rows === undefined ? '' : `/${s.rows}`}${s.match === true ? ' (match)' : ''}`;
+}
+
+/** THE `[ranked]` LINE — the one line docs/ranked-repro.md and `.claude/commands/*` tell a round to
+ *  paste as the measurement every later claim is compared against. It lives here, beside `scoreOf`
+ *  and in the same leaf module, because it now has TWO producers: the CLI's own ranked run
+ *  (`main.ts`) and the benchmark's `bench fan`, which re-enters the harness's ranked call for one
+ *  row. A second hand-spelling of it was the actual bug this function replaces — the copy had
+ *  dropped `synthesized` and the source stamp, i.e. exactly the two fields that are not counts of
+ *  the fan but claims about what the score RESTS ON:
+ *
+ *  - `synthesized` — how many of the winner's declarations asmlift invented from the target's own
+ *    asm. Such a declaration is fitted to the bytes it is scored against: it cannot lose score,
+ *    only manufacture agreement, so a `(match)` that depends on one has to say so on the line that
+ *    gets pasted, or the line becomes publishable proof of a match nobody can check.
+ *  - `[stamp]` — WHICH TREE produced the number. A run against different sources is otherwise
+ *    indistinguishable from a clean one (provenance.ts), and a stamp anywhere but on the pasted
+ *    line is a stamp nobody pastes.
+ *
+ *  Structural parameter types, not the CLI's `RankedResult`: importing that type would make this
+ *  module reach `./rank` → `./score` → objdiff-wasm, which is the one thing its leafness buys.
+ *  No trailing newline — the caller owns line separation. */
+export function rankedSummaryLine(a: {
+  scored: number;
+  dropped: number;
+  withheld: number;
+  synthesized: number;
+  best: { label: string; score: { score: number; rows?: number; match?: boolean } };
+  stamp: string;
+}): string {
+  return (
+    `asmlift: [ranked] ${a.scored} candidate(s) scored, ${a.dropped} dropped, ` +
+    `${a.withheld} withheld, ${a.synthesized} synthesized, ` +
+    `best ${a.best.label}: ${scoreOf(a.best.score)} ` +
+    `[${a.stamp}]`
+  );
 }

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -245,9 +245,9 @@ export interface WithheldCandidate {
  *  nothing scored, `dropped` IS the whole fan, and a bare `Error` discards it. A caller that
  *  prints one candidate's failure (the `cause`) is showing the LAST spelling the scorer refused,
  *  which is neither the first nor a representative one — the benchmark's own noncompile rows have
- *  up to a thousand siblings behind that single line. The message is unchanged from the plain
- *  `Error` this replaces: `bench fidelity` matches it verbatim to recognise a reproduced
- *  noncompile row. */
+ *  up to a thousand siblings behind that single line. The MESSAGE is load-bearing and must stay
+ *  byte-identical: `bench fidelity` matches it verbatim to recognise a reproduced noncompile
+ *  row. */
 export class NoScorableCandidateError extends Error {
   readonly dropped: DroppedCandidate[];
   readonly withheld: WithheldCandidate[];
@@ -265,9 +265,8 @@ export class NoScorableCandidateError extends Error {
  *  It is a sibling of `NoScorableCandidateError` and a DIFFERENT fact, which is the whole reason
  *  it is a class: nothing was scored there because nothing COMPILED, and nothing was scored here
  *  because nothing was ever spelled. A surface that cannot tell the two apart prints one of them
- *  under the other's name — `bench fan` shipped a version that guessed from which call site
- *  caught, and reported a declined row as `noncompile`. The message is unchanged from the plain
- *  `Error` this replaces (`packages/core/test/rank-backend-decline.test.ts` matches it). */
+ *  under the other's name. The message is load-bearing too
+ *  (`packages/core/test/rank-backend-decline.test.ts` matches it). */
 export class NoSpellableCandidateError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -239,6 +239,26 @@ export interface WithheldCandidate {
   why: string;
 }
 
+/** EVERY candidate refused — `rankBy` has no ranked result to return, so it throws this.
+ *
+ *  The two lists ride on the error, and that is the point of having a class at all: on a row where
+ *  nothing scored, `dropped` IS the whole fan, and a bare `Error` discards it. A caller that
+ *  prints one candidate's failure (the `cause`) is showing the LAST spelling the scorer refused,
+ *  which is neither the first nor a representative one — the benchmark's own noncompile rows have
+ *  up to a thousand siblings behind that single line. The message is unchanged from the plain
+ *  `Error` this replaces: `bench fidelity` matches it verbatim to recognise a reproduced
+ *  noncompile row. */
+export class NoScorableCandidateError extends Error {
+  readonly dropped: DroppedCandidate[];
+  readonly withheld: WithheldCandidate[];
+  constructor(message: string, dropped: DroppedCandidate[], withheld: WithheldCandidate[], options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'NoScorableCandidateError';
+    this.dropped = dropped;
+    this.withheld = withheld;
+  }
+}
+
 export interface RankedResult<S> {
   best: Scored<S>; // lowest score
   candidates: Scored<S>[]; // sorted best (lowest) first
@@ -1912,7 +1932,9 @@ export function rankBy<S extends { score: number; rows?: number }>(
     // scorer failure, and a list that was entirely proof-gated is a different thing entirely.
     const why =
       lastScoreErr !== null ? firstLine(lastScoreErr) : `${withheld.length} candidate(s) withheld, none scored`;
-    throw new Error(`no scorable candidate for '${symbol}': ${why}`, { cause: lastScoreErr });
+    throw new NoScorableCandidateError(`no scorable candidate for '${symbol}': ${why}`, dropped, withheld, {
+      cause: lastScoreErr,
+    });
   }
   results.sort(compareScored);
   return { best: results[0], candidates: results.map(({ order: _order, ...c }) => c), dropped, withheld };

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -259,6 +259,22 @@ export class NoScorableCandidateError extends Error {
   }
 }
 
+/** EVERY spelling refused BY THE BACKEND, before anything was compiled — `enumerateCandidates`
+ *  has no fan to return, so it throws this.
+ *
+ *  It is a sibling of `NoScorableCandidateError` and a DIFFERENT fact, which is the whole reason
+ *  it is a class: nothing was scored there because nothing COMPILED, and nothing was scored here
+ *  because nothing was ever spelled. A surface that cannot tell the two apart prints one of them
+ *  under the other's name — `bench fan` shipped a version that guessed from which call site
+ *  caught, and reported a declined row as `noncompile`. The message is unchanged from the plain
+ *  `Error` this replaces (`packages/core/test/rank-backend-decline.test.ts` matches it). */
+export class NoSpellableCandidateError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'NoSpellableCandidateError';
+  }
+}
+
 export interface RankedResult<S> {
   best: Scored<S>; // lowest score
   candidates: Scored<S>[]; // sorted best (lowest) first
@@ -1886,9 +1902,10 @@ export function enumerateCandidates(
   // candidate; all of them together is the row, and it stays LOUD — the alternative is a caller
   // ranking an empty list and reporting no match for a function nothing ever tried to spell.
   if (out.length === 0) {
-    throw new Error(`no spellable candidate for '${name}': ${firstLine(lastEmitError ?? 'no candidate produced')}`, {
-      cause: lastEmitError,
-    });
+    throw new NoSpellableCandidateError(
+      `no spellable candidate for '${name}': ${firstLine(lastEmitError ?? 'no candidate produced')}`,
+      { cause: lastEmitError },
+    );
   }
   return out;
 }

--- a/packages/core/test/rank-backend-decline.test.ts
+++ b/packages/core/test/rank-backend-decline.test.ts
@@ -10,7 +10,7 @@ import { expect, test } from 'vitest';
 
 import { cBackend } from '../src/backend/c';
 import type { LanguageBackend } from '../src/l3/ast';
-import { enumerateCandidates } from '../src/rank';
+import { NoScorableCandidateError, NoSpellableCandidateError, enumerateCandidates, rankBy } from '../src/rank';
 import { ARMV4T_AGBCC } from '../src/target';
 
 // `a0 < a1 ? 1 : 0` — a divergent if whose compare the signedness pin casts under the `unsigned`
@@ -57,6 +57,65 @@ test('a backend that refuses every tree fails LOUD, naming the refusal', () => {
   expect(() => enumerateCandidates('f', ASM, ARMV4T_AGBCC, { backend: refusing(/.*/) })).toThrow(
     /no spellable candidate for 'f': refusing backend/,
   );
+});
+
+// …AS ITS OWN CLASS. Nothing scored and nothing SPELLED are different facts about a row, and a
+// surface that cannot separate them prints one under the other's name: `bench fan` shipped a
+// version that guessed from which call site caught and reported a declined row as `noncompile`.
+// The message is asserted here too, because it is the only thing that was pinned before the class
+// existed and it must stay byte-identical.
+test('the total refusal is NoSpellableCandidateError, not a bare Error', () => {
+  let thrown: unknown;
+  try {
+    enumerateCandidates('f', ASM, ARMV4T_AGBCC, { backend: refusing(/.*/) });
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toBeInstanceOf(NoSpellableCandidateError);
+  expect((thrown as Error).message.startsWith("no spellable candidate for 'f': ")).toBe(true);
+  // …and it is NOT the scoring-side sibling, which is the confusion the two classes exist to end.
+  expect(thrown).not.toBeInstanceOf(NoScorableCandidateError);
+});
+
+// THE OTHER HALF: `rankBy`'s throw. Two things ride on it and neither was pinned — `run/fan.ts`
+// reaches the whole fan of a `noncompile` row through `dropped`/`withheld` (there is no ranked
+// result to return, so those lists ARE the fan), and `apps/benchmark/src/run/fidelity.ts` matches
+// this MESSAGE verbatim, alongside `code === 1`, to recognise a reproduced noncompile row. A
+// one-word edit to either would pass every other gate in the repo.
+test('every candidate failing to score throws the class, carrying both refusal lists', () => {
+  const candidates = enumerateCandidates('f', ASM, ARMV4T_AGBCC).slice(0, 3);
+  let thrown: unknown;
+  try {
+    rankBy(candidates, 'f', () => {
+      throw new Error('agbcc failed: c.c:1: parse error');
+    });
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toBeInstanceOf(NoScorableCandidateError);
+  const e = thrown as NoScorableCandidateError;
+  expect(e.message.startsWith("no scorable candidate for 'f': ")).toBe(true);
+  expect(e.dropped.map((d) => d.label)).toEqual(candidates.map((c) => c.label));
+  expect(e.withheld).toEqual([]);
+});
+
+// The all-WITHHELD branch: nothing threw, so there is no `cause` to quote and the count is the
+// only fact there is. `bench fan` prints these lines as the fan too.
+test('an entirely withheld fan throws the same class, with the withheld list on it', () => {
+  const candidates = enumerateCandidates('f', ASM, ARMV4T_AGBCC)
+    .slice(0, 2)
+    .map((c) => ({ ...c, matchOnly: true as const }));
+  let thrown: unknown;
+  try {
+    rankBy(candidates, 'f', () => ({ score: 7, rows: 12 }));
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toBeInstanceOf(NoScorableCandidateError);
+  const e = thrown as NoScorableCandidateError;
+  expect(e.dropped).toEqual([]);
+  expect(e.withheld.map((w) => w.label)).toEqual(candidates.map((c) => c.label));
+  expect(e.message).toContain('2 candidate(s) withheld, none scored');
 });
 
 // …AND IT MUST SAY WHICH SPELLING IT REFUSED. The PRE-FAN products (rank.ts PRE_FAN_PRODUCTS)

--- a/packages/core/test/rank-backend-decline.test.ts
+++ b/packages/core/test/rank-backend-decline.test.ts
@@ -60,10 +60,8 @@ test('a backend that refuses every tree fails LOUD, naming the refusal', () => {
 });
 
 // …AS ITS OWN CLASS. Nothing scored and nothing SPELLED are different facts about a row, and a
-// surface that cannot separate them prints one under the other's name: `bench fan` shipped a
-// version that guessed from which call site caught and reported a declined row as `noncompile`.
-// The message is asserted here too, because it is the only thing that was pinned before the class
-// existed and it must stay byte-identical.
+// surface that cannot separate them prints one under the other's name. The message is asserted
+// here too: it must stay byte-identical, because surfaces match it.
 test('the total refusal is NoSpellableCandidateError, not a bare Error', () => {
   let thrown: unknown;
   try {
@@ -77,11 +75,11 @@ test('the total refusal is NoSpellableCandidateError, not a bare Error', () => {
   expect(thrown).not.toBeInstanceOf(NoScorableCandidateError);
 });
 
-// THE OTHER HALF: `rankBy`'s throw. Two things ride on it and neither was pinned — `run/fan.ts`
-// reaches the whole fan of a `noncompile` row through `dropped`/`withheld` (there is no ranked
-// result to return, so those lists ARE the fan), and `apps/benchmark/src/run/fidelity.ts` matches
-// this MESSAGE verbatim, alongside `code === 1`, to recognise a reproduced noncompile row. A
-// one-word edit to either would pass every other gate in the repo.
+// THE OTHER HALF: `rankBy`'s throw. Two things ride on it — `run/fan.ts` reaches the whole fan of a
+// `noncompile` row through `dropped`/`withheld` (there is no ranked result to return, so those
+// lists ARE the fan), and `apps/benchmark/src/run/fidelity.ts` matches this MESSAGE verbatim,
+// alongside `code === 1`, to recognise a reproduced noncompile row. A one-word edit to either would
+// pass every other gate in the repo.
 test('every candidate failing to score throws the class, carrying both refusal lists', () => {
   const candidates = enumerateCandidates('f', ASM, ARMV4T_AGBCC).slice(0, 3);
   let thrown: unknown;


### PR DESCRIPTION
`pnpm bench fan <row>` prints the ranked candidate fan the harness already computes for one row
and then throws away. `eval/asmlift.ts` calls `decompileRanked`, publishes four facts out of the
result — the winner's label, the winner's source, the dropped list, the withheld list — and drops
`RankedResult.candidates`, where every OTHER spelling carries its own label, its own score and the
exact C it was scored from. This is the supported way to read them, taking a row id, in the
harness's own configuration.

```
pnpm bench fan <sym|project:sym:toolchain> [--show <label>] [--enumerate] [--force]
```

## What of the premise held, and what did not

| claim the item rested on | verdict, measured |
| --- | --- |
| `eval/asmlift.ts` never reads `ranked.candidates` | **TRUE** |
| the score TABLE was unobtainable | **FALSE, and stated so.** `pnpm asmlift --score-against` has printed `[score]` for every candidate all along, and `bench repro --run` reaches it for a row. What was genuinely unreachable is a NON-WINNER'S SOURCE (`results.json` carries the winner's C and no other's), row-scoped access in the harness's own configuration, a fan listed without compiling, and the `[lever] … threw` channel that `cli/rank.ts` itself says `bench run` has no sink for |
| the fan is reachable without re-enumerating | **FALSE and irrelevant** — nothing caches a fan, so any consumer re-enumerates. It is reachable from the harness's own case set in ~9 s for a small row, which was the test that mattered |
| `RankOptions.onProgress`'s third argument is a `number` | **FALSE on main** — it is a `MatchScore`. The first draft printed `[object Object]` |
| `cli.ts`'s subcommand list in the brief | **stale** — `repro` and `baseline` were already there |

## Commits

- `a75eecd9` — move `scoreOf` out of the argv entry point into the leaf `packages/cli/src/score-format.ts`. Necessary: `main.ts` keeps `./rank` type-only on purpose and `./score` pulls objdiff-wasm, so neither could host it for a second consumer.
- `a1d2b139` — export `cli/rank.ts`'s private `enumerate` as `enumerateRanked`; the two ranking drivers already shared it and `--enumerate` is the third caller.
- `e33417db` — extract `rankOptionsFor()` + `asmliftFan()` from `runAsmlift`. Pure refactor, same object, same call.
- `71b2dd3c` — `apps/benchmark/src/run/fan.ts`, the `cli.ts` dispatch, `apps/benchmark/test/fan.test.ts`.
- `f1ef6fcf` — wire it where it will be read: `docs/ranked-repro.md`, `.claude/commands/match-function.md` (Phase 1, where capability-vs-lever is decided) and `attribute-function.md` (Phase 0, next to the baseline). The mining round's standing warning is that a surface named nowhere earns `bench target`'s 6 calls against `bench run`'s 594.
- `2a317b3b` — one renderer each for the `[ranked]` line and the `[declared]` block, so the fan cannot describe a synthesized declaration in different words than the command whose numbers it reproduces.
- `1d04332e` — `NoScorableCandidateError` carries `dropped`/`withheld`, so a row where every candidate was refused does not lose its whole fan with the stack frame.
- `8c9e5f86` — answer a row that has no fan instead of crashing on it: exit 2 and a sentence.
- `71c61811` — price the refusal from a measurement rather than a hunch.
- `c39ff683` — `NoSpellableCandidateError` as a sibling class, and `isDecline` moved to `packages/cli/src/decline.ts` because two surfaces now have to agree about it.
- `4a2454fb` — the playground's drop list survives a total ranking failure.
- `9c5c591b` — per-TIER scoring rate; the real tier is ~40% more expensive per candidate than the synthetic one.
- `48c5f78c` — comment audit.
- `4acee237` — the artifact re-stamp (below).

## Bench: needed, run, and it moved nothing

The branch touches `packages/core/src`, `packages/cli/src` and `apps/benchmark/src`, three of the
five paths `scripts/check-artifact-provenance.sh` measures, so a full run was owed.

```
✓ synthetic: 783 results in 454.1s
✓ real:      252 results in 2491.7s
bench regression --base origin/main:  0 lost, 0 missing, 0 gained, 0 other flips (1035 rows)
bench diff --base origin/main:        0 field change(s), 0 added, 0 removed (1035 / 1035)
```

**Zero rows moved, and zero FIELDS moved** — source bytes included. asmlift 598, m2c 412,
unchanged. The artifact commit therefore changes exactly two lines per file: `generatedAt` and the
asmlift commit sha. That is the expected result: every touched line on a measured path is inert
there — two `Error` subclasses whose messages are byte-identical to the `Error` each replaces (and
`eval/outcome.ts` classifies from message TEXT, not class; there is no `instanceof` anywhere on the
classification path), a regex extracted into `asm-scrub.ts` with one spelling for its three
callers, a const moved between modules, a return-type annotation, and a subcommand nothing else
calls.

## The scope guard, set from a measurement

`FAN_SCORE_LIMIT = 2000`. `synthetic:sizebound:agbcc` enumerates 800 and scores them in **48 s
cold** (10 s warm), so the limit is about two minutes; `kleod:CountCollectedGems:agbcc`'s 5,952 is
~8 min and worth `--force`; `LoadBGTilemapData`'s 225,792 is over five hours and is refused with
`--enumerate` named as the way out. **The LBG ranked run was never started.** The rate is per tier
(60 ms synthetic, 85 ms real) because a real candidate escalates through up to three preludes in
`makeRealCompile` where a synthetic one is a single small prelude — one rate under-priced the real
tier by ~35%, on the exact row the refusal quotes.

## Reviewer findings, all confirmed by re-running before touching

Two review waves, four reviewers. **Nothing was declined as wrong.** The load-bearing ones:

- **BLOCKER** — the command died with a Node stack trace on every declined and every noncompile
  row (237 of 1,035). Now exit 2 and a sentence chosen **by the error class**, never by which call
  site caught it: `--force` skips the guarded pre-count enumeration, so a declined row's lift error
  arrives at the SCORING catch, where a call-site guess called it `noncompile` — and both briefs
  tell a round to pass `--force`.
- **`--enumerate --show best`** named a near-worst candidate under the winner's name
  (`unsigned` where the real best was `signed/expr-home/uns-cmp/livebase-block/volatile/initfirst/pollread`).
  Refused now, and refused before the row is built.
- **the refusal's price was wrong by ~20×**, then ~40% low again on the real tier. Both corrected
  from cold runs with `ASMLIFT_CANDCACHE=0`, and the doc-comment claim that 60 ms was "the
  pessimistic end" is deleted because it was false.
- **the blocker fix was untested in both halves** — now 7 tests over the pure `noFanReport` and 3
  core tests over `rankBy`'s throw, including the verbatim message prefix `run/fidelity.ts:208`
  matches to recognise a reproduced noncompile row.
- **`--show` was silently dropped** on the one row class where every candidate is unshowable.
- **`rankOptionsFor` had no return annotation** — verified: `symbolz: 1` typechecks clean
  unannotated, on `main` too. A mistyped option is a dropped one, and a dropped `symbols` is the
  112,896-vs-135,936 discrepancy class `docs/ranked-repro.md` is about.
- **the fix landed in one of the two `rankBy`s** — the webapp's worker forwards `err.message` only
  and a `structuredClone` would drop subclass fields anyway, so the worker folds the counts and the
  first three labels into the message.

Also found while fixing theirs: `attribute-function.md` quoted the old message **verbatim**, which
this change would have made stale — the exact failure mode one file over. Both briefs now state the
rule (the sentence is chosen by the error) rather than a string.

The comment audit deleted two **false** comments the branch had shipped: a claim that a `RankedResult`
type import would add a runtime edge (an `import type` is erased, and the same file's header says so),
and a claim about unreachable `break`s contradicted by two sibling cases in the same switch. It also
cut an unsourceable "~82,756 candidates" figure and every sentence narrating the branch's own review
rounds.

## Declined, with reasons

1. **A counted/capped enumeration in core**, so the >2,000 guard need not pay a full enumeration
   (marked optional by its reviewer). `enumerateCandidates` builds the product eagerly, and a cap
   changes what a "fan" IS for every caller — a new way for `bench fan` to disagree with `bench run`
   about the fan, which is the one property this command exists to have. The doc fix delivers the
   same information at zero risk.
2. **An exact `selfDeclared()` probe** for the synthesized count. Reaching it means changing
   `benchCompilerFor` to return the whole compilers object rather than `.compile`, touching the
   harness's scoring path for a diagnostic line. The tier rule is exact on the real tier and
   over-reports at worst on the synthetic one — wrong in the safe direction, and its doc-comment
   says which.
3. **Inlining `asmliftFan`** (marked "marginal either way"). It is the named seam that says the fan
   goes through the harness's OWN driver and not the parallel one; inlining makes it one edit easier
   for a later round to reach for `decompileRanked` directly.

## What this does NOT do

Not a tier-wide form — the question is always about one function, and a tier-wide fan would write
tens of thousands of sources. Not a cache: nothing stores a fan, so every call re-enumerates. Not a
replacement for `bench repro`, which re-runs the row's published SCRIPT; this opens the ranking that
script's one line summarises. It does not give a DECLINED row a fan — enumeration has no annotate
mode, so it throws on the same gap the row declines on, and the command reports that as the finding
it is. And `--enumerate` is cheap against compiling, not cheap absolutely: ~120 candidates/s, so the
biggest fans take minutes to merely list.

## Gate

- `pnpm bench run` — `✓ synthetic 783 / ✓ real 252`, exit 0 · `bench:merge` 1035 rows ·
  regression **0/0/0/0** · diff **0 field changes** · `check-artifact-provenance.sh` **OK**
- `npx vitest run` — **215 files / 3785 tests pass**. The first invocation had one flake
  (`mwcceppc (docker) failed: syntax error` on `synthetic:ghost:mwcc_242_81`, docker contention
  immediately after the bench); a clean re-run is green.
- `pnpm test:matching` — **41 files / 359 tests pass** (the gate CI structurally cannot run)
- `pnpm exec vitest run apps/benchmark/test` — **35 files / 859 tests pass** (the CI-only mirror gate)
- `pnpm typecheck` clean · `pnpm lint` **0 errors** (126 warnings, none in a file this branch
  touches) · `pnpm format` clean

Base did not move: `origin/main` was already this branch's merge base (`83279138`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
