### PR TITLE
Record a bench run while it works, so a tree edit cannot silently void it

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -289,6 +289,17 @@ phase whose other work does not depend on its answer, and read the log at the en
 until grep -q 'EXIT=' /tmp/<round>-bench.log; do sleep 30; done
 ```
 
+**What you keep working ON is constrained, and it is now checkable.** `provenance.ts` samples git
+DURING the run and the sample is STICKY, so ONE edit — a comment audit, a `pnpm format`, an editor
+save — stamps the whole run dirty and `bench:merge` throws the numbers away 39 minutes later. A
+round lost **2,420 s** to exactly that, auditing its comments beside its own gate bench. So a run in
+flight holds `bench-running` at the repo root, and **`pnpm bench lock` exits 1 while it does**,
+naming the pid, the argv and the elapsed time. Run it before any phase that EDITS the tree; the
+work this background pattern is for is read-only — reading the diff, grepping the corpus, running
+the unit tests, drafting the report. The marker is gitignored (so it cannot dirty the run itself),
+removed on exit and on Ctrl-C, and reads as STALE from its own pid if the run was SIGKILLed: a stale
+marker blocks nothing, and `rm bench-running` is the whole cure.
+
 **Wait on a log marker, never on `pgrep -f "<pattern>"`** when the pattern also matches your own
 waiting shell — five waiter shells once deadlocked on each other for eight hours doing exactly
 that, long after the jobs they watched had finished.
@@ -296,7 +307,9 @@ that, long after the jobs they watched had finished.
 **Two full benches must never overlap on this machine.** It has 10 cores, the run fans 8 shards,
 and a ranked run takes `--jobs 6`; a bench measured **2704 s against a neighbour versus 1800 s
 solo**. Worse than slow: a shard killed by a neighbour writes a partial tier with **no error line**,
-and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line.
+and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. `bench run` now refuses a
+second run **in the same worktree** — both write `results/<tier>.json` — but that marker is
+per-worktree and says nothing about the neighbour: across worktrees this is still discipline.
 
 ---
 

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -304,7 +304,11 @@ auditing its comments beside its own gate bench. So a run in flight records itse
 `/tmp/asmlift-bench-running-<uid>/<pid>.json`. **Run `pnpm bench in-flight` before any phase that
 EDITS the tree, and read its exit code: 1 means a run is measuring this worktree — wait for its
 `EXIT=` line — and 0 means the tree is yours.** The work this background pattern is for is
-read-only: reading the diff, grepping the corpus, running the unit tests, drafting the report. A
+read-only: reading the diff, grepping the corpus, drafting the report. **The unit suites are NOT**
+— `packages/cli/test/offline/provenance.test.ts` writes an untracked `__provenance-probe__/` into
+`packages/` for the length of one test (it has to: it is asserting that the sampler can tell three
+dirty states apart), and a bench that samples inside that window is stamped dirty for good. Measured
+on this branch's own gate run. Run the suites before the bench or after it, not beside it. A
 run that was killed leaves its record behind and it reads STALE — that blocks nothing, and the next
 run sweeps it.
 

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -174,7 +174,7 @@ exclusions) get written down for their own future family, not smuggled into this
 ## Phase 6 — Author the rows
 
 This phase writes into `apps/benchmark/dataset`, one of the five paths
-`scripts/check-artifact-provenance.sh` measures, so **run `pnpm bench lock` first**: exit 1 means a
+`scripts/check-artifact-provenance.sh` measures, so **run `pnpm bench in-flight` first**: exit 1 means a
 bench is measuring this worktree, and one save stamps its whole run dirty (the sampler is sticky) —
 wait for that run's `EXIT=` line. A round paid 2,420 s for editing beside its own gate bench.
 
@@ -236,7 +236,9 @@ attribution line for every decline naming its first blocker. Constraints learned
    attribution signal, not your shell: the preflight has already ruled that out.**
 2. Expect the two tag-vocabulary tests to fail BETWEEN adding the tag and merging the artifacts;
    they must pass after. `npx vitest run`, `pnpm test:matching`, `pnpm typecheck`,
-   `pnpm lint`, `pnpm format` check.
+   `pnpm lint`, `pnpm format` check. **`pnpm format` is `prettier --write .`, a tree WRITE**, and
+   step 1 above is a 35-minute bench you were told to background — a mid-run sweep is exactly the
+   2,420 s incident. `pnpm bench in-flight` first: exit 1 means wait.
 3. Artifacts (`apps/benchmark/results/results.json`, both web copies) regenerated at the source
    commit's HEAD (`meta.asmlift.dirty` must be false) and committed separately — **after** your
    final rebase, as the last commit. A rebase rewrites the commit the artifact's stamp names, and
@@ -298,14 +300,20 @@ until grep -q 'EXIT=' /tmp/<round>-bench.log; do sleep 30; done
 DURING the run and the sample is STICKY, so ONE edit — a comment audit, a `pnpm format`, an editor
 save — stamps the whole run dirty and `bench:merge` throws the numbers away 39 minutes later. A
 round lost **2,420 s** to exactly that, auditing its comments beside its own gate bench. So a run in
-flight records itself in `bench-running/<pid>.json` at the repo root. **Run `pnpm bench lock`
-before any phase that EDITS the tree, and read its exit code: 1 means a run is in flight — wait for
-its `EXIT=` line — and 0 means the tree is yours.** The refusal names the pid, the argv and the
-elapsed time. The work this background pattern is for is read-only — reading the diff, grepping the
-corpus, running the unit tests, drafting the report. The records are gitignored (so they cannot
-dirty the run itself) and removed when the run exits; a run that dies without getting there leaves
-its record behind, and that record reads as STALE from its dead pid: stale blocks nothing, the next
-run sweeps it, and `rm bench-running/<pid>.json` clears it now.
+flight records itself, in `/tmp/asmlift-bench-running-<uid>/<pid>.json`. **Run `pnpm bench in-flight`
+before any phase that EDITS the tree, and read its exit code: 1 means a run is measuring this
+worktree — wait for its `EXIT=` line — and 0 means the tree is yours.** The refusal names the pid,
+the argv and the elapsed time. The work this background pattern is for is read-only — reading the
+diff, grepping the corpus, running the unit tests, drafting the report. The register lives outside
+every worktree, so it can never dirty the run itself; records are removed when the run exits, and a
+run that dies without getting there leaves its record behind, reading STALE from its dead pid:
+stale blocks nothing, the next run sweeps it, and `rm /tmp/asmlift-bench-running-<uid>/<pid>.json`
+clears it now.
+
+**If you edit anyway, the run says so within ~2 s** — `[provenance] THE TREE WENT DIRTY MID-RUN`,
+on the run's own stderr, once, naming the paths. That line means the run is already lost: the
+sample is sticky and reverting does not undo it. Stop it, revert or commit, start it again. Do not
+read it as a warning to be careful for the rest of the run.
 
 **`kill -TERM` does not stop a `bench run`** — measured: one sent SIGTERM 6 s in ran all 291 cases
 and REWROTE `results/synthetic.json` before exiting 143. A run is blocked in `spawnSync` for every
@@ -319,11 +327,14 @@ that, long after the jobs they watched had finished.
 **Two full benches must never overlap on this machine.** It has 10 cores, the run fans 8 shards,
 and a ranked run takes `--jobs 6`; a bench measured **2704 s against a neighbour versus 1800 s
 solo**. Worse than slow: a shard killed by a neighbour writes a partial tier with **no error line**,
-and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. `bench run` now refuses a
-second run **in the same worktree that writes a tier file the live one is writing** — a scoped
-`--tier synthetic --only <sym>` beside a background `--tier real` is not refused, because they
-touch different files. That marker is per-worktree and says nothing about the neighbour: across
-worktrees this is still discipline.
+and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. **`bench run` now
+enforces this**: the register is machine-wide, so a second FULL bench is refused while one is
+running in ANY worktree, and a second run in THIS worktree is refused when it writes a tier file
+the live one is writing. What is still allowed is the scoped dev loop — a `--tier synthetic --only
+<sym>` probe beside a background `--tier real`, here or beside a neighbour's full bench — because a
+15 s probe is not what fans 8 shards. If you have a real reason to measure anyway, `--no-lock` says
+so out loud and leaves every other record alone; **never `rm` a record you did not write**, which
+is the one move that silently unprotects someone else's run.
 
 ---
 

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -173,10 +173,10 @@ exclusions) get written down for their own future family, not smuggled into this
 
 ## Phase 6 — Author the rows
 
-This phase writes into `apps/benchmark/dataset`, one of the five paths
-`scripts/check-artifact-provenance.sh` measures, so **run `pnpm bench in-flight` first**: exit 1 means a
-bench is measuring this worktree, and one save stamps its whole run dirty (the sampler is sticky) —
-wait for that run's `EXIT=` line. A round paid 2,420 s for editing beside its own gate bench.
+This phase writes files, and the mid-run provenance sampler counts every path but the benchmark's
+own regenerated artifacts — so **run `pnpm bench in-flight` first**: exit 1 means a bench is
+measuring this worktree and one save stamps its whole run dirty, stickily. Wait for that run's
+`EXIT=` line.
 
 One family, one block comment, modeled on the existing families in `dataset/synthetic.ts` (the
 uninit-local block is the reference): what each row isolates, which are controls, and an
@@ -237,8 +237,8 @@ attribution line for every decline naming its first blocker. Constraints learned
 2. Expect the two tag-vocabulary tests to fail BETWEEN adding the tag and merging the artifacts;
    they must pass after. `npx vitest run`, `pnpm test:matching`, `pnpm typecheck`,
    `pnpm lint`, `pnpm format` check. **`pnpm format` is `prettier --write .`, a tree WRITE**, and
-   step 1 above is a 35-minute bench you were told to background — a mid-run sweep is exactly the
-   2,420 s incident. `pnpm bench in-flight` first: exit 1 means wait.
+   step 1 above is a bench you were told to background: `pnpm bench in-flight` first, exit 1 means
+   wait.
 3. Artifacts (`apps/benchmark/results/results.json`, both web copies) regenerated at the source
    commit's HEAD (`meta.asmlift.dirty` must be false) and committed separately — **after** your
    final rebase, as the last commit. A rebase rewrites the commit the artifact's stamp names, and
@@ -296,24 +296,21 @@ phase whose other work does not depend on its answer, and read the log at the en
 until grep -q 'EXIT=' /tmp/<round>-bench.log; do sleep 30; done
 ```
 
-**What you keep working ON is constrained, and it is now checkable.** `provenance.ts` samples git
+**What you keep working ON is constrained, and it is checkable.** `provenance.ts` samples git
 DURING the run and the sample is STICKY, so ONE edit — a comment audit, a `pnpm format`, an editor
-save — stamps the whole run dirty and `bench:merge` throws the numbers away 39 minutes later. A
-round lost **2,420 s** to exactly that, auditing its comments beside its own gate bench. So a run in
-flight records itself, in `/tmp/asmlift-bench-running-<uid>/<pid>.json`. **Run `pnpm bench in-flight`
-before any phase that EDITS the tree, and read its exit code: 1 means a run is measuring this
-worktree — wait for its `EXIT=` line — and 0 means the tree is yours.** The refusal names the pid,
-the argv and the elapsed time. The work this background pattern is for is read-only — reading the
-diff, grepping the corpus, running the unit tests, drafting the report. The register lives outside
-every worktree, so it can never dirty the run itself; records are removed when the run exits, and a
-run that dies without getting there leaves its record behind, reading STALE from its dead pid:
-stale blocks nothing, the next run sweeps it, and `rm /tmp/asmlift-bench-running-<uid>/<pid>.json`
-clears it now.
+save, anywhere but the benchmark's own regenerated artifacts — stamps the whole run dirty and
+`bench:merge` throws the numbers away 39 minutes later. A round lost **2,420 s** to exactly that,
+auditing its comments beside its own gate bench. So a run in flight records itself, in
+`/tmp/asmlift-bench-running-<uid>/<pid>.json`. **Run `pnpm bench in-flight` before any phase that
+EDITS the tree, and read its exit code: 1 means a run is measuring this worktree — wait for its
+`EXIT=` line — and 0 means the tree is yours.** The work this background pattern is for is
+read-only: reading the diff, grepping the corpus, running the unit tests, drafting the report. A
+run that was killed leaves its record behind and it reads STALE — that blocks nothing, and the next
+run sweeps it.
 
 **If you edit anyway, the run says so within ~2 s** — `[provenance] THE TREE WENT DIRTY MID-RUN`,
 on the run's own stderr, once, naming the paths. That line means the run is already lost: the
-sample is sticky and reverting does not undo it. Stop it, revert or commit, start it again. Do not
-read it as a warning to be careful for the rest of the run.
+sample is sticky and reverting does not undo it. Stop it, revert or commit, start it again.
 
 **`kill -TERM` does not stop a `bench run`** — measured: one sent SIGTERM 6 s in ran all 291 cases
 and REWROTE `results/synthetic.json` before exiting 143. A run is blocked in `spawnSync` for every
@@ -327,7 +324,7 @@ that, long after the jobs they watched had finished.
 **Two full benches must never overlap on this machine.** It has 10 cores, the run fans 8 shards,
 and a ranked run takes `--jobs 6`; a bench measured **2704 s against a neighbour versus 1800 s
 solo**. Worse than slow: a shard killed by a neighbour writes a partial tier with **no error line**,
-and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. **`bench run` now
+and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. **`bench run`
 enforces this**: the register is machine-wide, so a second FULL bench is refused while one is
 running in ANY worktree, and a second run in THIS worktree is refused when it writes a tier file
 the live one is writing. What is still allowed is the scoped dev loop — a `--tier synthetic --only

--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -173,6 +173,11 @@ exclusions) get written down for their own future family, not smuggled into this
 
 ## Phase 6 — Author the rows
 
+This phase writes into `apps/benchmark/dataset`, one of the five paths
+`scripts/check-artifact-provenance.sh` measures, so **run `pnpm bench lock` first**: exit 1 means a
+bench is measuring this worktree, and one save stamps its whole run dirty (the sampler is sticky) —
+wait for that run's `EXIT=` line. A round paid 2,420 s for editing beside its own gate bench.
+
 One family, one block comment, modeled on the existing families in `dataset/synthetic.ts` (the
 uninit-local block is the reference): what each row isolates, which are controls, and an
 attribution line for every decline naming its first blocker. Constraints learned the hard way:
@@ -293,12 +298,19 @@ until grep -q 'EXIT=' /tmp/<round>-bench.log; do sleep 30; done
 DURING the run and the sample is STICKY, so ONE edit — a comment audit, a `pnpm format`, an editor
 save — stamps the whole run dirty and `bench:merge` throws the numbers away 39 minutes later. A
 round lost **2,420 s** to exactly that, auditing its comments beside its own gate bench. So a run in
-flight holds `bench-running` at the repo root, and **`pnpm bench lock` exits 1 while it does**,
-naming the pid, the argv and the elapsed time. Run it before any phase that EDITS the tree; the
-work this background pattern is for is read-only — reading the diff, grepping the corpus, running
-the unit tests, drafting the report. The marker is gitignored (so it cannot dirty the run itself),
-removed on exit and on Ctrl-C, and reads as STALE from its own pid if the run was SIGKILLed: a stale
-marker blocks nothing, and `rm bench-running` is the whole cure.
+flight records itself in `bench-running/<pid>.json` at the repo root. **Run `pnpm bench lock`
+before any phase that EDITS the tree, and read its exit code: 1 means a run is in flight — wait for
+its `EXIT=` line — and 0 means the tree is yours.** The refusal names the pid, the argv and the
+elapsed time. The work this background pattern is for is read-only — reading the diff, grepping the
+corpus, running the unit tests, drafting the report. The records are gitignored (so they cannot
+dirty the run itself) and removed when the run exits; a run that dies without getting there leaves
+its record behind, and that record reads as STALE from its dead pid: stale blocks nothing, the next
+run sweeps it, and `rm bench-running/<pid>.json` clears it now.
+
+**`kill -TERM` does not stop a `bench run`** — measured: one sent SIGTERM 6 s in ran all 291 cases
+and REWROTE `results/synthetic.json` before exiting 143. A run is blocked in `spawnSync` for every
+case, so no signal handler can run until it is done. `kill -9` is the stop that works, and the
+record it strands is stale.
 
 **Wait on a log marker, never on `pgrep -f "<pattern>"`** when the pattern also matches your own
 waiting shell — five waiter shells once deadlocked on each other for eight hours doing exactly
@@ -308,8 +320,10 @@ that, long after the jobs they watched had finished.
 and a ranked run takes `--jobs 6`; a bench measured **2704 s against a neighbour versus 1800 s
 solo**. Worse than slow: a shard killed by a neighbour writes a partial tier with **no error line**,
 and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. `bench run` now refuses a
-second run **in the same worktree** — both write `results/<tier>.json` — but that marker is
-per-worktree and says nothing about the neighbour: across worktrees this is still discipline.
+second run **in the same worktree that writes a tier file the live one is writing** — a scoped
+`--tier synthetic --only <sym>` beside a background `--tier real` is not refused, because they
+touch different files. That marker is per-worktree and says nothing about the neighbour: across
+worktrees this is still discipline.
 
 ---
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -361,7 +361,11 @@ auditing its comments beside its own gate bench. So a run in flight records itse
 `/tmp/asmlift-bench-running-<uid>/<pid>.json`. **Run `pnpm bench in-flight` before any phase that
 EDITS the tree, and read its exit code: 1 means a run is measuring this worktree — wait for its
 `EXIT=` line — and 0 means the tree is yours.** The work this background pattern is for is
-read-only: reading the diff, grepping the corpus, running the unit tests, drafting the report. A
+read-only: reading the diff, grepping the corpus, drafting the report. **The unit suites are NOT**
+— `packages/cli/test/offline/provenance.test.ts` writes an untracked `__provenance-probe__/` into
+`packages/` for the length of one test (it has to: it is asserting that the sampler can tell three
+dirty states apart), and a bench that samples inside that window is stamped dirty for good. Measured
+on this branch's own gate run. Run the suites before the bench or after it, not beside it. A
 run that was killed leaves its record behind and it reads STALE — that blocks nothing, and the next
 run sweeps it.
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -277,7 +277,9 @@ on the corpus. A finding already triaged is not a new finding unless it falsifie
 ## Phase 6 — Audit the commentary you introduced
 
 Do this AFTER the adversarial rounds, never before: remediation rewrites code, and a comment
-written for the first version is the likeliest thing in the diff to have become false.
+written for the first version is the likeliest thing in the diff to have become false. And **not
+while a bench is in flight** — this phase rewrites files across the whole diff, the mid-run sampler
+is sticky, and a round paid 2,420 s for the pair. `pnpm bench lock` answers it in a second.
 
 Inventory first — `git diff main HEAD`, added lines matching `^\+\s*(//|/\*|\*)`, counted per
 file. That number is the budget you are arguing about; core already runs ~31% comments.
@@ -349,6 +351,17 @@ phase whose other work does not depend on its answer, and read the log at the en
 until grep -q 'EXIT=' /tmp/<round>-bench.log; do sleep 30; done
 ```
 
+**What you keep working ON is constrained, and it is now checkable.** `provenance.ts` samples git
+DURING the run and the sample is STICKY, so ONE edit — a comment audit, a `pnpm format`, an editor
+save — stamps the whole run dirty and `bench:merge` throws the numbers away 39 minutes later. A
+round lost **2,420 s** to exactly that, auditing its comments beside its own gate bench. So a run in
+flight holds `bench-running` at the repo root, and **`pnpm bench lock` exits 1 while it does**,
+naming the pid, the argv and the elapsed time. Run it before any phase that EDITS the tree; the
+work this background pattern is for is read-only — reading the diff, grepping the corpus, running
+the unit tests, drafting the report. The marker is gitignored (so it cannot dirty the run itself),
+removed on exit and on Ctrl-C, and reads as STALE from its own pid if the run was SIGKILLed: a stale
+marker blocks nothing, and `rm bench-running` is the whole cure.
+
 **Wait on a log marker, never on `pgrep -f "<pattern>"`** when the pattern also matches your own
 waiting shell — five waiter shells once deadlocked on each other for eight hours doing exactly
 that, long after the jobs they watched had finished.
@@ -356,7 +369,9 @@ that, long after the jobs they watched had finished.
 **Two full benches must never overlap on this machine.** It has 10 cores, the run fans 8 shards,
 and a ranked run takes `--jobs 6`; a bench measured **2704 s against a neighbour versus 1800 s
 solo**. Worse than slow: a shard killed by a neighbour writes a partial tier with **no error line**,
-and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line.
+and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. `bench run` now refuses a
+second run **in the same worktree** — both write `results/<tier>.json` — but that marker is
+per-worktree and says nothing about the neighbour: across worktrees this is still discipline.
 
 ---
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -279,7 +279,7 @@ on the corpus. A finding already triaged is not a new finding unless it falsifie
 Do this AFTER the adversarial rounds, never before: remediation rewrites code, and a comment
 written for the first version is the likeliest thing in the diff to have become false. And **not
 while a bench is in flight** — this phase rewrites files across the whole diff, the mid-run sampler
-is sticky, and a round paid 2,420 s for the pair. **Run `pnpm bench lock` first**: exit 1 means a
+is sticky, and a round paid 2,420 s for the pair. **Run `pnpm bench in-flight` first**: exit 1 means a
 run is measuring this worktree, so wait for its `EXIT=` line before you touch a file.
 
 Inventory first — `git diff main HEAD`, added lines matching `^\+\s*(//|/\*|\*)`, counted per
@@ -304,7 +304,8 @@ Then, over every comment you added or changed, **tests included**:
 Keep the refusal conditions, and any *why* not derivable from the code: a compiler behaviour, a
 shape the IR cannot represent, why an absence is deliberate.
 
-Finish with a mechanical sweep for survivors and re-run `pnpm format`. No test covers a comment, so
+Finish with a mechanical sweep for survivors and re-run `pnpm format` (a `prettier --write .`, so
+`pnpm bench in-flight` first if a bench is still in flight). No test covers a comment, so
 this phase is the only pass they get.
 
 ## Phase 7 — Report and write back
@@ -356,14 +357,20 @@ until grep -q 'EXIT=' /tmp/<round>-bench.log; do sleep 30; done
 DURING the run and the sample is STICKY, so ONE edit — a comment audit, a `pnpm format`, an editor
 save — stamps the whole run dirty and `bench:merge` throws the numbers away 39 minutes later. A
 round lost **2,420 s** to exactly that, auditing its comments beside its own gate bench. So a run in
-flight records itself in `bench-running/<pid>.json` at the repo root. **Run `pnpm bench lock`
-before any phase that EDITS the tree, and read its exit code: 1 means a run is in flight — wait for
-its `EXIT=` line — and 0 means the tree is yours.** The refusal names the pid, the argv and the
-elapsed time. The work this background pattern is for is read-only — reading the diff, grepping the
-corpus, running the unit tests, drafting the report. The records are gitignored (so they cannot
-dirty the run itself) and removed when the run exits; a run that dies without getting there leaves
-its record behind, and that record reads as STALE from its dead pid: stale blocks nothing, the next
-run sweeps it, and `rm bench-running/<pid>.json` clears it now.
+flight records itself, in `/tmp/asmlift-bench-running-<uid>/<pid>.json`. **Run `pnpm bench in-flight`
+before any phase that EDITS the tree, and read its exit code: 1 means a run is measuring this
+worktree — wait for its `EXIT=` line — and 0 means the tree is yours.** The refusal names the pid,
+the argv and the elapsed time. The work this background pattern is for is read-only — reading the
+diff, grepping the corpus, running the unit tests, drafting the report. The register lives outside
+every worktree, so it can never dirty the run itself; records are removed when the run exits, and a
+run that dies without getting there leaves its record behind, reading STALE from its dead pid:
+stale blocks nothing, the next run sweeps it, and `rm /tmp/asmlift-bench-running-<uid>/<pid>.json`
+clears it now.
+
+**If you edit anyway, the run says so within ~2 s** — `[provenance] THE TREE WENT DIRTY MID-RUN`,
+on the run's own stderr, once, naming the paths. That line means the run is already lost: the
+sample is sticky and reverting does not undo it. Stop it, revert or commit, start it again. Do not
+read it as a warning to be careful for the rest of the run.
 
 **`kill -TERM` does not stop a `bench run`** — measured: one sent SIGTERM 6 s in ran all 291 cases
 and REWROTE `results/synthetic.json` before exiting 143. A run is blocked in `spawnSync` for every
@@ -377,11 +384,14 @@ that, long after the jobs they watched had finished.
 **Two full benches must never overlap on this machine.** It has 10 cores, the run fans 8 shards,
 and a ranked run takes `--jobs 6`; a bench measured **2704 s against a neighbour versus 1800 s
 solo**. Worse than slow: a shard killed by a neighbour writes a partial tier with **no error line**,
-and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. `bench run` now refuses a
-second run **in the same worktree that writes a tier file the live one is writing** — a scoped
-`--tier synthetic --only <sym>` beside a background `--tier real` is not refused, because they
-touch different files. That marker is per-worktree and says nothing about the neighbour: across
-worktrees this is still discipline.
+and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. **`bench run` now
+enforces this**: the register is machine-wide, so a second FULL bench is refused while one is
+running in ANY worktree, and a second run in THIS worktree is refused when it writes a tier file
+the live one is writing. What is still allowed is the scoped dev loop — a `--tier synthetic --only
+<sym>` probe beside a background `--tier real`, here or beside a neighbour's full bench — because a
+15 s probe is not what fans 8 shards. If you have a real reason to measure anyway, `--no-lock` says
+so out loud and leaves every other record alone; **never `rm` a record you did not write**, which
+is the one move that silently unprotects someone else's run.
 
 ---
 

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -279,8 +279,9 @@ on the corpus. A finding already triaged is not a new finding unless it falsifie
 Do this AFTER the adversarial rounds, never before: remediation rewrites code, and a comment
 written for the first version is the likeliest thing in the diff to have become false. And **not
 while a bench is in flight** — this phase rewrites files across the whole diff, the mid-run sampler
-is sticky, and a round paid 2,420 s for the pair. **Run `pnpm bench in-flight` first**: exit 1 means a
-run is measuring this worktree, so wait for its `EXIT=` line before you touch a file.
+is sticky, and a round paid 2,420 s for exactly this pair. **Run `pnpm bench in-flight` first**:
+exit 1 means a run is measuring this worktree, so wait for its `EXIT=` line before you touch a
+file.
 
 Inventory first — `git diff main HEAD`, added lines matching `^\+\s*(//|/\*|\*)`, counted per
 file. That number is the budget you are arguing about; core already runs ~31% comments.
@@ -304,8 +305,7 @@ Then, over every comment you added or changed, **tests included**:
 Keep the refusal conditions, and any *why* not derivable from the code: a compiler behaviour, a
 shape the IR cannot represent, why an absence is deliberate.
 
-Finish with a mechanical sweep for survivors and re-run `pnpm format` (a `prettier --write .`, so
-`pnpm bench in-flight` first if a bench is still in flight). No test covers a comment, so
+Finish with a mechanical sweep for survivors and re-run `pnpm format`. No test covers a comment, so
 this phase is the only pass they get.
 
 ## Phase 7 — Report and write back
@@ -353,24 +353,21 @@ phase whose other work does not depend on its answer, and read the log at the en
 until grep -q 'EXIT=' /tmp/<round>-bench.log; do sleep 30; done
 ```
 
-**What you keep working ON is constrained, and it is now checkable.** `provenance.ts` samples git
+**What you keep working ON is constrained, and it is checkable.** `provenance.ts` samples git
 DURING the run and the sample is STICKY, so ONE edit — a comment audit, a `pnpm format`, an editor
-save — stamps the whole run dirty and `bench:merge` throws the numbers away 39 minutes later. A
-round lost **2,420 s** to exactly that, auditing its comments beside its own gate bench. So a run in
-flight records itself, in `/tmp/asmlift-bench-running-<uid>/<pid>.json`. **Run `pnpm bench in-flight`
-before any phase that EDITS the tree, and read its exit code: 1 means a run is measuring this
-worktree — wait for its `EXIT=` line — and 0 means the tree is yours.** The refusal names the pid,
-the argv and the elapsed time. The work this background pattern is for is read-only — reading the
-diff, grepping the corpus, running the unit tests, drafting the report. The register lives outside
-every worktree, so it can never dirty the run itself; records are removed when the run exits, and a
-run that dies without getting there leaves its record behind, reading STALE from its dead pid:
-stale blocks nothing, the next run sweeps it, and `rm /tmp/asmlift-bench-running-<uid>/<pid>.json`
-clears it now.
+save, anywhere but the benchmark's own regenerated artifacts — stamps the whole run dirty and
+`bench:merge` throws the numbers away 39 minutes later. A round lost **2,420 s** to exactly that,
+auditing its comments beside its own gate bench. So a run in flight records itself, in
+`/tmp/asmlift-bench-running-<uid>/<pid>.json`. **Run `pnpm bench in-flight` before any phase that
+EDITS the tree, and read its exit code: 1 means a run is measuring this worktree — wait for its
+`EXIT=` line — and 0 means the tree is yours.** The work this background pattern is for is
+read-only: reading the diff, grepping the corpus, running the unit tests, drafting the report. A
+run that was killed leaves its record behind and it reads STALE — that blocks nothing, and the next
+run sweeps it.
 
 **If you edit anyway, the run says so within ~2 s** — `[provenance] THE TREE WENT DIRTY MID-RUN`,
 on the run's own stderr, once, naming the paths. That line means the run is already lost: the
-sample is sticky and reverting does not undo it. Stop it, revert or commit, start it again. Do not
-read it as a warning to be careful for the rest of the run.
+sample is sticky and reverting does not undo it. Stop it, revert or commit, start it again.
 
 **`kill -TERM` does not stop a `bench run`** — measured: one sent SIGTERM 6 s in ran all 291 cases
 and REWROTE `results/synthetic.json` before exiting 143. A run is blocked in `spawnSync` for every
@@ -384,7 +381,7 @@ that, long after the jobs they watched had finished.
 **Two full benches must never overlap on this machine.** It has 10 cores, the run fans 8 shards,
 and a ranked run takes `--jobs 6`; a bench measured **2704 s against a neighbour versus 1800 s
 solo**. Worse than slow: a shard killed by a neighbour writes a partial tier with **no error line**,
-and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. **`bench run` now
+and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. **`bench run`
 enforces this**: the register is machine-wide, so a second FULL bench is refused while one is
 running in ANY worktree, and a second run in THIS worktree is refused when it writes a tier file
 the live one is writing. What is still allowed is the scoped dev loop — a `--tier synthetic --only

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -279,7 +279,8 @@ on the corpus. A finding already triaged is not a new finding unless it falsifie
 Do this AFTER the adversarial rounds, never before: remediation rewrites code, and a comment
 written for the first version is the likeliest thing in the diff to have become false. And **not
 while a bench is in flight** — this phase rewrites files across the whole diff, the mid-run sampler
-is sticky, and a round paid 2,420 s for the pair. `pnpm bench lock` answers it in a second.
+is sticky, and a round paid 2,420 s for the pair. **Run `pnpm bench lock` first**: exit 1 means a
+run is measuring this worktree, so wait for its `EXIT=` line before you touch a file.
 
 Inventory first — `git diff main HEAD`, added lines matching `^\+\s*(//|/\*|\*)`, counted per
 file. That number is the budget you are arguing about; core already runs ~31% comments.
@@ -355,12 +356,19 @@ until grep -q 'EXIT=' /tmp/<round>-bench.log; do sleep 30; done
 DURING the run and the sample is STICKY, so ONE edit — a comment audit, a `pnpm format`, an editor
 save — stamps the whole run dirty and `bench:merge` throws the numbers away 39 minutes later. A
 round lost **2,420 s** to exactly that, auditing its comments beside its own gate bench. So a run in
-flight holds `bench-running` at the repo root, and **`pnpm bench lock` exits 1 while it does**,
-naming the pid, the argv and the elapsed time. Run it before any phase that EDITS the tree; the
-work this background pattern is for is read-only — reading the diff, grepping the corpus, running
-the unit tests, drafting the report. The marker is gitignored (so it cannot dirty the run itself),
-removed on exit and on Ctrl-C, and reads as STALE from its own pid if the run was SIGKILLed: a stale
-marker blocks nothing, and `rm bench-running` is the whole cure.
+flight records itself in `bench-running/<pid>.json` at the repo root. **Run `pnpm bench lock`
+before any phase that EDITS the tree, and read its exit code: 1 means a run is in flight — wait for
+its `EXIT=` line — and 0 means the tree is yours.** The refusal names the pid, the argv and the
+elapsed time. The work this background pattern is for is read-only — reading the diff, grepping the
+corpus, running the unit tests, drafting the report. The records are gitignored (so they cannot
+dirty the run itself) and removed when the run exits; a run that dies without getting there leaves
+its record behind, and that record reads as STALE from its dead pid: stale blocks nothing, the next
+run sweeps it, and `rm bench-running/<pid>.json` clears it now.
+
+**`kill -TERM` does not stop a `bench run`** — measured: one sent SIGTERM 6 s in ran all 291 cases
+and REWROTE `results/synthetic.json` before exiting 143. A run is blocked in `spawnSync` for every
+case, so no signal handler can run until it is done. `kill -9` is the stop that works, and the
+record it strands is stale.
 
 **Wait on a log marker, never on `pgrep -f "<pattern>"`** when the pattern also matches your own
 waiting shell — five waiter shells once deadlocked on each other for eight hours doing exactly
@@ -370,8 +378,10 @@ that, long after the jobs they watched had finished.
 and a ranked run takes `--jobs 6`; a bench measured **2704 s against a neighbour versus 1800 s
 solo**. Worse than slow: a shard killed by a neighbour writes a partial tier with **no error line**,
 and `grep -c SKIP` reads 0 either way — so always read the `✓`/`✗` tier line. `bench run` now refuses a
-second run **in the same worktree** — both write `results/<tier>.json` — but that marker is
-per-worktree and says nothing about the neighbour: across worktrees this is still discipline.
+second run **in the same worktree that writes a tier file the live one is writing** — a scoped
+`--tier synthetic --only <sym>` beside a background `--tier real` is not refused, because they
+touch different files. That marker is per-worktree and says nothing about the neighbour: across
+worktrees this is still discipline.
 
 ---
 

--- a/.claude/commands/update-m2c.md
+++ b/.claude/commands/update-m2c.md
@@ -31,10 +31,9 @@ Key facts about the setup (verified 2026-08-05):
    "before" side is not what main published. `pnpm bench baseline <sym>` reads a single row straight
    from `origin/main`, and [`docs/baseline-freshness.md`](../../docs/baseline-freshness.md) is the
    rule for which of two numbers wins.
-3. Write the new sha to `apps/benchmark/M2C_COMMIT`; `git -C ../m2c checkout <NEW>`. That file is
-   on a provenance-MEASURED path, so **`pnpm bench in-flight` first**: exit 1 means a bench is
-   measuring this worktree and one save stamps its whole run dirty (the sampler is sticky) — wait
-   for its `EXIT=` line. A round paid 2,420 s for editing beside its own bench.
+3. Write the new sha to `apps/benchmark/M2C_COMMIT`; `git -C ../m2c checkout <NEW>`. **`pnpm bench in-flight`
+   first**: exit 1 means a bench is measuring this worktree, and any save — this file included —
+   stamps its whole run dirty, stickily. Wait for its `EXIT=` line.
 4. Smoke-test the new m2c under the local Python before the full run: `python3 m2c.py --help`
    (upstream occasionally breaks on newer Pythons; catch it in 2 seconds, not mid-run).
 5. `pnpm bench run` (background it), then `pnpm bench merge` — `run` only writes the per-tier

--- a/.claude/commands/update-m2c.md
+++ b/.claude/commands/update-m2c.md
@@ -31,11 +31,17 @@ Key facts about the setup (verified 2026-08-05):
    "before" side is not what main published. `pnpm bench baseline <sym>` reads a single row straight
    from `origin/main`, and [`docs/baseline-freshness.md`](../../docs/baseline-freshness.md) is the
    rule for which of two numbers wins.
-3. Write the new sha to `apps/benchmark/M2C_COMMIT`; `git -C ../m2c checkout <NEW>`.
+3. Write the new sha to `apps/benchmark/M2C_COMMIT`; `git -C ../m2c checkout <NEW>`. That file is
+   on a provenance-MEASURED path, so **`pnpm bench in-flight` first**: exit 1 means a bench is
+   measuring this worktree and one save stamps its whole run dirty (the sampler is sticky) — wait
+   for its `EXIT=` line. A round paid 2,420 s for editing beside its own bench.
 4. Smoke-test the new m2c under the local Python before the full run: `python3 m2c.py --help`
    (upstream occasionally breaks on newer Pythons; catch it in 2 seconds, not mid-run).
 5. `pnpm bench run` (background it), then `pnpm bench merge` — `run` only writes the per-tier
    files; `merge` produces `results.json` and republishes the web data. Both steps are required.
+   While that run is in flight the tree is not yours to edit: `pnpm bench in-flight` before you
+   touch a file, and if you edit anyway the run prints `[provenance] THE TREE WENT DIRTY MID-RUN`
+   within ~2 s — that means it is already lost, so stop it rather than finish it.
 
 ## Phase 2 — Attribute every moved row
 

--- a/.claude/workflows/meta-optimizer-loop.js
+++ b/.claude/workflows/meta-optimizer-loop.js
@@ -89,7 +89,9 @@ const HOUSE = `
 - **NEVER \`git stash\`.**
 - \`research/\` is gitignored — never cite a research/ path in a commit, a PR body, or a doc.
 - **Numbers come from commands.** Never state a timing, a count or a behaviour you did not observe.
-- Lint is \`npx eslint apps packages\` (NOT \`pnpm lint\`). \`pnpm format\` before committing.
+- Lint is \`npx eslint apps packages\` (NOT \`pnpm lint\`). \`pnpm format\` before committing — it is
+  \`prettier --write .\`, a tree WRITE, so \`pnpm bench in-flight\` first: exit 1 means a bench is
+  measuring this worktree, and one save stamps its whole run dirty (one round paid 2,420 s for it).
 - \`source /tmp/wt-env.sh\` in every shell before any harness command, or rows silently SKIP.
 - Never wait with a \`pgrep -f\` pattern matching your own shell; use a log marker.
 - Commit messages end with:
@@ -234,7 +236,11 @@ ${implReport}
    downstream depends on?
 5. **Re-run every gate yourself.** If the change adds a fail-loud check, verify it fires on the bad
    condition AND does not fire on a clean run — a false-alarming guard stalls every future round.
-6. **Apply fixes yourself** rather than bouncing back; commit, push, say what you changed.
+6. **Apply fixes yourself** rather than bouncing back; commit, push, say what you changed. This is
+   an EDIT in the worktree that just ran step 3's full bench, which is the 2,420 s shape: run
+   \`pnpm bench in-flight\` before you touch a file, and if you edit anyway the run prints
+   \`[provenance] THE TREE WENT DIRTY MID-RUN\` within ~2 s — the run is lost at that point, so
+   stop it and start it again rather than let it finish.
 7. **Merge when CI is green** (poll \`gh pr checks\`, never with a self-matching \`pgrep\`), then
    \`gh pr merge <n> --squash\`, and **verify main is still green**.
 8. **Refuse to merge** if a blocking finding cannot be fixed soundly. Refusing is a valid outcome.

--- a/.claude/workflows/meta-optimizer-loop.js
+++ b/.claude/workflows/meta-optimizer-loop.js
@@ -237,9 +237,8 @@ ${implReport}
 5. **Re-run every gate yourself.** If the change adds a fail-loud check, verify it fires on the bad
    condition AND does not fire on a clean run — a false-alarming guard stalls every future round.
 6. **Apply fixes yourself** rather than bouncing back; commit, push, say what you changed. This is
-   an EDIT in the worktree that just ran step 3's full bench, which is the 2,420 s shape: run
-   \`pnpm bench in-flight\` before you touch a file, and if you edit anyway the run prints
-   \`[provenance] THE TREE WENT DIRTY MID-RUN\` within ~2 s — the run is lost at that point, so
+   an EDIT in a worktree that may still be measuring: \`pnpm bench in-flight\` before you touch a
+   file, and if a run prints \`[provenance] THE TREE WENT DIRTY MID-RUN\` it is already lost —
    stop it and start it again rather than let it finish.
 7. **Merge when CI is green** (poll \`gh pr checks\`, never with a self-matching \`pgrep\`), then
    \`gh pr merge <n> --squash\`, and **verify main is still green**.

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,4 @@ research/
 # worktree reads and nothing prunes.
 .envrc.local
 .local/
-# `bench run`'s advisory marker (apps/benchmark/src/run/lock.ts): a directory of `<pid>.json`
-# records, one per run in flight, written at the repo root and read by the phases that edit the
-# tree. ANCHORED: unanchored it would also hide anything of this name anywhere in the tree. It must
-# be invisible to git or it becomes the untracked path the preflight above refuses to start on.
-/bench-running
 packages/cli/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,9 @@ research/
 # worktree reads and nothing prunes.
 .envrc.local
 .local/
-# `bench run`'s advisory marker (apps/benchmark/src/run/lock.ts), written at the repo root while a
-# run is in flight and read by the phases that edit the tree. ANCHORED: unanchored it would also
-# hide a file of this name anywhere in the tree. It must be invisible to git or it becomes the
-# untracked file the preflight above refuses to start on.
+# `bench run`'s advisory marker (apps/benchmark/src/run/lock.ts): a directory of `<pid>.json`
+# records, one per run in flight, written at the repo root and read by the phases that edit the
+# tree. ANCHORED: unanchored it would also hide anything of this name anywhere in the tree. It must
+# be invisible to git or it becomes the untracked path the preflight above refuses to start on.
 /bench-running
 packages/cli/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,9 @@ research/
 # worktree reads and nothing prunes.
 .envrc.local
 .local/
+# `bench run`'s advisory marker (apps/benchmark/src/run/lock.ts), written at the repo root while a
+# run is in flight and read by the phases that edit the tree. ANCHORED: unanchored it would also
+# hide a file of this name anywhere in the tree. It must be invisible to git or it becomes the
+# untracked file the preflight above refuses to start on.
+/bench-running
 packages/cli/dist/

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -171,6 +171,13 @@ run in ~2 min, a warm re-run in ~40 s):
 pnpm bench run                        # both tiers -> results/{synthetic,real}.json (intermediates)
 pnpm bench run --tier synthetic --only divc      # targeted subset
 pnpm bench run --serial               # in-process, for debugging (also how shard children run)
+pnpm bench lock                       # is a run measuring this worktree RIGHT NOW? exit 1 if so,
+                                      #   naming `bench-running` (the gitignored marker `bench run`
+                                      #   holds while it works), its pid, argv and elapsed time.
+                                      #   Ask before ANY phase that edits the tree: the provenance
+                                      #   sampler below is sticky, so one mid-run edit costs the
+                                      #   whole run. A SIGKILLed run leaves the marker behind and
+                                      #   it reads as stale from its pid — that blocks nothing
 pnpm bench:merge                      # = bench merge: tiers -> results/results.json, then publish
 pnpm bench publish                    # re-stage results.json into the web app alone
 pnpm bench:smoke                      # one trivial fn through every available toolchain

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -171,16 +171,20 @@ run in ~2 min, a warm re-run in ~40 s):
 pnpm bench run                        # both tiers -> results/{synthetic,real}.json (intermediates)
 pnpm bench run --tier synthetic --only divc      # targeted subset
 pnpm bench run --serial               # in-process, for debugging (also how shard children run)
-pnpm bench lock                       # is a run measuring this worktree RIGHT NOW? exit 1 if so,
-                                      #   naming `bench-running/<pid>.json` (the gitignored record
-                                      #   each `bench run` writes while it works), its pid, argv and
-                                      #   elapsed time. Run it before ANY phase that edits the tree:
-                                      #   the provenance sampler below is sticky, so one mid-run
-                                      #   edit costs the whole run. A killed run leaves its record
-                                      #   behind and it reads as stale from its pid — that blocks
-                                      #   nothing, and the next run sweeps it. A second `bench run`
-                                      #   is refused only when it writes a tier file the live one
-                                      #   is already writing
+pnpm bench in-flight                  # is a run measuring this worktree RIGHT NOW? exit 1 if so,
+                                      #   naming the record each `bench run` writes while it works
+                                      #   (`/tmp/asmlift-bench-running-<uid>/<pid>.json`), its pid,
+                                      #   argv and elapsed time. Run it before ANY phase that edits
+                                      #   the tree: the provenance sampler below is sticky, so one
+                                      #   mid-run edit costs the whole run. A killed run leaves its
+                                      #   record behind and it reads as stale from its pid — that
+                                      #   blocks nothing, and the next run sweeps it. The register
+                                      #   is machine-wide and each record names its worktree, so
+                                      #   `bench run` refuses a second run that writes a tier file
+                                      #   the live one is writing, AND a second FULL bench beside
+                                      #   one running anywhere on this machine. `--no-lock` is the
+                                      #   sanctioned way past that, out loud; never `rm` a record
+                                      #   you did not write
 pnpm bench:merge                      # = bench merge: tiers -> results/results.json, then publish
 pnpm bench publish                    # re-stage results.json into the web app alone
 pnpm bench:smoke                      # one trivial fn through every available toolchain

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -172,12 +172,15 @@ pnpm bench run                        # both tiers -> results/{synthetic,real}.j
 pnpm bench run --tier synthetic --only divc      # targeted subset
 pnpm bench run --serial               # in-process, for debugging (also how shard children run)
 pnpm bench lock                       # is a run measuring this worktree RIGHT NOW? exit 1 if so,
-                                      #   naming `bench-running` (the gitignored marker `bench run`
-                                      #   holds while it works), its pid, argv and elapsed time.
-                                      #   Ask before ANY phase that edits the tree: the provenance
-                                      #   sampler below is sticky, so one mid-run edit costs the
-                                      #   whole run. A SIGKILLed run leaves the marker behind and
-                                      #   it reads as stale from its pid — that blocks nothing
+                                      #   naming `bench-running/<pid>.json` (the gitignored record
+                                      #   each `bench run` writes while it works), its pid, argv and
+                                      #   elapsed time. Run it before ANY phase that edits the tree:
+                                      #   the provenance sampler below is sticky, so one mid-run
+                                      #   edit costs the whole run. A killed run leaves its record
+                                      #   behind and it reads as stale from its pid — that blocks
+                                      #   nothing, and the next run sweeps it. A second `bench run`
+                                      #   is refused only when it writes a tier file the live one
+                                      #   is already writing
 pnpm bench:merge                      # = bench merge: tiers -> results/results.json, then publish
 pnpm bench publish                    # re-stage results.json into the web app alone
 pnpm bench:smoke                      # one trivial fn through every available toolchain

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -172,19 +172,14 @@ pnpm bench run                        # both tiers -> results/{synthetic,real}.j
 pnpm bench run --tier synthetic --only divc      # targeted subset
 pnpm bench run --serial               # in-process, for debugging (also how shard children run)
 pnpm bench in-flight                  # is a run measuring this worktree RIGHT NOW? exit 1 if so,
-                                      #   naming the record each `bench run` writes while it works
-                                      #   (`/tmp/asmlift-bench-running-<uid>/<pid>.json`), its pid,
-                                      #   argv and elapsed time. Run it before ANY phase that edits
-                                      #   the tree: the provenance sampler below is sticky, so one
-                                      #   mid-run edit costs the whole run. A killed run leaves its
-                                      #   record behind and it reads as stale from its pid — that
-                                      #   blocks nothing, and the next run sweeps it. The register
-                                      #   is machine-wide and each record names its worktree, so
-                                      #   `bench run` refuses a second run that writes a tier file
-                                      #   the live one is writing, AND a second FULL bench beside
-                                      #   one running anywhere on this machine. `--no-lock` is the
-                                      #   sanctioned way past that, out loud; never `rm` a record
-                                      #   you did not write
+                                      #   naming the record `bench run` writes while it works
+                                      #   (`/tmp/asmlift-bench-running-<uid>/<pid>.json`). Run it
+                                      #   before ANY phase that edits the tree: the provenance
+                                      #   sampler below is sticky, so one mid-run edit costs the
+                                      #   whole run. `bench run` reads the same register and
+                                      #   refuses a second run writing a tier file the live one is
+                                      #   writing, or a second FULL bench anywhere on this machine;
+                                      #   `--no-lock` is the sanctioned way past that
 pnpm bench:merge                      # = bench merge: tiers -> results/results.json, then publish
 pnpm bench publish                    # re-stage results.json into the web app alone
 pnpm bench:smoke                      # one trivial fn through every available toolchain

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -205,8 +205,7 @@ switch (command) {
     // Then record that this worktree is being measured, so the phases that EDIT it — and the next
     // `bench run` on this machine — can tell. Taking the record is a WRITE and not a verdict,
     // which is why it is here and the refusal is in preflight.ts; which invocations are exempt is
-    // that file's `runTakesTheBenchLock` (a shard child writes nothing: the parent that spawned it
-    // already did, and eight children's records would say eight runs are in flight).
+    // that file's `runTakesTheBenchLock`.
     if (runTakesTheBenchLock(runOpts)) {
       if (opts['no-lock']) {
         console.error(
@@ -220,9 +219,9 @@ switch (command) {
         });
       }
     }
-    // Deliberately NOT folded into `preflightRefusals`: that function's two verdicts are each
-    // gated on a predicate (whole-tier / touches-real), while the m2c pin applies to EVERY run,
-    // shard children and `--only` included, and throws its own remediation line.
+    // Deliberately NOT folded into `preflightRefusals`: each of that function's verdicts is gated
+    // on a predicate (takes-a-record / whole-tier / touches-real), while the m2c pin applies to
+    // EVERY run, shard children and `--only` included, and throws its own remediation line.
     const { assertM2cPinned } = await import('./eval/m2c');
     assertM2cPinned();
     if (opts.serial) {

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -73,8 +73,9 @@ import { RESULTS_DIR } from './config';
 import { materializeScoringContext, writeScoreConfig } from './decomp-config';
 import { merge } from './report/merge';
 import { publish } from './report/publish';
+import { acquireBenchLock, benchLockStatus, concurrentRunRefusal, readBenchLock } from './run/lock';
 import { type Tier, emptySelectionError, orchestrate, tierIsFiltered } from './run/orchestrate';
-import { preflightRefusals } from './run/preflight';
+import { isShardChild, preflightRefusals } from './run/preflight';
 import { parseShard, runCases } from './run/runner';
 import { smoke } from './run/smoke';
 import { verify } from './run/verify';
@@ -188,6 +189,17 @@ switch (command) {
       console.error(preflight.refusals.join('\n\n'));
       process.exit(1);
     }
+    // Then take the worktree, so the phases that EDIT it can tell that they must not. A shard
+    // CHILD takes nothing: the parent that spawned it holds the marker already, and eight children
+    // fighting over one path would clear it the moment the first of them exited.
+    if (!isShardChild({ tiers, shard: opts.shard, serial: opts.serial })) {
+      const concurrent = concurrentRunRefusal(readBenchLock());
+      if (concurrent !== undefined) {
+        console.error(concurrent);
+        process.exit(1);
+      }
+      acquireBenchLock(`bench ${process.argv.slice(2).join(' ')}`);
+    }
     // Deliberately NOT folded into `preflightRefusals`: that function's two verdicts are each
     // gated on a predicate (whole-tier / touches-real), while the m2c pin applies to EVERY run,
     // shard children and `--only` included, and throws its own remediation line.
@@ -271,6 +283,12 @@ switch (command) {
       }
       await orchestrate({ jobs, tiers, only: opts.only, project: opts.project, toolchain: opts.toolchain });
     }
+    break;
+  }
+  case 'lock': {
+    // The read every tree-EDITING phase makes: is a bench measuring this worktree right now?
+    // Exits 1 while one is, naming the marker. See run/lock.ts.
+    process.exit(benchLockStatus());
     break;
   }
   case 'repro': {
@@ -512,7 +530,7 @@ switch (command) {
   }
   default:
     console.error(
-      `usage: bench <run|repro|target|fan|gates|setup|fidelity|merge|publish|baseline|stale-check|regression|diff|smoke|verify|vendor> — got ${JSON.stringify(command)}`,
+      `usage: bench <run|lock|repro|target|fan|gates|setup|fidelity|merge|publish|baseline|stale-check|regression|diff|smoke|verify|vendor> — got ${JSON.stringify(command)}`,
     );
     process.exit(2);
 }

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -189,16 +189,20 @@ switch (command) {
       console.error(preflight.refusals.join('\n\n'));
       process.exit(1);
     }
-    // Then take the worktree, so the phases that EDIT it can tell that they must not. A shard
-    // CHILD takes nothing: the parent that spawned it holds the marker already, and eight children
-    // fighting over one path would clear it the moment the first of them exited.
+    // Then record that this worktree is being measured, so the phases that EDIT it can tell that
+    // they must not. A shard CHILD records nothing: the parent that spawned it already did, and
+    // eight children's records would say eight runs are in flight.
+    //
+    // The refusal is on the TIERS this run writes, not on "a run is in flight": a scoped probe on
+    // a tier the background run is not writing collides with nothing, and refusing it would send
+    // the round looking for a way past the guard.
     if (!isShardChild({ tiers, shard: opts.shard, serial: opts.serial })) {
-      const concurrent = concurrentRunRefusal(readBenchLock());
+      const concurrent = concurrentRunRefusal(readBenchLock(), tiers);
       if (concurrent !== undefined) {
         console.error(concurrent);
         process.exit(1);
       }
-      acquireBenchLock(`bench ${process.argv.slice(2).join(' ')}`);
+      acquireBenchLock(`bench ${process.argv.slice(2).join(' ')}`, tiers);
     }
     // Deliberately NOT folded into `preflightRefusals`: that function's two verdicts are each
     // gated on a predicate (whole-tier / touches-real), while the m2c pin applies to EVERY run,

--- a/apps/benchmark/src/cli.ts
+++ b/apps/benchmark/src/cli.ts
@@ -2,7 +2,12 @@
 // subcommand here — there are no other executable scripts.
 //
 //   pnpm bench run [--jobs N] [--tier synthetic|real|both] [--only s] [--project p]
-//                  [--serial] [--shard i/N] [--toolchain id]
+//                  [--serial] [--shard i/N] [--toolchain id] [--no-lock]
+//   pnpm bench in-flight                 # is a `bench run` measuring this worktree RIGHT NOW?
+//                                        # exit 1 if so, naming the record, its pid, argv and age.
+//                                        # Run it before ANY phase that edits the tree: the
+//                                        # provenance sampler is sticky, so one mid-run save costs
+//                                        # the whole run (see run/lock.ts)
 //   pnpm bench repro <sym|id> [--out <dir>] [--tool asmlift|m2c] [--run]
 //                                        # THE vehicle that reproduces one published row: writes
 //                                        # the row's own generated script with this machine's
@@ -73,9 +78,9 @@ import { RESULTS_DIR } from './config';
 import { materializeScoringContext, writeScoreConfig } from './decomp-config';
 import { merge } from './report/merge';
 import { publish } from './report/publish';
-import { acquireBenchLock, benchLockStatus, concurrentRunRefusal, readBenchLock } from './run/lock';
+import { acquireBenchLock, benchLockStatus } from './run/lock';
 import { type Tier, emptySelectionError, orchestrate, tierIsFiltered } from './run/orchestrate';
-import { isShardChild, preflightRefusals } from './run/preflight';
+import { preflightRefusals, runIsWholeTier, runTakesTheBenchLock } from './run/preflight';
 import { parseShard, runCases } from './run/runner';
 import { smoke } from './run/smoke';
 import { verify } from './run/verify';
@@ -91,6 +96,11 @@ const { values: opts, positionals } = parseArgs({
     toolchain: { type: 'string' },
     shard: { type: 'string' },
     serial: { type: 'boolean', default: false },
+    // run only: the sanctioned way past the concurrent-run refusal (run/lock.ts). It skips the
+    // verdict AND the record, so this run is invisible to the next one — which is the price, said
+    // out loud on stderr. It exists so that the way past a refusal is not `rm`ing a record someone
+    // else's live run depends on.
+    'no-lock': { type: 'boolean', default: false },
     build: { type: 'boolean', default: false },
     out: { type: 'string' },
     'project-root': { type: 'string' },
@@ -172,16 +182,19 @@ switch (command) {
       );
       process.exit(2);
     }
-    // BEFORE anything that costs: the two conditions that make a run's numbers worthless are both
-    // decidable in under a second. See run/preflight.ts.
-    const preflight = preflightRefusals({
+    // BEFORE anything that costs: the conditions that make a run's numbers worthless — or that
+    // make starting it at all a mistake — are all decidable in under a second. ONE options object,
+    // read by every verdict and by the record below, because two hand-kept copies of it drift.
+    // See run/preflight.ts.
+    const runOpts = {
       tiers,
       only: opts.only,
       project: opts.project,
       toolchain: opts.toolchain,
       shard: opts.shard,
       serial: opts.serial,
-    });
+    };
+    const preflight = preflightRefusals(runOpts, { ignoreLock: opts['no-lock'] });
     for (const w of preflight.warnings) {
       console.error(`${w}\n`);
     }
@@ -189,20 +202,23 @@ switch (command) {
       console.error(preflight.refusals.join('\n\n'));
       process.exit(1);
     }
-    // Then record that this worktree is being measured, so the phases that EDIT it can tell that
-    // they must not. A shard CHILD records nothing: the parent that spawned it already did, and
-    // eight children's records would say eight runs are in flight.
-    //
-    // The refusal is on the TIERS this run writes, not on "a run is in flight": a scoped probe on
-    // a tier the background run is not writing collides with nothing, and refusing it would send
-    // the round looking for a way past the guard.
-    if (!isShardChild({ tiers, shard: opts.shard, serial: opts.serial })) {
-      const concurrent = concurrentRunRefusal(readBenchLock(), tiers);
-      if (concurrent !== undefined) {
-        console.error(concurrent);
-        process.exit(1);
+    // Then record that this worktree is being measured, so the phases that EDIT it — and the next
+    // `bench run` on this machine — can tell. Taking the record is a WRITE and not a verdict,
+    // which is why it is here and the refusal is in preflight.ts; which invocations are exempt is
+    // that file's `runTakesTheBenchLock` (a shard child writes nothing: the parent that spawned it
+    // already did, and eight children's records would say eight runs are in flight).
+    if (runTakesTheBenchLock(runOpts)) {
+      if (opts['no-lock']) {
+        console.error(
+          '[bench lock] --no-lock: this run takes NO record, so nothing will stop an agent editing\n' +
+            '             the tree under it, and the next `bench run` cannot see it. You said so.\n',
+        );
+      } else {
+        acquireBenchLock(`bench ${process.argv.slice(2).join(' ')}`, {
+          tiers,
+          whole: runIsWholeTier(runOpts),
+        });
       }
-      acquireBenchLock(`bench ${process.argv.slice(2).join(' ')}`, tiers);
     }
     // Deliberately NOT folded into `preflightRefusals`: that function's two verdicts are each
     // gated on a predicate (whole-tier / touches-real), while the m2c pin applies to EVERY run,
@@ -289,9 +305,11 @@ switch (command) {
     }
     break;
   }
-  case 'lock': {
+  case 'in-flight': {
     // The read every tree-EDITING phase makes: is a bench measuring this worktree right now?
-    // Exits 1 while one is, naming the marker. See run/lock.ts.
+    // Exits 1 while one is, naming the record. Not called `lock`, because it takes nothing and
+    // holds nothing — `bench run` is what writes a record, and a reader who typed a verb would
+    // reasonably expect this to reserve the tree for them. See run/lock.ts.
     process.exit(benchLockStatus());
     break;
   }
@@ -534,7 +552,7 @@ switch (command) {
   }
   default:
     console.error(
-      `usage: bench <run|lock|repro|target|fan|gates|setup|fidelity|merge|publish|baseline|stale-check|regression|diff|smoke|verify|vendor> — got ${JSON.stringify(command)}`,
+      `usage: bench <run|in-flight|repro|target|fan|gates|setup|fidelity|merge|publish|baseline|stale-check|regression|diff|smoke|verify|vendor> — got ${JSON.stringify(command)}`,
     );
     process.exit(2);
 }

--- a/apps/benchmark/src/provenance.ts
+++ b/apps/benchmark/src/provenance.ts
@@ -12,11 +12,7 @@
 // `report/merge.ts` refuses to merge a tier whose stamp disagrees with merge time. The two
 // samples together cover the whole window.
 //
-// AND IT SAYS SO AT THE TRANSITION (`announceWentDirty`). The refusal at `bench:merge` is correct
-// and 39 minutes late; the sample that decides it is taken after every case, so the loss is
-// knowable within ~2 s. That line is the DETECTIVE half of `run/lock.ts`'s preventive register:
-// the register only works if whoever edits the tree asks first, while this fires whatever the
-// cause.
+// AND IT SAYS SO AT THE TRANSITION, on the run's own stderr — see `wentDirtyNotice`.
 //
 // STICKY, and that is the point rather than an optimization: a mutation that appears and is
 // reverted mid-run must still be reported, so once a sample sees a dirty tree this process reports

--- a/apps/benchmark/src/provenance.ts
+++ b/apps/benchmark/src/provenance.ts
@@ -12,6 +12,12 @@
 // `report/merge.ts` refuses to merge a tier whose stamp disagrees with merge time. The two
 // samples together cover the whole window.
 //
+// AND IT SAYS SO AT THE TRANSITION (`announceWentDirty`). The refusal at `bench:merge` is correct
+// and 39 minutes late; the sample that decides it is taken after every case, so the loss is
+// knowable within ~2 s. That line is the DETECTIVE half of `run/lock.ts`'s preventive register:
+// the register only works if whoever edits the tree asks first, while this fires whatever the
+// cause.
+//
 // STICKY, and that is the point rather than an optimization: a mutation that appears and is
 // reverted mid-run must still be reported, so once a sample sees a dirty tree this process reports
 // dirty for the rest of its life. Sampling is rate-limited (`flush()` runs after every case, and
@@ -124,11 +130,51 @@ export function asmliftProvenance(): { commit: string; dirty: boolean } | undefi
     return sticky;
   }
   const status = spawnSync('git', ['-C', REPO_ROOT, 'status', '--porcelain'], { encoding: 'utf8' });
+  const wasDirty = sticky?.dirty ?? false;
   sticky = {
     commit: head.stdout.trim(),
-    dirty: (sticky?.dirty ?? false) || status.status !== 0 || codeDirtyFrom(status.stdout),
+    dirty: wasDirty || status.status !== 0 || codeDirtyFrom(status.stdout),
   };
+  const notice = wentDirtyNotice(wasDirty, sticky.dirty, status.status === 0 ? codeDirtyPaths(status.stdout) : []);
+  if (notice !== undefined) {
+    console.error(notice);
+  }
   return sticky;
+}
+
+/** SAY SO, at the transition, once.
+ *
+ *  The verdict this samples for is already correct without a word printed: `merge` refuses the
+ *  tier and `stale-check` refuses to publish it. What it is not is TIMELY — the round finds out at
+ *  `bench:merge`, and the incident that cost the most was 2,420 s of measurement that had already
+ *  been worthless for 30 of its 40 minutes. The sample that decides it is taken after every case,
+ *  so the loss is knowable within ~2 s and was simply never said aloud.
+ *
+ *  DETECTIVE, where `run/lock.ts` is preventive, and it does not replace it: the register only
+ *  works if whoever edits the tree asks first, while this fires whatever the cause — an agent that
+ *  never read a brief, an editor autosave, a neighbour worktree's `pnpm format` sweeping this one.
+ *  It fires in the SHARD CHILDREN too, which is where the samples with real resolution are taken:
+ *  `orchestrate.ts` spawns them with stderr `inherit`, so the line reaches the run's own log.
+ *
+ *  Sticky means this can only happen once per process, so there is no rate limit to add. */
+export function wentDirtyNotice(wasDirty: boolean, nowDirty: boolean, paths: readonly string[]): string | undefined {
+  // The EDGE, not the state: sticky means `nowDirty` stays true for the rest of the process, and a
+  // line per case for 291 cases would bury the one that says what happened.
+  if (wasDirty || !nowDirty) {
+    return undefined;
+  }
+  const shown = paths.slice(0, 5);
+  return [
+    '',
+    `[provenance] THE TREE WENT DIRTY MID-RUN, in ${paths.length || 'some'} path(s):`,
+    ...shown.map((p) => `  ${p}`),
+    ...(paths.length > shown.length ? [`  …and ${paths.length - shown.length} more`] : []),
+    'This sample is STICKY: every tier this process writes is now stamped dirty, `bench:merge`',
+    'will refuse it, and reverting the edit does not undo that. STOP NOW rather than at the end —',
+    'revert or commit, then start the run again. (`pnpm bench in-flight` before an edit is the',
+    'check that would have prevented this.)',
+    '',
+  ].join('\n');
 }
 
 /** The RUN's provenance for a tier that was STITCHED from shard part files.

--- a/apps/benchmark/src/run/lock.ts
+++ b/apps/benchmark/src/run/lock.ts
@@ -7,53 +7,83 @@
 // editor save. That run is 39 minutes of measurement no commit holds, and it is the shape that cost
 // the most: one round lost 2,420 s to a comment audit run beside its own gate bench.
 //
-// The fix is not a machine-wide queue. It is a name for the fact: `bench run` writes
-// `bench-running` at the repo root and removes it on the way out, and the phases that EDIT the tree
-// read it and refuse (`pnpm bench lock`, wired into the function briefs' audit phase).
+// The fix is not a machine-wide queue. It is a name for the fact: `bench run` writes a record under
+// `bench-running/` at the repo root and removes it on the way out, and the phases that EDIT the
+// tree read it and refuse (`pnpm bench lock`, wired into the function briefs' audit phase).
+//
+// ONE RECORD PER RUN, not one slot. `bench-running/<pid>.json`, because a single slot makes the
+// guard LIE: a second run that took the slot would delete the first run's protection when IT
+// finished, and `bench lock` would then clear an audit to edit the tree under a bench still in
+// flight — louder than no guard, and wrong. A worktree is held while ANY record names a live
+// process, and a run only ever writes and unlinks its own.
 //
 // ADVISORY, on purpose. It coordinates one worktree's agents, not the machine: two worktrees have
-// two markers, and nothing here waits, queues, or retries.
+// two directories, and nothing here waits, queues, or retries.
+//
+// NO SIGNAL HANDLERS, and this is the one place tidiness had to lose. `orchestrate.ts` blocks the
+// event loop in `spawnSync` for every case, so a JS listener for SIGTERM turns an OS-level kill
+// into a callback that cannot run until the loop unblocks. Measured in isolation (node blocked in
+// `spawnSync('sleep', ['10'])`, SIGTERM at 600 ms): with no listener it died at 608 ms; with one it
+// ran the full 10 s, exited **0**, and the listener never ran — the signal was swallowed outright.
+//
+// What this does NOT buy is a killable `bench run`. Importing `run/orchestrate.ts` makes tsx bind
+// its own hidden SIGINT/SIGTERM handler (hidden: it patches `process.listenerCount`, which reports
+// 0), so the CLI is signal-deferred on `origin/main` too — measured, with no handler of ours: a
+// `bench run --tier synthetic --serial` sent SIGTERM 6 s in ran all 291 cases, REWROTE
+// `results/synthetic.json`, and only then exited 143. `kill -9` is the stop that works. Adding a
+// second listener on top of that could only make things worse, and did.
+//
+// So a run that dies without reaching its exit path leaves its record behind, exactly like a
+// SIGKILL: it names a pid that is gone, so it reads `stale`, and stale blocks nothing.
 //
 // GITIGNORED (`/bench-running`, anchored) — and that is load-bearing rather than tidy. An untracked
-// file at the repo root is exactly what `preflight.ts` refuses to start on and what the mid-run
+// path at the repo root is exactly what `preflight.ts` refuses to start on and what the mid-run
 // sampler stamps dirty, so a marker git can see would cause the loss it exists to prevent.
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { constants as osConstants } from 'node:os';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, rmdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { REPO_ROOT } from '../config';
 
-/** The marker's name at the repo root. Quoted in every refusal, and in `.gitignore` as
- *  `/bench-running` — unanchored, the pattern would also hide a file of that name anywhere in the
- *  tree, which is how a real committed artifact once went missing here. */
+/** The marker's name at the repo root: a directory of `<pid>.json` records. Quoted in every
+ *  refusal, and in `.gitignore` as `/bench-running` — unanchored, the pattern would also hide
+ *  anything of that name anywhere in the tree, which is how a real committed artifact once went
+ *  missing here. */
 export const BENCH_LOCK_FILE = 'bench-running';
 
-/** What the marker records: enough for a reader to decide whether to wait or to clear it. */
+/** What one run records: enough for a reader to decide whether to wait or to clear it, and enough
+ *  for the NEXT run to tell whether the two of them collide on a `results/<tier>.json`. */
 export interface BenchLockRecord {
   pid: number;
   startedAt: string;
   command: string;
+  /** The tiers this run writes. Empty only for a record written by an older build. */
+  tiers: string[];
 }
 
 export type BenchLockState =
-  /** No marker: nothing is measuring this worktree. */
+  /** No live record: nothing is measuring this worktree. */
   | { state: 'free'; path: string }
-  /** A marker whose process is still alive. */
-  | { state: 'held'; path: string; record: BenchLockRecord }
-  /** A marker left behind — the run was SIGKILLed, or the machine went down. Treated as free by
-   *  every reader, because the alternative is a round blocked on a file nobody can explain. */
-  | { state: 'stale'; path: string; record?: BenchLockRecord; why: string };
+  /** At least one record naming a live process, oldest first. */
+  | { state: 'held'; path: string; records: BenchLockRecord[] }
+  /** The directory is there but every record in it is dead or unreadable — a SIGKILLed or
+   *  signalled run, or a lost machine. Treated as free by every reader, because the alternative is
+   *  a round blocked on a file nobody can explain. */
+  | { state: 'stale'; path: string; why: string };
 
 export function benchLockPath(root: string = REPO_ROOT): string {
   return join(root, BENCH_LOCK_FILE);
+}
+
+function recordPath(root: string, pid: number): string {
+  return join(benchLockPath(root), `${pid}.json`);
 }
 
 /** Is that pid a process this machine still has? EPERM means yes and owned by someone else; only
  *  ESRCH means gone.
  *
  *  A recycled pid therefore reads as HELD when the bench that wrote it is long dead. That is the
- *  direction to be wrong in: a false `held` costs one `rm` and says so on screen, while a false
- *  `stale` costs the 2,420 s this file exists to keep. */
+ *  direction to be wrong in: a false `held` costs one `rm` of a record named on screen, while a
+ *  false `stale` costs the 2,420 s this file exists to keep. */
 function pidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -63,27 +93,67 @@ function pidAlive(pid: number): boolean {
   }
 }
 
+function parseRecord(text: string): BenchLockRecord | undefined {
+  try {
+    const r = JSON.parse(text) as Partial<BenchLockRecord>;
+    if (typeof r?.pid !== 'number' || !Number.isInteger(r.pid) || r.pid <= 0) {
+      return undefined;
+    }
+    return {
+      pid: r.pid,
+      startedAt: String(r.startedAt ?? 'unknown'),
+      command: String(r.command ?? 'unknown'),
+      tiers: Array.isArray(r.tiers) ? r.tiers.map(String) : [],
+    };
+  } catch {
+    // A half-written or hand-edited record names no process, so no reader can ever clear it by
+    // waiting. Unreadable is dead.
+    return undefined;
+  }
+}
+
+/** Every record on disk, live and dead, so acquire can sweep the dead ones and read can explain
+ *  itself. Anything that is not a readable `<pid>.json` counts as one dead record. */
+function scan(root: string): { live: BenchLockRecord[]; dead: string[] } {
+  const dir = benchLockPath(root);
+  let names: string[];
+  try {
+    names = readdirSync(dir).filter((n) => n.endsWith('.json'));
+  } catch {
+    // Missing, or a plain FILE where the directory should be (an older build's marker, a stray
+    // `touch`). Either way there is no live record in it.
+    return { live: [], dead: existsSync(dir) ? [dir] : [] };
+  }
+  const live: BenchLockRecord[] = [];
+  const dead: string[] = [];
+  for (const name of names) {
+    const path = join(dir, name);
+    let record: BenchLockRecord | undefined;
+    try {
+      record = parseRecord(readFileSync(path, 'utf8'));
+    } catch {
+      record = undefined;
+    }
+    if (record && pidAlive(record.pid)) {
+      live.push(record);
+    } else {
+      dead.push(path);
+    }
+  }
+  live.sort((a, b) => (Date.parse(a.startedAt) || 0) - (Date.parse(b.startedAt) || 0));
+  return { live, dead };
+}
+
 export function readBenchLock(root: string = REPO_ROOT): BenchLockState {
   const path = benchLockPath(root);
-  if (!existsSync(path)) {
-    return { state: 'free', path };
+  const { live, dead } = scan(root);
+  if (live.length > 0) {
+    return { state: 'held', path, records: live };
   }
-  let record: BenchLockRecord;
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
-    const r = parsed as Partial<BenchLockRecord>;
-    if (typeof r?.pid !== 'number' || !Number.isInteger(r.pid) || r.pid <= 0) {
-      throw new Error('no pid');
-    }
-    record = { pid: r.pid, startedAt: String(r.startedAt ?? 'unknown'), command: String(r.command ?? 'unknown') };
-  } catch (e) {
-    // A half-written or hand-edited marker names no process, so no reader can ever clear it by
-    // waiting. Unreadable is stale.
-    return { state: 'stale', path, why: `unreadable (${(e as Error).message})` };
+  if (dead.length > 0) {
+    return { state: 'stale', path, why: `${dead.length} record(s), none naming a live process` };
   }
-  return pidAlive(record.pid)
-    ? { state: 'held', path, record }
-    : { state: 'stale', path, record, why: `pid ${record.pid} is gone` };
+  return { state: 'free', path };
 }
 
 function elapsed(startedAt: string): string {
@@ -94,77 +164,112 @@ function elapsed(startedAt: string): string {
   return `${Math.round((Date.now() - t) / 1000)} s`;
 }
 
+function describe(r: BenchLockRecord): string {
+  return (
+    `\`${BENCH_LOCK_FILE}/${r.pid}.json\` (pid ${r.pid}, started ${r.startedAt}, ` +
+    `${elapsed(r.startedAt)} ago): ${r.command}`
+  );
+}
+
 /** What a tree-editing phase is told when a run is in flight, or undefined when it may proceed. */
 export function benchInFlightRefusal(state: BenchLockState): string | undefined {
   if (state.state !== 'held') {
     return undefined;
   }
   return [
-    `REFUSED: a bench run is measuring this worktree — \`${BENCH_LOCK_FILE}\` (pid ${state.record.pid}, started ` +
-      `${state.record.startedAt}, ${elapsed(state.record.startedAt)} ago): ${state.record.command}`,
+    `REFUSED: a bench run is measuring this worktree — ${describe(state.records[0])}`,
+    ...state.records.slice(1).map((r) => `  and ${describe(r)}`),
     '',
     'Editing the tree now does not just risk the edit: `provenance.ts` samples git DURING the run',
     'and the sample is STICKY, so one save stamps the whole run dirty and `bench:merge` throws the',
     'numbers away — 39 minutes, after the fact, for a change that was reverted.',
-    'Wait for the run (its log ends in an `EXIT=` line), then edit. If the run is dead, the marker',
-    `names its pid: check, then \`rm ${BENCH_LOCK_FILE}\`.`,
+    'Wait for the run (its log ends in an `EXIT=` line), then edit. If the run is dead, the record',
+    `names its pid: check, then \`rm ${BENCH_LOCK_FILE}/<pid>.json\`.`,
   ].join('\n');
 }
 
-/** What `bench run` is told when another run already holds this worktree. Separate text: the
- *  reader is not editing anything, they are about to rewrite `results/<tier>.json` under a run that
- *  is still writing it. */
-export function concurrentRunRefusal(state: BenchLockState): string | undefined {
+/** What `bench run` is told when a run already in flight writes a tier file it is about to write.
+ *
+ *  Gated on the TIERS, not on "a run is in flight". A background `--tier real` and a scoped
+ *  `--tier synthetic --only <sym>` touch different files and are the dev loop HARD RULE 2 and both
+ *  briefs prescribe; refusing that would be the trade `preflight.ts` warns about in advance — "one
+ *  sanctioned name beats an escape hatch", and the invented way past a wrong refusal here is `rm`,
+ *  which is the one move that can silently unprotect the run still in flight. A scoped run on the
+ *  SAME tier is still refused: it rewrites `results/<tier>.json` with its handful of rows. */
+export function concurrentRunRefusal(state: BenchLockState, tiers: readonly string[]): string | undefined {
   if (state.state !== 'held') {
     return undefined;
   }
+  const clashes = state.records
+    .map((r) => ({ record: r, shared: r.tiers.filter((t) => tiers.includes(t)) }))
+    // An older build's record carries no tiers; assume it collides rather than assume it does not.
+    .filter((c) => c.shared.length > 0 || c.record.tiers.length === 0);
+  if (clashes.length === 0) {
+    return undefined;
+  }
+  const shared = clashes[0].shared;
+  const files = (shared.length > 0 ? shared : tiers).map((t) => `apps/benchmark/results/${t}.json`).join(', ');
   return [
-    `bench run REFUSED: pid ${state.record.pid} is already running one here (\`${BENCH_LOCK_FILE}\`, started ` +
-      `${state.record.startedAt}, ${elapsed(state.record.startedAt)} ago): ${state.record.command}`,
+    `bench run REFUSED: pid ${clashes[0].record.pid} is already running one here — ${describe(clashes[0].record)}`,
     '',
-    'Both runs write `apps/benchmark/results/<tier>.json`, so the second publishes a tier stitched',
-    'from two measurements — and on a 10-core machine they halve each other besides.',
-    `Wait for it, or run in a separate worktree. If that pid is dead, \`rm ${BENCH_LOCK_FILE}\`.`,
+    `Both runs write ${files}, so the second publishes a tier stitched from two`,
+    'measurements — and on a 10-core machine they halve each other besides.',
+    'Wait for it, run a tier it is not writing, or use a separate worktree. If that pid is dead,',
+    `\`rm ${BENCH_LOCK_FILE}/${clashes[0].record.pid}.json\`.`,
   ].join('\n');
 }
 
-/** Take the marker for this process and arrange for it to go away again.
+/** Take a record for this process and arrange for it to go away again.
  *
  *  Removal is hung off `process.on('exit')` rather than a `try`/`finally` because `cli.ts` leaves
  *  through `process.exit()` on a dozen paths, and each one would need its own release. Signals get
- *  explicit handlers that remove and then re-exit — an unhandled SIGINT never runs `exit`
- *  listeners, and Ctrl-C on a 39-minute run is not the rare case.
+ *  NO handler of ours — see the module header. A run that dies without reaching `exit` leaves a
+ *  record naming a dead pid, which is what `stale` is for, and the same is true of SIGKILL or a
+ *  lost machine.
  *
- *  What no handler can cover is SIGKILL or a lost machine, which is what `stale` is for. */
-export function acquireBenchLock(command: string, root: string = REPO_ROOT): string {
-  const path = benchLockPath(root);
-  const record: BenchLockRecord = { pid: process.pid, startedAt: new Date().toISOString(), command };
-  writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`);
-  const release = () => releaseBenchLock(root, record.pid);
-  process.on('exit', release);
-  for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
-    process.on(sig, () => {
-      release();
-      process.exit(128 + (osConstants.signals[sig] as number));
-    });
+ *  Never touches another run's record, on either side. Two runs launched in the same millisecond
+ *  can both read `free` and both proceed — a read/write window `concurrentRunRefusal` cannot close
+ *  from here. Left open knowingly: with one record per pid the racing pair only DUPLICATES work,
+ *  where the single-slot shape had the second run EVICT the first's protection, and real launches
+ *  are seconds apart. */
+export function acquireBenchLock(command: string, tiers: readonly string[], root: string = REPO_ROOT): string {
+  const dir = benchLockPath(root);
+  const { dead } = scan(root);
+  if (dead.length === 1 && dead[0] === dir) {
+    // A plain file where the directory belongs. It names no live run, so it is safe to clear.
+    console.error(`[bench lock] cleared a stale \`${BENCH_LOCK_FILE}\` left by an older build`);
+    rmSync(dir, { force: true });
   }
+  mkdirSync(dir, { recursive: true });
+  for (const path of dead) {
+    if (path === dir) {
+      continue;
+    }
+    console.error(`[bench lock] cleared a stale record: ${path.slice(root.length + 1)}`);
+    rmSync(path, { force: true });
+  }
+  const record: BenchLockRecord = {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    command,
+    tiers: [...tiers],
+  };
+  const path = recordPath(root, process.pid);
+  writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`);
+  process.on('exit', () => releaseBenchLock(root, record.pid));
   return path;
 }
 
-/** Remove the marker, but only if it is still OURS: a run that overwrote a stale marker and a
- *  concurrent process that cleared it by hand both end with someone else's record on disk, and
- *  deleting that would silently unlock a live run. */
+/** Remove OUR record, and the directory once it holds nothing. Another run's record is never
+ *  touched: deleting one would silently unlock a live run, which is the failure that makes an
+ *  advisory guard worse than none. */
 export function releaseBenchLock(root: string = REPO_ROOT, pid: number = process.pid): void {
-  const path = benchLockPath(root);
+  rmSync(recordPath(root, pid), { force: true });
   try {
-    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<BenchLockRecord>;
-    if (parsed?.pid !== pid) {
-      return;
-    }
+    rmdirSync(benchLockPath(root));
   } catch {
-    return;
+    // Not empty (another run holds a record), or already gone. Both are fine.
   }
-  rmSync(path, { force: true });
 }
 
 /** `bench lock`: the read the audit phases run. Exit 0 = go ahead, 1 = a run is in flight. */
@@ -177,11 +282,11 @@ export function benchLockStatus(root: string = REPO_ROOT): number {
   }
   if (state.state === 'stale') {
     console.log(
-      `no bench run in flight — \`${BENCH_LOCK_FILE}\` is stale (${state.why}). ` +
-        `The next \`bench run\` overwrites it; \`rm ${BENCH_LOCK_FILE}\` to be rid of it now.`,
+      `no bench run in flight — \`${BENCH_LOCK_FILE}\` holds only records of dead runs (${state.why}). ` +
+        `The next \`bench run\` sweeps them; \`rm -r ${BENCH_LOCK_FILE}\` to be rid of them now.`,
     );
     return 0;
   }
-  console.log(`no bench run in flight (no ${state.path}) — the tree is yours to edit.`);
+  console.log(`no bench run in flight (no \`${BENCH_LOCK_FILE}\`) — the tree is yours to edit.`);
   return 0;
 }

--- a/apps/benchmark/src/run/lock.ts
+++ b/apps/benchmark/src/run/lock.ts
@@ -1,0 +1,187 @@
+// Is a `bench run` measuring THIS worktree right now? An advisory marker, and the one question
+// `preflight.ts` structurally cannot answer.
+//
+// The start-time refusal there asks "is the tree dirty at second 0". `provenance.ts` asks "was it
+// dirty at any sample DURING the run", stickily, and `merge` refuses the tier. Between them sits a
+// run that starts clean and is dirtied while it is in flight — a comment audit, a `pnpm format`, an
+// editor save. That run is 39 minutes of measurement no commit holds, and it is the shape that cost
+// the most: one round lost 2,420 s to a comment audit run beside its own gate bench.
+//
+// The fix is not a machine-wide queue. It is a name for the fact: `bench run` writes
+// `bench-running` at the repo root and removes it on the way out, and the phases that EDIT the tree
+// read it and refuse (`pnpm bench lock`, wired into the function briefs' audit phase).
+//
+// ADVISORY, on purpose. It coordinates one worktree's agents, not the machine: two worktrees have
+// two markers, and nothing here waits, queues, or retries.
+//
+// GITIGNORED (`/bench-running`, anchored) — and that is load-bearing rather than tidy. An untracked
+// file at the repo root is exactly what `preflight.ts` refuses to start on and what the mid-run
+// sampler stamps dirty, so a marker git can see would cause the loss it exists to prevent.
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { constants as osConstants } from 'node:os';
+import { join } from 'node:path';
+
+import { REPO_ROOT } from '../config';
+
+/** The marker's name at the repo root. Quoted in every refusal, and in `.gitignore` as
+ *  `/bench-running` — unanchored, the pattern would also hide a file of that name anywhere in the
+ *  tree, which is how a real committed artifact once went missing here. */
+export const BENCH_LOCK_FILE = 'bench-running';
+
+/** What the marker records: enough for a reader to decide whether to wait or to clear it. */
+export interface BenchLockRecord {
+  pid: number;
+  startedAt: string;
+  command: string;
+}
+
+export type BenchLockState =
+  /** No marker: nothing is measuring this worktree. */
+  | { state: 'free'; path: string }
+  /** A marker whose process is still alive. */
+  | { state: 'held'; path: string; record: BenchLockRecord }
+  /** A marker left behind — the run was SIGKILLed, or the machine went down. Treated as free by
+   *  every reader, because the alternative is a round blocked on a file nobody can explain. */
+  | { state: 'stale'; path: string; record?: BenchLockRecord; why: string };
+
+export function benchLockPath(root: string = REPO_ROOT): string {
+  return join(root, BENCH_LOCK_FILE);
+}
+
+/** Is that pid a process this machine still has? EPERM means yes and owned by someone else; only
+ *  ESRCH means gone.
+ *
+ *  A recycled pid therefore reads as HELD when the bench that wrote it is long dead. That is the
+ *  direction to be wrong in: a false `held` costs one `rm` and says so on screen, while a false
+ *  `stale` costs the 2,420 s this file exists to keep. */
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+export function readBenchLock(root: string = REPO_ROOT): BenchLockState {
+  const path = benchLockPath(root);
+  if (!existsSync(path)) {
+    return { state: 'free', path };
+  }
+  let record: BenchLockRecord;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    const r = parsed as Partial<BenchLockRecord>;
+    if (typeof r?.pid !== 'number' || !Number.isInteger(r.pid) || r.pid <= 0) {
+      throw new Error('no pid');
+    }
+    record = { pid: r.pid, startedAt: String(r.startedAt ?? 'unknown'), command: String(r.command ?? 'unknown') };
+  } catch (e) {
+    // A half-written or hand-edited marker names no process, so no reader can ever clear it by
+    // waiting. Unreadable is stale.
+    return { state: 'stale', path, why: `unreadable (${(e as Error).message})` };
+  }
+  return pidAlive(record.pid)
+    ? { state: 'held', path, record }
+    : { state: 'stale', path, record, why: `pid ${record.pid} is gone` };
+}
+
+function elapsed(startedAt: string): string {
+  const t = Date.parse(startedAt);
+  if (Number.isNaN(t)) {
+    return 'unknown';
+  }
+  return `${Math.round((Date.now() - t) / 1000)} s`;
+}
+
+/** What a tree-editing phase is told when a run is in flight, or undefined when it may proceed. */
+export function benchInFlightRefusal(state: BenchLockState): string | undefined {
+  if (state.state !== 'held') {
+    return undefined;
+  }
+  return [
+    `REFUSED: a bench run is measuring this worktree — \`${BENCH_LOCK_FILE}\` (pid ${state.record.pid}, started ` +
+      `${state.record.startedAt}, ${elapsed(state.record.startedAt)} ago): ${state.record.command}`,
+    '',
+    'Editing the tree now does not just risk the edit: `provenance.ts` samples git DURING the run',
+    'and the sample is STICKY, so one save stamps the whole run dirty and `bench:merge` throws the',
+    'numbers away — 39 minutes, after the fact, for a change that was reverted.',
+    'Wait for the run (its log ends in an `EXIT=` line), then edit. If the run is dead, the marker',
+    `names its pid: check, then \`rm ${BENCH_LOCK_FILE}\`.`,
+  ].join('\n');
+}
+
+/** What `bench run` is told when another run already holds this worktree. Separate text: the
+ *  reader is not editing anything, they are about to rewrite `results/<tier>.json` under a run that
+ *  is still writing it. */
+export function concurrentRunRefusal(state: BenchLockState): string | undefined {
+  if (state.state !== 'held') {
+    return undefined;
+  }
+  return [
+    `bench run REFUSED: pid ${state.record.pid} is already running one here (\`${BENCH_LOCK_FILE}\`, started ` +
+      `${state.record.startedAt}, ${elapsed(state.record.startedAt)} ago): ${state.record.command}`,
+    '',
+    'Both runs write `apps/benchmark/results/<tier>.json`, so the second publishes a tier stitched',
+    'from two measurements — and on a 10-core machine they halve each other besides.',
+    `Wait for it, or run in a separate worktree. If that pid is dead, \`rm ${BENCH_LOCK_FILE}\`.`,
+  ].join('\n');
+}
+
+/** Take the marker for this process and arrange for it to go away again.
+ *
+ *  Removal is hung off `process.on('exit')` rather than a `try`/`finally` because `cli.ts` leaves
+ *  through `process.exit()` on a dozen paths, and each one would need its own release. Signals get
+ *  explicit handlers that remove and then re-exit — an unhandled SIGINT never runs `exit`
+ *  listeners, and Ctrl-C on a 39-minute run is not the rare case.
+ *
+ *  What no handler can cover is SIGKILL or a lost machine, which is what `stale` is for. */
+export function acquireBenchLock(command: string, root: string = REPO_ROOT): string {
+  const path = benchLockPath(root);
+  const record: BenchLockRecord = { pid: process.pid, startedAt: new Date().toISOString(), command };
+  writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`);
+  const release = () => releaseBenchLock(root, record.pid);
+  process.on('exit', release);
+  for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+    process.on(sig, () => {
+      release();
+      process.exit(128 + (osConstants.signals[sig] as number));
+    });
+  }
+  return path;
+}
+
+/** Remove the marker, but only if it is still OURS: a run that overwrote a stale marker and a
+ *  concurrent process that cleared it by hand both end with someone else's record on disk, and
+ *  deleting that would silently unlock a live run. */
+export function releaseBenchLock(root: string = REPO_ROOT, pid: number = process.pid): void {
+  const path = benchLockPath(root);
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<BenchLockRecord>;
+    if (parsed?.pid !== pid) {
+      return;
+    }
+  } catch {
+    return;
+  }
+  rmSync(path, { force: true });
+}
+
+/** `bench lock`: the read the audit phases run. Exit 0 = go ahead, 1 = a run is in flight. */
+export function benchLockStatus(root: string = REPO_ROOT): number {
+  const state = readBenchLock(root);
+  const refusal = benchInFlightRefusal(state);
+  if (refusal !== undefined) {
+    console.error(refusal);
+    return 1;
+  }
+  if (state.state === 'stale') {
+    console.log(
+      `no bench run in flight — \`${BENCH_LOCK_FILE}\` is stale (${state.why}). ` +
+        `The next \`bench run\` overwrites it; \`rm ${BENCH_LOCK_FILE}\` to be rid of it now.`,
+    );
+    return 0;
+  }
+  console.log(`no bench run in flight (no ${state.path}) — the tree is yours to edit.`);
+  return 0;
+}

--- a/apps/benchmark/src/run/lock.ts
+++ b/apps/benchmark/src/run/lock.ts
@@ -1,24 +1,40 @@
-// Is a `bench run` measuring THIS worktree right now? An advisory marker, and the one question
-// `preflight.ts` structurally cannot answer.
+// Which `bench run`s are measuring something on this MACHINE right now? An advisory register of
+// records, and the two questions `preflight.ts` structurally cannot answer from a git status.
 //
-// The start-time refusal there asks "is the tree dirty at second 0". `provenance.ts` asks "was it
-// dirty at any sample DURING the run", stickily, and `merge` refuses the tier. Between them sits a
-// run that starts clean and is dirtied while it is in flight — a comment audit, a `pnpm format`, an
-// editor save. That run is 39 minutes of measurement no commit holds, and it is the shape that cost
-// the most: one round lost 2,420 s to a comment audit run beside its own gate bench.
+// QUESTION 1 — "may I edit this tree?" The start-time refusal in `preflight.ts` asks "is the tree
+// dirty at second 0". `provenance.ts` asks "was it dirty at any sample DURING the run", stickily,
+// and `merge` refuses the tier. Between them sits a run that starts clean and is dirtied while it
+// is in flight — a comment audit, a `pnpm format`, an editor save. That run is 39 minutes of
+// measurement no commit holds, and it is the shape that cost the most: one round lost 2,420 s to a
+// comment audit run beside its own gate bench.
 //
-// The fix is not a machine-wide queue. It is a name for the fact: `bench run` writes a record under
-// `bench-running/` at the repo root and removes it on the way out, and the phases that EDIT the
-// tree read it and refuse (`pnpm bench lock`, wired into the function briefs' audit phase).
+// QUESTION 2 — "may I start a run?" Two full benches on one machine halve each other (2,704 s
+// against a neighbour versus 1,800 s solo) and, worse, a shard killed by a neighbour writes a
+// partial tier with NO error line. That is the standing house rule "two full benches must never
+// overlap on this machine", and it is the hazard with two recorded incidents.
 //
-// ONE RECORD PER RUN, not one slot. `bench-running/<pid>.json`, because a single slot makes the
-// guard LIE: a second run that took the slot would delete the first run's protection when IT
-// finished, and `bench lock` would then clear an audit to edit the tree under a bench still in
-// flight — louder than no guard, and wrong. A worktree is held while ANY record names a live
-// process, and a run only ever writes and unlinks its own.
+// So the register is MACHINE-WIDE and each record names the tree it measures: a run writes
+// `<register>/<pid>.json` on the way in and removes it on the way out, and every reader filters by
+// what it actually cares about. Question 1 reads only the records whose `root` is this worktree —
+// a neighbour's bench cannot be dirtied by an edit here. Question 2 reads them all: a whole-tier
+// run is refused against a whole-tier run at ANY root, and same-root runs are refused when they
+// write the same `results/<tier>.json`.
 //
-// ADVISORY, on purpose. It coordinates one worktree's agents, not the machine: two worktrees have
-// two directories, and nothing here waits, queues, or retries.
+// WHERE, and why not `os.tmpdir()`. A machine-wide rendezvous is worth nothing if two processes
+// disagree about where it is, and `tmpdir()` disagrees: measured on this machine, an interactive
+// shell gives `/var/folders/…/T` from `$TMPDIR` while the same node with `TMPDIR` unset gives
+// `/tmp`. Two agents would then hold two registers and each would read the other as absent — the
+// guard firing green while the hazard is live, which is worse than no guard. `/tmp` is resolved
+// from no environment variable, so every process on this machine agrees. The uid suffix is for
+// permissions, not privacy: `/tmp` is sticky, and a second user's records would be unremovable.
+//
+// ADVISORY: nothing here waits, queues or retries, and `--no-lock` walks past it (see
+// `concurrentRunRefusal`). The register is a name for a fact, not a mutex.
+//
+// ONE RECORD PER RUN, not one slot. A single slot makes the guard LIE: a second run that took the
+// slot would delete the first run's protection when IT finished, and a tree-editing phase would
+// then be cleared to edit under a bench still in flight — louder than no guard, and wrong. A run
+// only ever writes and unlinks its own record.
 //
 // NO SIGNAL HANDLERS, and this is the one place tidiness had to lose. `orchestrate.ts` blocks the
 // event loop in `spawnSync` for every case, so a JS listener for SIGTERM turns an OS-level kill
@@ -36,46 +52,54 @@
 // So a run that dies without reaching its exit path leaves its record behind, exactly like a
 // SIGKILL: it names a pid that is gone, so it reads `stale`, and stale blocks nothing.
 //
-// GITIGNORED (`/bench-running`, anchored) — and that is load-bearing rather than tidy. An untracked
-// path at the repo root is exactly what `preflight.ts` refuses to start on and what the mid-run
-// sampler stamps dirty, so a marker git can see would cause the loss it exists to prevent.
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, rmdirSync, writeFileSync } from 'node:fs';
+// OUTSIDE EVERY WORKTREE, which is what makes it free. A marker inside the tree is an untracked
+// path — exactly what `preflight.ts` refuses to start on and what the mid-run sampler stamps
+// dirty — so it would have to be gitignored, and the guard would be one `.gitignore` edit away
+// from causing the loss it exists to prevent. In `/tmp` it cannot be seen by git at all.
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { REPO_ROOT } from '../config';
 
-/** The marker's name at the repo root: a directory of `<pid>.json` records. Quoted in every
- *  refusal, and in `.gitignore` as `/bench-running` — unanchored, the pattern would also hide
- *  anything of that name anywhere in the tree, which is how a real committed artifact once went
- *  missing here. */
-export const BENCH_LOCK_FILE = 'bench-running';
+/** The register's directory: machine-wide, per-uid, and derived from NO environment variable —
+ *  see the header for the `tmpdir()` measurement that rules that function out here. Quoted in
+ *  every refusal, so a reader can `ls` it. */
+export const BENCH_LOCK_DIR =
+  process.platform === 'win32'
+    ? join(tmpdir(), 'asmlift-bench-running')
+    : `/tmp/asmlift-bench-running-${typeof process.getuid === 'function' ? process.getuid() : 0}`;
 
-/** What one run records: enough for a reader to decide whether to wait or to clear it, and enough
- *  for the NEXT run to tell whether the two of them collide on a `results/<tier>.json`. */
+/** What one run records. Enough for a reader to decide whether to wait or to clear it, enough for
+ *  the NEXT run to tell whether the two collide on a `results/<tier>.json`, and enough to tell a
+ *  run measuring THIS worktree from one measuring a neighbour. */
 export interface BenchLockRecord {
   pid: number;
   startedAt: string;
   command: string;
-  /** The tiers this run writes. Empty only for a record written by an older build. */
+  /** The tiers this run writes. */
   tiers: string[];
+  /** The worktree it measures. Absent in a record this build cannot parse; absent means UNKNOWN,
+   *  and unknown is never a clearance — it matches every root. */
+  root?: string;
+  /** Does it rewrite at least one tier file WHOLE (`preflight.ts`'s `runIsWholeTier`)? That, not
+   *  "is it slow", is what makes two runs a house-rule violation rather than a dev loop. */
+  whole: boolean;
 }
 
 export type BenchLockState =
-  /** No live record: nothing is measuring this worktree. */
+  /** No live record anywhere on this machine. */
   | { state: 'free'; path: string }
-  /** At least one record naming a live process, oldest first. */
+  /** At least one record naming a live process, oldest first. Records at ANY root: it is each
+   *  reader's job to filter, because the two questions filter differently. */
   | { state: 'held'; path: string; records: BenchLockRecord[] }
   /** The directory is there but every record in it is dead or unreadable — a SIGKILLed or
    *  signalled run, or a lost machine. Treated as free by every reader, because the alternative is
    *  a round blocked on a file nobody can explain. */
   | { state: 'stale'; path: string; why: string };
 
-export function benchLockPath(root: string = REPO_ROOT): string {
-  return join(root, BENCH_LOCK_FILE);
-}
-
-function recordPath(root: string, pid: number): string {
-  return join(benchLockPath(root), `${pid}.json`);
+function recordPath(dir: string, pid: number): string {
+  return join(dir, `${pid}.json`);
 }
 
 /** Is that pid a process this machine still has? EPERM means yes and owned by someone else; only
@@ -83,7 +107,8 @@ function recordPath(root: string, pid: number): string {
  *
  *  A recycled pid therefore reads as HELD when the bench that wrote it is long dead. That is the
  *  direction to be wrong in: a false `held` costs one `rm` of a record named on screen, while a
- *  false `stale` costs the 2,420 s this file exists to keep. */
+ *  false `stale` costs the 2,420 s this file exists to keep. `/tmp` is cleared on reboot, which is
+ *  when recycling is likeliest. */
 function pidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -104,6 +129,10 @@ function parseRecord(text: string): BenchLockRecord | undefined {
       startedAt: String(r.startedAt ?? 'unknown'),
       command: String(r.command ?? 'unknown'),
       tiers: Array.isArray(r.tiers) ? r.tiers.map(String) : [],
+      root: typeof r.root === 'string' ? r.root : undefined,
+      // Unknown is not a clearance, on this axis too: a record that does not say gets treated as
+      // the run that collides.
+      whole: r.whole !== false,
     };
   } catch {
     // A half-written or hand-edited record names no process, so no reader can ever clear it by
@@ -114,15 +143,25 @@ function parseRecord(text: string): BenchLockRecord | undefined {
 
 /** Every record on disk, live and dead, so acquire can sweep the dead ones and read can explain
  *  itself. Anything that is not a readable `<pid>.json` counts as one dead record. */
-function scan(root: string): { live: BenchLockRecord[]; dead: string[] } {
-  const dir = benchLockPath(root);
+function scan(dir: string): { live: BenchLockRecord[]; dead: string[] } {
   let names: string[];
   try {
     names = readdirSync(dir).filter((n) => n.endsWith('.json'));
   } catch {
-    // Missing, or a plain FILE where the directory should be (an older build's marker, a stray
-    // `touch`). Either way there is no live record in it.
-    return { live: [], dead: existsSync(dir) ? [dir] : [] };
+    // Either it is not there at all, or something that is not a readable directory is. A PLAIN
+    // file (a stray `touch`) names no live run and is safe to clear; an unreadable DIRECTORY is
+    // not — sweeping that would delete live records — so it is reported as neither, and the
+    // acquire below fails loudly on its own write instead.
+    if (!existsSync(dir)) {
+      return { live: [], dead: [] };
+    }
+    let isDir = false;
+    try {
+      isDir = lstatSync(dir).isDirectory();
+    } catch {
+      isDir = false;
+    }
+    return { live: [], dead: isDir ? [] : [dir] };
   }
   const live: BenchLockRecord[] = [];
   const dead: string[] = [];
@@ -132,6 +171,9 @@ function scan(root: string): { live: BenchLockRecord[]; dead: string[] } {
     try {
       record = parseRecord(readFileSync(path, 'utf8'));
     } catch {
+      // Including EISDIR: a DIRECTORY named `<pid>.json` is junk, and it is swept like any other
+      // unreadable record. The sweep's `rmSync` is recursive for exactly this case — without it,
+      // one such directory makes every later `bench run` in this register die on a Node stack.
       record = undefined;
     }
     if (record && pidAlive(record.pid)) {
@@ -144,16 +186,21 @@ function scan(root: string): { live: BenchLockRecord[]; dead: string[] } {
   return { live, dead };
 }
 
-export function readBenchLock(root: string = REPO_ROOT): BenchLockState {
-  const path = benchLockPath(root);
-  const { live, dead } = scan(root);
+export function readBenchLock(dir: string = BENCH_LOCK_DIR): BenchLockState {
+  const { live, dead } = scan(dir);
   if (live.length > 0) {
-    return { state: 'held', path, records: live };
+    return { state: 'held', path: dir, records: live };
   }
   if (dead.length > 0) {
-    return { state: 'stale', path, why: `${dead.length} record(s), none naming a live process` };
+    return { state: 'stale', path: dir, why: `${dead.length} record(s), none naming a live process` };
   }
-  return { state: 'free', path };
+  return { state: 'free', path: dir };
+}
+
+/** Does this record measure that worktree? A record that does not say which tree it measures
+ *  matches every one: unknown is not a clearance. */
+function measures(r: BenchLockRecord, root: string): boolean {
+  return r.root === undefined || r.root === root;
 }
 
 function elapsed(startedAt: string): string {
@@ -164,58 +211,108 @@ function elapsed(startedAt: string): string {
   return `${Math.round((Date.now() - t) / 1000)} s`;
 }
 
-function describe(r: BenchLockRecord): string {
+/** One record as a line a reader can act on. The directory comes from the STATE that was read,
+ *  never from `BENCH_LOCK_DIR`: every refusal here quotes a path to `rm`, and a message naming a
+ *  path the reader did not read is a message that sends them to delete the wrong file. */
+function describe(r: BenchLockRecord, dir: string): string {
   return (
-    `\`${BENCH_LOCK_FILE}/${r.pid}.json\` (pid ${r.pid}, started ${r.startedAt}, ` +
-    `${elapsed(r.startedAt)} ago): ${r.command}`
+    `\`${dir}/${r.pid}.json\` (pid ${r.pid}, started ${r.startedAt}, ` + `${elapsed(r.startedAt)} ago): ${r.command}`
   );
 }
 
-/** What a tree-editing phase is told when a run is in flight, or undefined when it may proceed. */
-export function benchInFlightRefusal(state: BenchLockState): string | undefined {
+/** What a tree-editing phase is told when a run is measuring THIS worktree, or undefined when it
+ *  may proceed. Filtered by root on purpose: a neighbour worktree's bench cannot be stamped dirty
+ *  by an edit here, and refusing on it would block every round on this machine whenever any round
+ *  is measuring. */
+export function benchInFlightRefusal(state: BenchLockState, root: string = REPO_ROOT): string | undefined {
   if (state.state !== 'held') {
     return undefined;
   }
+  const mine = state.records.filter((r) => measures(r, root));
+  if (mine.length === 0) {
+    return undefined;
+  }
   return [
-    `REFUSED: a bench run is measuring this worktree — ${describe(state.records[0])}`,
-    ...state.records.slice(1).map((r) => `  and ${describe(r)}`),
+    `REFUSED: a bench run is measuring this worktree — ${describe(mine[0], state.path)}`,
+    ...mine.slice(1).map((r) => `  and ${describe(r, state.path)}`),
     '',
     'Editing the tree now does not just risk the edit: `provenance.ts` samples git DURING the run',
     'and the sample is STICKY, so one save stamps the whole run dirty and `bench:merge` throws the',
     'numbers away — 39 minutes, after the fact, for a change that was reverted.',
     'Wait for the run (its log ends in an `EXIT=` line), then edit. If the run is dead, the record',
-    `names its pid: check, then \`rm ${BENCH_LOCK_FILE}/<pid>.json\`.`,
+    `names its pid: check, then \`rm ${state.path}/<pid>.json\`.`,
   ].join('\n');
 }
 
-/** What `bench run` is told when a run already in flight writes a tier file it is about to write.
+/** What this run is: the three facts every verdict below is decided on. */
+export interface BenchRunIdentity {
+  tiers: readonly string[];
+  /** Does it rewrite a tier file whole? `preflight.ts`'s `runIsWholeTier`. */
+  whole: boolean;
+  root?: string;
+}
+
+/** What `bench run` is told when another run makes starting this one a mistake, on either of the
+ *  two counts that have actually cost time.
  *
- *  Gated on the TIERS, not on "a run is in flight". A background `--tier real` and a scoped
- *  `--tier synthetic --only <sym>` touch different files and are the dev loop HARD RULE 2 and both
- *  briefs prescribe; refusing that would be the trade `preflight.ts` warns about in advance — "one
- *  sanctioned name beats an escape hatch", and the invented way past a wrong refusal here is `rm`,
- *  which is the one move that can silently unprotect the run still in flight. A scoped run on the
- *  SAME tier is still refused: it rewrites `results/<tier>.json` with its handful of rows. */
-export function concurrentRunRefusal(state: BenchLockState, tiers: readonly string[]): string | undefined {
+ *  SAME WORKTREE, SAME TIER FILE. A run already in flight here writes `results/<tier>.json`, and so
+ *  does this one — including a one-row `--only` run, which rewrites the canonical file with its
+ *  handful of rows (`orchestrate.ts`'s `stitch`). The tiers decide it and not "a run is in flight":
+ *  a scoped `--tier synthetic --only <sym>` beside a background `--tier real` touches different
+ *  files and is the dev loop the house rules and both briefs prescribe.
+ *
+ *  TWO FULL BENCHES, ANY WORKTREE. The house rule, mechanised: 2,704 s against a neighbour versus
+ *  1,800 s solo, and a shard killed by a neighbour writes a partial tier with no error line. Only
+ *  whole-tier against whole-tier — a 15 s scoped probe is not what fans 8 shards, and refusing it
+ *  because a neighbour is busy would be this guard inventing a rule nobody has an incident for.
+ *
+ *  AND THERE IS A SANCTIONED DOOR, `--no-lock`. Not because the refusal is doubted: it is right,
+ *  and the wait is the correct move. It is here because the alternative door is `rm`ing someone
+ *  else's record, which is the one move that can silently unprotect a run still in flight — the
+ *  same "one sanctioned name beats an escape hatch" trade `preflight.ts` makes for `.envrc.local`.
+ *  A refusal an agent cannot legitimately pass is a refusal it passes illegitimately. */
+export function concurrentRunRefusal(state: BenchLockState, run: BenchRunIdentity): string | undefined {
   if (state.state !== 'held') {
     return undefined;
   }
-  const clashes = state.records
-    .map((r) => ({ record: r, shared: r.tiers.filter((t) => tiers.includes(t)) }))
-    // An older build's record carries no tiers; assume it collides rather than assume it does not.
-    .filter((c) => c.shared.length > 0 || c.record.tiers.length === 0);
-  if (clashes.length === 0) {
+  const root = run.root ?? REPO_ROOT;
+  const sameFile = state.records.find(
+    (r) => measures(r, root) && (r.tiers.length === 0 || r.tiers.some((t) => run.tiers.includes(t))),
+  );
+  if (sameFile !== undefined) {
+    const shared = sameFile.tiers.filter((t) => run.tiers.includes(t));
+    const files = (shared.length > 0 ? shared : run.tiers).map((t) => `apps/benchmark/results/${t}.json`).join(', ');
+    return [
+      `bench run REFUSED: pid ${sameFile.pid} is already measuring this worktree — ${describe(sameFile, state.path)}`,
+      '',
+      `Both runs write ${files}, so the second publishes a tier stitched from two`,
+      'measurements — a one-row `--only` run rewrites that file too, with its one row.',
+      'Wait for it (its log ends in an `EXIT=` line), or run a SCOPED probe (`--only`) on a tier it',
+      'is not writing — scoped, because a second WHOLE tier beside this one halves both runs and',
+      'can kill a shard with no error line. A separate worktree is the other way.',
+      `If that pid is dead: \`rm ${state.path}/${sameFile.pid}.json\`. If you have a reason to`,
+      'measure anyway, `--no-lock` says so out loud and leaves every other record alone — never',
+      "`rm` a record you did not write, which is the one move that unprotects someone else's run.",
+    ].join('\n');
+  }
+  if (!run.whole) {
     return undefined;
   }
-  const shared = clashes[0].shared;
-  const files = (shared.length > 0 ? shared : tiers).map((t) => `apps/benchmark/results/${t}.json`).join(', ');
+  const otherWhole = state.records.find((r) => r.whole);
+  if (otherWhole === undefined) {
+    return undefined;
+  }
   return [
-    `bench run REFUSED: pid ${clashes[0].record.pid} is already running one here — ${describe(clashes[0].record)}`,
+    `bench run REFUSED: a full bench is already running on this machine — ${describe(otherWhole, state.path)}`,
+    `  in ${otherWhole.root ?? 'an unrecorded worktree'}`,
     '',
-    `Both runs write ${files}, so the second publishes a tier stitched from two`,
-    'measurements — and on a 10-core machine they halve each other besides.',
-    'Wait for it, run a tier it is not writing, or use a separate worktree. If that pid is dead,',
-    `\`rm ${BENCH_LOCK_FILE}/${clashes[0].record.pid}.json\`.`,
+    'Two full benches must never overlap here: 10 cores, 8 shards each, and one measured 2,704 s',
+    'against a neighbour versus 1,800 s solo. Worse than slow — a shard killed by a neighbour',
+    'writes a partial tier with NO error line, and `grep -c SKIP` reads 0 either way.',
+    'Wait for it, or scope this one (`--only <sym>`, or `--tier` the one it is not writing): a',
+    'scoped probe is not refused against a neighbour, only against a run writing the same file.',
+    `If that pid is dead: \`rm ${state.path}/${otherWhole.pid}.json\`. If you have a reason to`,
+    'measure anyway, `--no-lock` says so out loud and leaves every other record alone.',
   ].join('\n');
 }
 
@@ -227,66 +324,81 @@ export function concurrentRunRefusal(state: BenchLockState, tiers: readonly stri
  *  record naming a dead pid, which is what `stale` is for, and the same is true of SIGKILL or a
  *  lost machine.
  *
- *  Never touches another run's record, on either side. Two runs launched in the same millisecond
- *  can both read `free` and both proceed — a read/write window `concurrentRunRefusal` cannot close
- *  from here. Left open knowingly: with one record per pid the racing pair only DUPLICATES work,
- *  where the single-slot shape had the second run EVICT the first's protection, and real launches
- *  are seconds apart. */
-export function acquireBenchLock(command: string, tiers: readonly string[], root: string = REPO_ROOT): string {
-  const dir = benchLockPath(root);
-  const { dead } = scan(root);
+ *  Never touches another run's record, on either side, and never removes the DIRECTORY: an empty
+ *  register costs nothing outside the tree, while removing it would race a neighbour that has just
+ *  created it and not yet written into it, throwing ENOENT out of a 35-minute command before it
+ *  did any work.
+ *
+ *  Two runs launched in the same millisecond can both read `free` and both proceed — a read/write
+ *  window no reader can close from here. Left open knowingly: with one record per pid the racing
+ *  pair only DUPLICATES work, where the single-slot shape had the second run EVICT the first's
+ *  protection, and real launches are seconds apart. */
+export function acquireBenchLock(command: string, run: BenchRunIdentity, dir: string = BENCH_LOCK_DIR): string {
+  const { dead } = scan(dir);
   if (dead.length === 1 && dead[0] === dir) {
-    // A plain file where the directory belongs. It names no live run, so it is safe to clear.
-    console.error(`[bench lock] cleared a stale \`${BENCH_LOCK_FILE}\` left by an older build`);
-    rmSync(dir, { force: true });
+    // Something that is not a directory where the register belongs. It names no live run.
+    console.error(`[bench lock] cleared a stray \`${dir}\` that is not a directory`);
+    rmSync(dir, { recursive: true, force: true });
   }
   mkdirSync(dir, { recursive: true });
   for (const path of dead) {
     if (path === dir) {
       continue;
     }
-    console.error(`[bench lock] cleared a stale record: ${path.slice(root.length + 1)}`);
-    rmSync(path, { force: true });
+    console.error(`[bench lock] cleared a stale record: ${path}`);
+    // Recursive because a DIRECTORY named `<pid>.json` reaches this list too, and a plain `rmSync`
+    // throws EISDIR on it — which would brick every later run in this register.
+    rmSync(path, { recursive: true, force: true });
   }
   const record: BenchLockRecord = {
     pid: process.pid,
     startedAt: new Date().toISOString(),
     command,
-    tiers: [...tiers],
+    tiers: [...run.tiers],
+    root: run.root ?? REPO_ROOT,
+    whole: run.whole,
   };
-  const path = recordPath(root, process.pid);
+  const path = recordPath(dir, process.pid);
   writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`);
-  process.on('exit', () => releaseBenchLock(root, record.pid));
+  process.on('exit', () => releaseBenchLock(dir, record.pid));
   return path;
 }
 
-/** Remove OUR record, and the directory once it holds nothing. Another run's record is never
- *  touched: deleting one would silently unlock a live run, which is the failure that makes an
- *  advisory guard worse than none. */
-export function releaseBenchLock(root: string = REPO_ROOT, pid: number = process.pid): void {
-  rmSync(recordPath(root, pid), { force: true });
-  try {
-    rmdirSync(benchLockPath(root));
-  } catch {
-    // Not empty (another run holds a record), or already gone. Both are fine.
-  }
+/** Remove OUR record. Another run's record is never touched: deleting one would silently unlock a
+ *  live run, which is the failure that makes an advisory guard worse than none. */
+export function releaseBenchLock(dir: string = BENCH_LOCK_DIR, pid: number = process.pid): void {
+  rmSync(recordPath(dir, pid), { recursive: true, force: true });
 }
 
-/** `bench lock`: the read the audit phases run. Exit 0 = go ahead, 1 = a run is in flight. */
-export function benchLockStatus(root: string = REPO_ROOT): number {
-  const state = readBenchLock(root);
-  const refusal = benchInFlightRefusal(state);
+/** `bench in-flight`: the read the tree-editing phases run. Exit 0 = go ahead, 1 = a run is
+ *  measuring THIS worktree. A neighbour's run is reported and does not change the verdict — it
+ *  cannot be dirtied from here, but a reader deciding whether to start a bench wants to know. */
+export function benchLockStatus(dir: string = BENCH_LOCK_DIR, root: string = REPO_ROOT): number {
+  const state = readBenchLock(dir);
+  const elsewhere = state.state === 'held' ? state.records.filter((r) => !measures(r, root)) : [];
+  const note = (): void => {
+    for (const r of elsewhere) {
+      console.log(
+        `(a bench is also running in ${r.root} — ${describe(r, state.path)}; it does not block an edit here,`,
+      );
+      console.log(' but starting a second FULL bench beside it is refused, and for good reason)');
+    }
+  };
+  const refusal = benchInFlightRefusal(state, root);
   if (refusal !== undefined) {
     console.error(refusal);
+    note();
     return 1;
   }
   if (state.state === 'stale') {
     console.log(
-      `no bench run in flight — \`${BENCH_LOCK_FILE}\` holds only records of dead runs (${state.why}). ` +
-        `The next \`bench run\` sweeps them; \`rm -r ${BENCH_LOCK_FILE}\` to be rid of them now.`,
+      `no bench run in flight — \`${dir}\` holds only records of dead runs (${state.why}). ` +
+        `The next \`bench run\` sweeps them; \`rm -r ${dir}\` to be rid of them now.`,
     );
+    note();
     return 0;
   }
-  console.log(`no bench run in flight (no \`${BENCH_LOCK_FILE}\`) — the tree is yours to edit.`);
+  console.log(`no bench run is measuring this worktree (no live record in \`${dir}\`) — it is yours to edit.`);
+  note();
   return 0;
 }

--- a/apps/benchmark/src/run/lock.ts
+++ b/apps/benchmark/src/run/lock.ts
@@ -46,8 +46,7 @@
 // its own hidden SIGINT/SIGTERM handler (hidden: it patches `process.listenerCount`, which reports
 // 0), so the CLI is signal-deferred on `origin/main` too — measured, with no handler of ours: a
 // `bench run --tier synthetic --serial` sent SIGTERM 6 s in ran all 291 cases, REWROTE
-// `results/synthetic.json`, and only then exited 143. `kill -9` is the stop that works. Adding a
-// second listener on top of that could only make things worse, and did.
+// `results/synthetic.json`, and only then exited 143. `kill -9` is the stop that works.
 //
 // So a run that dies without reaching its exit path leaves its record behind, exactly like a
 // SIGKILL: it names a pid that is gone, so it reads `stale`, and stale blocks nothing.
@@ -62,9 +61,10 @@ import { join } from 'node:path';
 
 import { REPO_ROOT } from '../config';
 
-/** The register's directory: machine-wide, per-uid, and derived from NO environment variable —
- *  see the header for the `tmpdir()` measurement that rules that function out here. Quoted in
- *  every refusal, so a reader can `ls` it. */
+/** The register's directory: machine-wide, per-uid, and — where the incidents happen — derived
+ *  from NO environment variable; see the header for the `tmpdir()` measurement that rules that
+ *  function out. Windows has no `/tmp` to agree on and no bench, so it falls back. Quoted in every
+ *  refusal, so a reader can `ls` it. */
 export const BENCH_LOCK_DIR =
   process.platform === 'win32'
     ? join(tmpdir(), 'asmlift-bench-running')
@@ -79,8 +79,9 @@ export interface BenchLockRecord {
   command: string;
   /** The tiers this run writes. */
   tiers: string[];
-  /** The worktree it measures. Absent in a record this build cannot parse; absent means UNKNOWN,
-   *  and unknown is never a clearance — it matches every root. */
+  /** The worktree it measures. Absent in a record that did not say which — an older build, or a
+   *  hand-written one. Absent means UNKNOWN, and unknown is never a clearance: it matches every
+   *  root. */
   root?: string;
   /** Does it rewrite at least one tier file WHOLE (`preflight.ts`'s `runIsWholeTier`)? That, not
    *  "is it slow", is what makes two runs a house-rule violation rather than a dev loop. */
@@ -107,8 +108,7 @@ function recordPath(dir: string, pid: number): string {
  *
  *  A recycled pid therefore reads as HELD when the bench that wrote it is long dead. That is the
  *  direction to be wrong in: a false `held` costs one `rm` of a record named on screen, while a
- *  false `stale` costs the 2,420 s this file exists to keep. `/tmp` is cleared on reboot, which is
- *  when recycling is likeliest. */
+ *  false `stale` costs the 2,420 s this file exists to keep. */
 function pidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);

--- a/apps/benchmark/src/run/preflight.ts
+++ b/apps/benchmark/src/run/preflight.ts
@@ -21,8 +21,9 @@
 // nothing was written — and the reader of this refusal is deciding whether to commit or to route
 // around it.
 //
-// TWO LAWS, TWO PREDICATES. `runIsWholeTier` asks "does this invocation rewrite a tier file
-// whole", which is the git question and only the git question. The `cpp` question is a different
+// THREE LAWS, THREE PREDICATES. `runIsWholeTier` asks "does this invocation rewrite a tier file
+// whole", which is the git question and only the git question — and, in `run/lock.ts`, also the
+// question of whether starting it beside a neighbour's full bench breaks the house rule. The `cpp` question is a different
 // one — "will this invocation preprocess anything with the host `cpp`" — and the tier alone
 // decides it: every `CPP` call site in `compile/{ido,kmc,gcc272}.ts` sits inside the `*Real`
 // export, `compile/real.ts` is their only consumer, and no synthetic row preprocesses. Scoping
@@ -45,6 +46,7 @@ import { CPP_PREPROCESS_FLAGS } from '../compile/util';
 import { CPP, REPO_ROOT } from '../config';
 import { codeDirtyPaths } from '../provenance';
 import { type ToolchainId, availableToolchains } from '../toolchains';
+import { type BenchLockState, concurrentRunRefusal, readBenchLock } from './lock';
 import { type Tier, tierIsFiltered } from './orchestrate';
 
 /** The gitignored name a local env file is expected to take, quoted in the refusal. One sanctioned
@@ -77,13 +79,25 @@ export interface PreflightOptions {
   serial?: boolean;
 }
 
-/** A shard CHILD, exempt from BOTH verdicts: the parent that spawned it has already answered them
- *  once, and every child re-answering would print the same refusal N times. `--shard` alone is NOT
- *  that child — `cli.ts`'s fan-out branch ignores the shard and runs the tier whole — so the test
- *  is `--shard` AND `--serial`, exactly how `orchestrate.ts` spawns one
- *  (`run --serial --tier X --shard i/N`). `cli.ts` rejects the other combination outright. */
-export function isShardChild(opts: PreflightOptions): boolean {
+/** A shard CHILD, exempt from EVERY verdict in this file and from taking a lock record: the parent
+ *  that spawned it has already answered them once, and every child re-answering would print the
+ *  same refusal N times — or, for the record, would say eight runs are in flight. `--shard` alone
+ *  is NOT that child — `cli.ts`'s fan-out branch ignores the shard and runs the tier whole — so
+ *  the test is `--shard` AND `--serial`, exactly how `orchestrate.ts` spawns one
+ *  (`run --serial --tier X --shard i/N`). `cli.ts` rejects the other combination outright.
+ *
+ *  Private: the three predicates below are the exported surface, so that every exemption is
+ *  spelled in the file that owns the sentence above rather than re-derived by a caller. */
+function isShardChild(opts: PreflightOptions): boolean {
   return opts.shard !== undefined && opts.serial === true;
+}
+
+/** Does this invocation write a record into `run/lock.ts`'s register, so the phases that edit the
+ *  tree can see it? Every run but a shard child. Exported for `cli.ts`, which takes the record
+ *  after this file's verdicts pass — taking one is not a refusal, so it does not belong in
+ *  `preflightRefusals`, but WHICH invocations are exempt does belong here with the other two. */
+export function runTakesTheBenchLock(opts: PreflightOptions): boolean {
+  return !isShardChild(opts);
 }
 
 /** Will this invocation rewrite at least one tier file WHOLE? That — not "is it slow" — is the
@@ -169,6 +183,10 @@ export interface PreflightDeps {
   repoRoot?: string;
   probe?: () => { ok: boolean; how: string };
   cppUsingToolchains?: () => ToolchainId[];
+  lockState?: () => BenchLockState;
+  /** `--no-lock`: the sanctioned way past the concurrent-run verdict, and the reason the verdict
+   *  can afford to be strict. See `concurrentRunRefusal`. */
+  ignoreLock?: boolean;
 }
 
 /** Which of the cpp-preprocessing toolchains are actually installed here. */
@@ -180,8 +198,14 @@ export function cppUsingToolchains(): ToolchainId[] {
 
 /** Every start-time verdict. Returned rather than exited on, so the caller owns the exit code and
  *  the test owns neither. Each verdict is gated on ITS OWN predicate — see the header:
- *  `runIsWholeTier` for git, `runUsesHostCpp` for the probe — so a scoped real run is checked for
- *  `cpp` and not for dirt, and a whole synthetic run the other way round.
+ *  `runTakesTheBenchLock` for the concurrent-run register, `runIsWholeTier` for git,
+ *  `runUsesHostCpp` for the probe — so a scoped real run is checked for `cpp` and not for dirt,
+ *  and a whole synthetic run the other way round.
+ *
+ *  The concurrent-run verdict lives HERE and not in `cli.ts` because it is the same shape as the
+ *  other two — a start-time refusal, gated on a predicate over the same options — and this file's
+ *  first sentence is its charter. `cli.ts` keeps only the WRITE (`acquireBenchLock`), which is not
+ *  a verdict.
  *
  *  A WARNING and not a refusal when `cpp` is broken but no toolchain that uses it is installed:
  *  this harness's standing policy is that a missing tool SKIPS its rows (`toolchains.ts` →
@@ -196,8 +220,21 @@ export function preflightRefusals(
 ): { refusals: string[]; warnings: string[] } {
   const refusals: string[] = [];
   const warnings: string[] = [];
+  const repoRoot = deps.repoRoot ?? REPO_ROOT;
+  // First, because it costs a readdir where the next verdict costs a `git status` and the one
+  // after it a compile — and because it is the verdict whose answer changes while you read it.
+  if (runTakesTheBenchLock(opts) && deps.ignoreLock !== true) {
+    const concurrent = concurrentRunRefusal((deps.lockState ?? readBenchLock)(), {
+      tiers: opts.tiers,
+      whole: runIsWholeTier(opts),
+      root: repoRoot,
+    });
+    if (concurrent !== undefined) {
+      refusals.push(concurrent);
+    }
+  }
   if (runIsWholeTier(opts)) {
-    const status = spawnSync('git', ['-C', deps.repoRoot ?? REPO_ROOT, 'status', '--porcelain'], { encoding: 'utf8' });
+    const status = spawnSync('git', ['-C', repoRoot, 'status', '--porcelain'], { encoding: 'utf8' });
     // git being unreadable is not a dirty tree, and the run-time stamp already reports that case as
     // dirty on its own. Refusing here on it would block a bench run in a tarball checkout.
     const dirty = status.status === 0 ? dirtyTreeRefusal(codeDirtyPaths(status.stdout)) : undefined;

--- a/apps/benchmark/src/run/preflight.ts
+++ b/apps/benchmark/src/run/preflight.ts
@@ -21,11 +21,13 @@
 // nothing was written — and the reader of this refusal is deciding whether to commit or to route
 // around it.
 //
-// THREE LAWS, THREE PREDICATES. `runIsWholeTier` asks "does this invocation rewrite a tier file
-// whole", which is the git question and only the git question — and, in `run/lock.ts`, also the
-// question of whether starting it beside a neighbour's full bench breaks the house rule. The `cpp` question is a different
-// one — "will this invocation preprocess anything with the host `cpp`" — and the tier alone
-// decides it: every `CPP` call site in `compile/{ido,kmc,gcc272}.ts` sits inside the `*Real`
+// THREE LAWS, THREE PREDICATES. `runTakesTheBenchLock` asks "is this a run at all, rather than one
+// of its own shard children" — the only invocations that carry a record in `run/lock.ts`'s
+// register, and so the only ones its concurrent-run refusal is about. `runIsWholeTier` asks "does
+// this invocation rewrite a tier file whole": the git question, and also what makes a second run
+// beside a neighbour's a breach of the house rule rather than a dev loop. The `cpp` question is a
+// different one — "will this invocation preprocess anything with the host `cpp`" — and the tier
+// alone decides it: every `CPP` call site in `compile/{ido,kmc,gcc272}.ts` sits inside the `*Real`
 // export, `compile/real.ts` is their only consumer, and no synthetic row preprocesses. Scoping
 // cannot narrow it (`--toolchain` does not filter the real tier at all — `cases/real.ts` takes
 // only `project`/`only`), and it must not: the scoped `--tier real --only <sym>` loop that both

--- a/apps/benchmark/src/run/preflight.ts
+++ b/apps/benchmark/src/run/preflight.ts
@@ -82,7 +82,7 @@ export interface PreflightOptions {
  *  that child — `cli.ts`'s fan-out branch ignores the shard and runs the tier whole — so the test
  *  is `--shard` AND `--serial`, exactly how `orchestrate.ts` spawns one
  *  (`run --serial --tier X --shard i/N`). `cli.ts` rejects the other combination outright. */
-function isShardChild(opts: PreflightOptions): boolean {
+export function isShardChild(opts: PreflightOptions): boolean {
   return opts.shard !== undefined && opts.serial === true;
 }
 

--- a/apps/benchmark/test/bench-lock.test.ts
+++ b/apps/benchmark/test/bench-lock.test.ts
@@ -1,9 +1,9 @@
-// The marker that says a run is in flight, and the two refusals read off it.
+// The register that says which runs are in flight, and the refusals read off it.
 //
-// Every assertion here runs against a THROWAWAY root. Deliberately: the real repo root's marker
-// belongs to whatever bench is running in this worktree, and a test that wrote one — or removed
-// one — would be the mid-run tree mutation this file exists to prevent, from inside the suite the
-// briefs tell you to run beside a bench.
+// Every assertion here runs against a THROWAWAY register directory, never `BENCH_LOCK_DIR`.
+// Deliberately: the real register belongs to whatever benches are running on this machine, and a
+// test that wrote a record into it — or swept one — would be the failure this file exists to
+// prevent, from inside the suite the briefs tell you to run beside a bench.
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -12,20 +12,25 @@ import { describe, expect, test } from 'vitest';
 
 import { REPO_ROOT } from '../src/config';
 import {
-  BENCH_LOCK_FILE,
+  BENCH_LOCK_DIR,
   type BenchLockRecord,
   acquireBenchLock,
   benchInFlightRefusal,
-  benchLockPath,
   benchLockStatus,
   concurrentRunRefusal,
   readBenchLock,
   releaseBenchLock,
 } from '../src/run/lock';
 
-function throwawayRoot(): string {
-  return mkdtempSync(join(tmpdir(), 'asmlift-lock-'));
+/** A throwaway REGISTER directory. Named `reg` and not `root` throughout, because the two are now
+ *  different things: the register is machine-wide and each record names the worktree it measures. */
+function throwawayReg(): string {
+  return join(mkdtempSync(join(tmpdir(), 'asmlift-lock-')), 'reg');
 }
+
+/** The worktree a record says it is measuring, and a second one that is somebody else's. */
+const MY_ROOT = '/tmp/pretend-worktree-a';
+const OTHER_ROOT = '/tmp/pretend-worktree-b';
 
 /** A pid that certainly names no process: one we watched exit, CONFIRMED gone before we hand it to
  *  a test. A busy machine recycles pids, and an unconfirmed one flips the assertion to `held`. */
@@ -43,14 +48,28 @@ function deadPid(): number {
   throw new Error('could not obtain a pid that is certainly dead');
 }
 
-function writeRecord(root: string, pid: number, record?: unknown): void {
-  const dir = benchLockPath(root);
+function writeRecord(dir: string, pid: number, record?: unknown): void {
   spawnSync('mkdir', ['-p', dir]);
-  const body = record ?? { pid, startedAt: new Date().toISOString(), command: 'bench run', tiers: ['synthetic'] };
+  const body = record ?? {
+    pid,
+    startedAt: new Date().toISOString(),
+    command: 'bench run',
+    tiers: ['synthetic'],
+    root: MY_ROOT,
+    whole: true,
+  };
   writeFileSync(join(dir, `${pid}.json`), typeof body === 'string' ? body : JSON.stringify(body));
 }
 
 const SYNTH = ['synthetic'];
+
+/** This run, as the refusals read it: whole-tier synthetic in MY_ROOT unless a case says else. */
+const asRun = (over: Partial<{ tiers: string[]; whole: boolean; root: string }> = {}) => ({
+  tiers: SYNTH,
+  whole: true,
+  root: MY_ROOT,
+  ...over,
+});
 
 /** Another process that is certainly ALIVE. `process.pid + 1` is not: whether it names anything is
  *  a lottery the sweep then wins, and this suite is run beside a bench. */
@@ -58,11 +77,11 @@ const LIVE_OTHER = process.ppid;
 
 describe('reading the marker', () => {
   test('no marker is a free worktree', () => {
-    expect(readBenchLock(throwawayRoot()).state).toBe('free');
+    expect(readBenchLock(throwawayReg()).state).toBe('free');
   });
 
   test('a record naming a LIVE process is held', () => {
-    const root = throwawayRoot();
+    const root = throwawayReg();
     writeRecord(root, process.pid);
     const state = readBenchLock(root);
     expect(state.state).toBe('held');
@@ -70,13 +89,13 @@ describe('reading the marker', () => {
   });
 
   test('a record naming a DEAD process is stale — a SIGKILLed run must not block the next round', () => {
-    const root = throwawayRoot();
+    const root = throwawayReg();
     writeRecord(root, deadPid());
     expect(readBenchLock(root).state).toBe('stale');
   });
 
   test('a record that names no pid at all is stale — nobody could ever clear it by waiting', () => {
-    const root = throwawayRoot();
+    const root = throwawayReg();
     writeRecord(root, 1234, '{ half-writ');
     expect(readBenchLock(root).state).toBe('stale');
     writeRecord(root, 1234, { startedAt: 'now' });
@@ -84,7 +103,7 @@ describe('reading the marker', () => {
   });
 
   test('a live record among dead ones still holds the worktree', () => {
-    const root = throwawayRoot();
+    const root = throwawayReg();
     writeRecord(root, deadPid());
     writeRecord(root, deadPid());
     writeRecord(root, process.pid);
@@ -94,144 +113,243 @@ describe('reading the marker', () => {
   });
 
   test('a plain FILE where the directory belongs names no live run, so it is stale not held', () => {
-    const root = throwawayRoot();
-    writeFileSync(benchLockPath(root), JSON.stringify({ pid: process.pid, command: 'bench run' }));
+    const root = throwawayReg();
+    writeFileSync(root, JSON.stringify({ pid: process.pid, command: 'bench run' }));
     expect(readBenchLock(root).state).toBe('stale');
+  });
+
+  test('a record naming ANOTHER worktree is still a live record — the register is machine-wide', () => {
+    const root = throwawayReg();
+    writeRecord(root, process.pid, {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      command: 'bench run',
+      tiers: SYNTH,
+      root: OTHER_ROOT,
+      whole: true,
+    });
+    const state = readBenchLock(root);
+    expect(state.state).toBe('held');
+    expect(state.state === 'held' && state.records[0].root).toBe(OTHER_ROOT);
   });
 });
 
 describe('taking and releasing it', () => {
   test('acquire records this pid, the time, the argv and the tiers; release removes it', () => {
-    const root = throwawayRoot();
-    const path = acquireBenchLock('bench run --tier real', ['real'], root);
+    const root = throwawayReg();
+    const path = acquireBenchLock('bench run --tier real', { tiers: ['real'], whole: true, root: MY_ROOT }, root);
     const record = JSON.parse(readFileSync(path, 'utf8')) as BenchLockRecord;
     expect(record.pid).toBe(process.pid);
     expect(record.command).toBe('bench run --tier real');
     expect(record.tiers).toEqual(['real']);
+    expect(record.root).toBe(MY_ROOT);
+    expect(record.whole).toBe(true);
     expect(Number.isNaN(Date.parse(record.startedAt))).toBe(false);
     expect(readBenchLock(root).state).toBe('held');
     releaseBenchLock(root);
     expect(existsSync(path)).toBe(false);
-    // And the directory goes with the last record, so `free` is the resting state a reader sees.
-    expect(existsSync(benchLockPath(root))).toBe(false);
+    // The DIRECTORY stays. Removing it would race a neighbour that has just created it and not yet
+    // written into it — an ENOENT out of a 35-minute command before it did any work — and an empty
+    // directory outside every worktree costs nothing. `free` is what a reader sees either way.
+    expect(readBenchLock(root).state).toBe('free');
   });
 
   test('release leaves SOMEONE ELSE’s record alone — clearing a live run would be the whole bug', () => {
-    const root = throwawayRoot();
+    const root = throwawayReg();
     writeRecord(root, LIVE_OTHER);
     releaseBenchLock(root);
-    expect(existsSync(join(benchLockPath(root), `${LIVE_OTHER}.json`))).toBe(true);
+    expect(existsSync(join(root, `${LIVE_OTHER}.json`))).toBe(true);
   });
 
   test('acquire cannot EVICT a live run — one slot would make the guard lie when the second run ends', () => {
     // The failure this shape exists to prevent: a second run takes the marker, finishes, removes
-    // it, and `bench lock` then clears an audit to edit the tree under a run still in flight.
-    const root = throwawayRoot();
+    // it, and `bench in-flight` then clears an audit to edit the tree under a run still in flight.
+    const root = throwawayReg();
     const other = LIVE_OTHER;
     writeRecord(root, other);
-    acquireBenchLock('bench run --tier synthetic', SYNTH, root);
-    expect(readdirSync(benchLockPath(root)).sort()).toEqual([`${other}.json`, `${process.pid}.json`].sort());
+    acquireBenchLock('bench run --tier synthetic', asRun(), root);
+    expect(readdirSync(root).sort()).toEqual([`${other}.json`, `${process.pid}.json`].sort());
     releaseBenchLock(root);
-    expect(existsSync(join(benchLockPath(root), `${other}.json`))).toBe(true);
+    expect(existsSync(join(root, `${other}.json`))).toBe(true);
     expect(readBenchLock(root).state).toBe('held');
   });
 
   test('acquire SWEEPS the records of dead runs', () => {
-    const root = throwawayRoot();
+    const root = throwawayReg();
     const gone = deadPid();
     writeRecord(root, gone);
-    acquireBenchLock('bench run', SYNTH, root);
-    expect(existsSync(join(benchLockPath(root), `${gone}.json`))).toBe(false);
+    acquireBenchLock('bench run', asRun(), root);
+    expect(existsSync(join(root, `${gone}.json`))).toBe(false);
     releaseBenchLock(root);
   });
 
   test('releasing when there is no marker is not an error', () => {
-    expect(() => releaseBenchLock(throwawayRoot())).not.toThrow();
+    expect(() => releaseBenchLock(throwawayReg())).not.toThrow();
+  });
+
+  test('a DIRECTORY named `<pid>.json` is swept, not thrown on — one would brick every later run', () => {
+    // `readFileSync` of it raises EISDIR, so it reads as an unreadable record; a non-recursive
+    // `rmSync` in the sweep then raises EISDIR in turn and no `bench run` can start here again.
+    const root = throwawayReg();
+    spawnSync('mkdir', ['-p', join(root, '99999.json')]);
+    expect(() => acquireBenchLock('bench run', asRun(), root)).not.toThrow();
+    expect(existsSync(join(root, '99999.json'))).toBe(false);
+    releaseBenchLock(root);
   });
 });
 
 describe('what a tree-editing phase is told', () => {
   test('a held worktree refuses, naming the record, the pid and the sticky sampler', () => {
-    const root = throwawayRoot();
+    const root = throwawayReg();
     writeRecord(root, process.pid);
-    const msg = benchInFlightRefusal(readBenchLock(root));
+    const msg = benchInFlightRefusal(readBenchLock(root), MY_ROOT);
     expect(msg).toBeDefined();
-    expect(msg).toContain(BENCH_LOCK_FILE);
+    // The register it QUOTES is the one it read, never the default constant: every refusal here
+    // names a path to `rm`, and naming one the reader did not read sends them at the wrong file.
+    expect(msg).toContain(root);
+    expect(msg).not.toContain(BENCH_LOCK_DIR);
     expect(msg).toContain(`pid ${process.pid}`);
     expect(msg).toMatch(/STICKY/);
   });
 
   test('a free or stale worktree does not — the phase proceeds', () => {
-    const free = throwawayRoot();
-    expect(benchInFlightRefusal(readBenchLock(free))).toBeUndefined();
-    const stale = throwawayRoot();
+    const free = throwawayReg();
+    expect(benchInFlightRefusal(readBenchLock(free), MY_ROOT)).toBeUndefined();
+    const stale = throwawayReg();
     writeRecord(stale, deadPid());
-    expect(benchInFlightRefusal(readBenchLock(stale))).toBeUndefined();
+    expect(benchInFlightRefusal(readBenchLock(stale), MY_ROOT)).toBeUndefined();
+  });
+
+  test('a run measuring ANOTHER worktree does not refuse an edit here — it cannot be dirtied from here', () => {
+    // The other direction of the same rule that makes the register machine-wide: refusing on a
+    // neighbour would block every round on this machine whenever any round is measuring.
+    const root = throwawayReg();
+    writeRecord(root, process.pid, {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      command: 'bench run',
+      tiers: SYNTH,
+      root: OTHER_ROOT,
+      whole: true,
+    });
+    expect(benchInFlightRefusal(readBenchLock(root), MY_ROOT)).toBeUndefined();
+    // …and `bench in-flight` says so on stdout while still exiting 0.
+    expect(benchLockStatus(root, MY_ROOT)).toBe(0);
+  });
+
+  test('a record that does not say WHICH worktree refuses anyway — unknown is not a clearance', () => {
+    const root = throwawayReg();
+    writeRecord(root, process.pid, {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      command: 'bench run',
+      tiers: SYNTH,
+    });
+    expect(benchInFlightRefusal(readBenchLock(root), MY_ROOT)).toBeDefined();
   });
 
   test('the tree-edit refusal is NOT tier-gated — any live run makes an edit cost the run', () => {
-    const root = throwawayRoot();
+    const root = throwawayReg();
     writeRecord(root, process.pid, {
       pid: process.pid,
       startedAt: new Date().toISOString(),
       command: 'bench run --tier real',
       tiers: ['real'],
+      root: MY_ROOT,
+      whole: true,
     });
-    expect(benchInFlightRefusal(readBenchLock(root))).toBeDefined();
+    expect(benchInFlightRefusal(readBenchLock(root), MY_ROOT)).toBeDefined();
   });
 
-  test('`bench lock` exits 1 while a run is in flight and 0 otherwise', () => {
-    const held = throwawayRoot();
+  test('`bench in-flight` exits 1 while a run is in flight and 0 otherwise', () => {
+    const held = throwawayReg();
     writeRecord(held, process.pid);
-    expect(benchLockStatus(held)).toBe(1);
-    expect(benchLockStatus(throwawayRoot())).toBe(0);
-    const stale = throwawayRoot();
+    expect(benchLockStatus(held, MY_ROOT)).toBe(1);
+    expect(benchLockStatus(throwawayReg(), MY_ROOT)).toBe(0);
+    const stale = throwawayReg();
     writeRecord(stale, deadPid());
-    expect(benchLockStatus(stale)).toBe(0);
+    expect(benchLockStatus(stale, MY_ROOT)).toBe(0);
   });
 });
 
 describe('what a SECOND bench run is told', () => {
-  const held = (tiers: string[]): ReturnType<typeof readBenchLock> => {
-    const root = throwawayRoot();
-    writeRecord(root, process.pid, {
+  /** A live record, as one live run of the given shape. */
+  const held = (over: Partial<{ tiers: string[]; whole: boolean; root: string }> = {}) => {
+    const reg = throwawayReg();
+    const r = { tiers: SYNTH, whole: true, root: MY_ROOT, ...over };
+    writeRecord(reg, process.pid, {
       pid: process.pid,
       startedAt: new Date().toISOString(),
-      command: `bench run --tier ${tiers.join('+')}`,
-      tiers,
+      command: `bench run --tier ${r.tiers.join('+')}`,
+      ...r,
     });
-    return readBenchLock(root);
+    return readBenchLock(reg);
   };
 
-  test('a run writing the SAME tier file is refused, and told what two runs do to it', () => {
-    const msg = concurrentRunRefusal(held(SYNTH), SYNTH);
+  test('a run writing the SAME tier file in the SAME worktree is refused, and told what that does', () => {
+    const msg = concurrentRunRefusal(held(), asRun());
     expect(msg).toContain('bench run REFUSED');
     expect(msg).toContain('apps/benchmark/results/synthetic.json');
-    expect(concurrentRunRefusal(readBenchLock(throwawayRoot()), SYNTH)).toBeUndefined();
+    expect(concurrentRunRefusal(readBenchLock(throwawayReg()), asRun())).toBeUndefined();
   });
 
-  test('a scoped run on a tier the live run is NOT writing is allowed through', () => {
-    // The dev loop HARD RULE 2 and both briefs prescribe. Refusing it would send the round looking
-    // for a way past the guard, and the only way past is the `rm` that unprotects the live run.
-    expect(concurrentRunRefusal(held(['real']), SYNTH)).toBeUndefined();
-    expect(concurrentRunRefusal(held(SYNTH), ['real'])).toBeUndefined();
-    expect(concurrentRunRefusal(held(['synthetic', 'real']), SYNTH)).toBeDefined();
+  test('a scoped run on a tier the live run in THIS worktree is not writing is allowed through', () => {
+    // The dev loop the house rules and both briefs prescribe. Refusing it would send the round
+    // looking for a way past the guard, and the invented way past is the `rm` that unprotects the
+    // live run. `whole: false` because a `--only` probe is what that loop actually is.
+    const scoped = asRun({ whole: false });
+    expect(concurrentRunRefusal(held({ tiers: ['real'] }), scoped)).toBeUndefined();
+    expect(concurrentRunRefusal(held({ tiers: SYNTH }), asRun({ tiers: ['real'], whole: false }))).toBeUndefined();
+    expect(concurrentRunRefusal(held({ tiers: ['synthetic', 'real'] }), scoped)).toBeDefined();
+  });
+
+  test('the same-file refusal names the SCOPED escape and `--no-lock`, never `rm` of a live record', () => {
+    // The message is what an agent reads at the moment it is looking for a way forward, so it must
+    // not sanction the thing the house rules forbid three lines away: a second WHOLE tier beside a
+    // live one. The word `scoped` is the whole point of the sentence.
+    const msg = concurrentRunRefusal(held(), asRun()) ?? '';
+    expect(msg).toMatch(/SCOPED/);
+    expect(msg).toContain('--only');
+    expect(msg).toContain('--no-lock');
+    expect(msg).toMatch(/never[\s\S]*`rm` a record you did not write/);
+  });
+
+  test('TWO FULL BENCHES are refused across worktrees — the hazard with two recorded incidents', () => {
+    // The house rule, mechanised. `2,704 s against a neighbour versus 1,800 s solo`, and a shard
+    // killed by a neighbour writes a partial tier with NO error line.
+    const msg = concurrentRunRefusal(held({ root: OTHER_ROOT, tiers: ['real'] }), asRun());
+    expect(msg).toContain('bench run REFUSED');
+    expect(msg).toContain('a full bench is already running on this machine');
+    expect(msg).toContain(OTHER_ROOT);
+    expect(msg).toContain('2,704 s');
+  });
+
+  test('…but only WHOLE against WHOLE: a scoped probe beside a neighbour is not refused', () => {
+    // Both directions. A 15 s `--only` probe is not what fans 8 shards, and refusing it because a
+    // neighbour is busy would be this guard inventing a rule nobody has an incident for.
+    expect(concurrentRunRefusal(held({ root: OTHER_ROOT }), asRun({ whole: false }))).toBeUndefined();
+    expect(concurrentRunRefusal(held({ root: OTHER_ROOT, whole: false }), asRun())).toBeUndefined();
   });
 
   test('a record carrying NO tiers is assumed to collide — an unknown is not a clearance', () => {
-    const root = throwawayRoot();
-    writeRecord(root, process.pid, { pid: process.pid, startedAt: new Date().toISOString(), command: 'bench run' });
-    expect(concurrentRunRefusal(readBenchLock(root), ['real'])).toBeDefined();
+    const reg = throwawayReg();
+    writeRecord(reg, process.pid, {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      command: 'bench run',
+      root: MY_ROOT,
+    });
+    expect(concurrentRunRefusal(readBenchLock(reg), asRun({ tiers: ['real'] }))).toBeDefined();
   });
 
   test('a STALE record does not refuse it — the next run sweeps what a SIGKILL left', () => {
-    const root = throwawayRoot();
-    writeRecord(root, deadPid());
-    expect(concurrentRunRefusal(readBenchLock(root), SYNTH)).toBeUndefined();
-    acquireBenchLock('bench run', SYNTH, root);
-    const state = readBenchLock(root);
+    const reg = throwawayReg();
+    writeRecord(reg, deadPid());
+    expect(concurrentRunRefusal(readBenchLock(reg), asRun())).toBeUndefined();
+    acquireBenchLock('bench run', asRun(), reg);
+    const state = readBenchLock(reg);
     expect(state.state === 'held' && state.records[0].pid).toBe(process.pid);
-    releaseBenchLock(root);
+    releaseBenchLock(reg);
   });
 });
 
@@ -245,21 +363,22 @@ describe('the marker survives the ways a run actually ends', () => {
     writeFileSync(
       script,
       `import { acquireBenchLock } from ${JSON.stringify(lock)};\n` +
-        `acquireBenchLock('bench run --tier synthetic', ['synthetic'], ${JSON.stringify(root)});\n` +
+        "acquireBenchLock('bench run --tier synthetic', " +
+        `{ tiers: ['synthetic'], whole: true, root: ${JSON.stringify(MY_ROOT)} }, ${JSON.stringify(root)});\n` +
         `console.log('ACQUIRED');\n${body}\n`,
     );
     return script;
   };
 
   test('a normal exit removes the record', () => {
-    const root = throwawayRoot();
+    const root = throwawayReg();
     const r = spawnSync('npx', ['tsx', child(root, 'process.exit(0);')], { cwd: REPO_ROOT, encoding: 'utf8' });
     expect(r.stdout).toContain('ACQUIRED');
     expect(readBenchLock(root).state).toBe('free');
   }, 60_000);
 
   test('an uncaught throw removes it too — `cli.ts` leaves through a dozen exits', () => {
-    const root = throwawayRoot();
+    const root = throwawayReg();
     spawnSync('npx', ['tsx', child(root, 'throw new Error("boom");')], { cwd: REPO_ROOT, encoding: 'utf8' });
     expect(readBenchLock(root).state).toBe('free');
   }, 60_000);
@@ -274,7 +393,7 @@ describe('the marker survives the ways a run actually ends', () => {
     // It does NOT follow that `bench run` is killable: importing `run/orchestrate.ts` makes tsx
     // bind a hidden handler of its own, and a real run sent SIGTERM finishes every remaining case
     // and rewrites `results/<tier>.json` first. That is true on `origin/main` too. `kill -9`.
-    const root = throwawayRoot();
+    const root = throwawayReg();
     const script = child(root, 'import { spawnSync as s } from "node:child_process"; s("sleep", ["30"]);');
     const { spawn } = await import('node:child_process');
     const proc = spawn('npx', ['tsx', script], { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'inherit'] });
@@ -301,24 +420,36 @@ describe('the marker survives the ways a run actually ends', () => {
     expect(code).not.toBe(0);
     // Left behind on purpose, and harmless: it names a pid that is gone.
     expect(readBenchLock(root).state).toBe('stale');
-    expect(benchLockStatus(root)).toBe(0);
+    expect(benchLockStatus(root, MY_ROOT)).toBe(0);
   }, 60_000);
 });
 
-describe('the marker is invisible to git', () => {
-  // Load-bearing rather than tidy: an untracked path at the repo root is what `preflight.ts`
-  // refuses to start on and what `provenance.ts` stamps a run dirty for, so a marker git can see
-  // causes the loss it exists to prevent.
-  const ignored = (path: string) =>
-    spawnSync('git', ['-C', REPO_ROOT, 'check-ignore', '-q', path], { encoding: 'utf8' }).status === 0;
-
-  test('the repo-root marker is gitignored, records and all', () => {
-    expect(ignored(BENCH_LOCK_FILE)).toBe(true);
-    expect(ignored(join(BENCH_LOCK_FILE, '12345.json'))).toBe(true);
+describe('where the register lives', () => {
+  test('OUTSIDE every worktree, so git can never see it', () => {
+    // Load-bearing rather than tidy: a marker inside the tree is an untracked path, which is what
+    // `preflight.ts` refuses to start on and what `provenance.ts` stamps a run dirty for — one
+    // `.gitignore` edit away from causing the loss it exists to prevent. Outside, there is nothing
+    // to gitignore and nothing to get wrong.
+    expect(BENCH_LOCK_DIR.startsWith(`${REPO_ROOT}/`)).toBe(false);
+    expect(
+      spawnSync('git', ['-C', REPO_ROOT, 'status', '--porcelain', '--ignored=no'], { encoding: 'utf8' }).stdout,
+    ).not.toContain('bench-running');
   });
 
-  test('and the pattern is ANCHORED — it hides nothing of that name deeper in the tree', () => {
-    expect(ignored(join('apps', 'benchmark', BENCH_LOCK_FILE))).toBe(false);
+  test('and at a path NO environment variable can move', () => {
+    // Measured, and the reason `os.tmpdir()` is not used: an interactive shell on this machine
+    // gives `/var/folders/…/T` from $TMPDIR while the same node with TMPDIR unset gives `/tmp`.
+    // Two agents would hold two registers and each would read the other as absent — the guard
+    // green while the hazard is live, which is worse than no guard.
+    if (process.platform !== 'win32') {
+      expect(BENCH_LOCK_DIR.startsWith('/tmp/')).toBe(true);
+      const other = spawnSync('node', ['-e', 'console.log(require("os").tmpdir())'], {
+        encoding: 'utf8',
+        env: { ...process.env, TMPDIR: '/var/folders/pretend/T' },
+      }).stdout.trim();
+      // `tmpdir()` moved with the variable; BENCH_LOCK_DIR is a constant that could not.
+      expect(other).toBe('/var/folders/pretend/T');
+    }
   });
 });
 
@@ -338,17 +469,17 @@ describe('the CLI is wired to it', () => {
     return cli.slice(from, to);
   }
 
-  test('`bench run` records the run, and refuses one that writes the same tier file', () => {
+  test('`bench run` takes a record, and a shard child does not', () => {
+    // The WRITE is all that is left here: the refusal read off the register is a preflight verdict
+    // and is tested as one, against injected state, in `preflight.test.ts`.
     const runCase = switchCase('run');
     expect(runCase).toContain('acquireBenchLock(');
-    // Tier-gated: a refusal that ignored the tiers would refuse the scoped dev loop.
-    expect(runCase).toMatch(/concurrentRunRefusal\(readBenchLock\(\), tiers\)/);
-    // A shard CHILD records nothing: eight of them would say eight runs are in flight.
-    expect(runCase).toContain('isShardChild(');
+    // Eight shard children's records would say eight runs are in flight.
+    expect(runCase).toContain('runTakesTheBenchLock(');
   });
 
-  test('`bench lock` is a subcommand and is listed in the usage line', () => {
-    expect(switchCase('lock')).toContain('benchLockStatus(');
-    expect(cli).toMatch(/usage: bench <run\|lock\|/);
+  test('`bench in-flight` is a subcommand and is listed in the usage line', () => {
+    expect(switchCase('in-flight')).toContain('benchLockStatus(');
+    expect(cli).toMatch(/usage: bench <run\|in-flight\|/);
   });
 });

--- a/apps/benchmark/test/bench-lock.test.ts
+++ b/apps/benchmark/test/bench-lock.test.ts
@@ -354,8 +354,8 @@ describe('what a SECOND bench run is told', () => {
 });
 
 describe('the marker survives the ways a run actually ends', () => {
-  // The item's second design point, and the one nothing in-process can check: these spawn a real
-  // child, so `process.on('exit')` and the ABSENCE of signal handlers are what is under test.
+  // Nothing in-process can check this: these spawn a real child, so `process.on('exit')` and the
+  // ABSENCE of signal handlers are what is under test.
   const child = (root: string, body: string): string => {
     const dir = mkdtempSync(join(tmpdir(), 'asmlift-lock-child-'));
     const script = join(dir, 'child.mjs');

--- a/apps/benchmark/test/bench-lock.test.ts
+++ b/apps/benchmark/test/bench-lock.test.ts
@@ -1,0 +1,180 @@
+// The marker that says a run is in flight, and the two refusals read off it.
+//
+// Every assertion here runs against a THROWAWAY root. Deliberately: the real repo root's marker
+// belongs to whatever bench is running in this worktree, and a test that wrote one — or removed
+// one — would be the mid-run tree mutation this file exists to prevent, from inside the suite the
+// briefs tell you to run beside a bench.
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+import { REPO_ROOT } from '../src/config';
+import {
+  BENCH_LOCK_FILE,
+  acquireBenchLock,
+  benchInFlightRefusal,
+  benchLockPath,
+  benchLockStatus,
+  concurrentRunRefusal,
+  readBenchLock,
+  releaseBenchLock,
+} from '../src/run/lock';
+
+function throwawayRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'asmlift-lock-'));
+}
+
+/** A pid that certainly names no process: one we watched exit. Better than a magic number, which
+ *  a busy machine can hand to something real. */
+function deadPid(): number {
+  const r = spawnSync('sh', ['-c', 'echo $$']);
+  return Number(r.stdout.toString().trim());
+}
+
+function writeMarker(root: string, record: unknown): void {
+  writeFileSync(benchLockPath(root), typeof record === 'string' ? record : JSON.stringify(record));
+}
+
+describe('reading the marker', () => {
+  test('no marker is a free worktree', () => {
+    expect(readBenchLock(throwawayRoot()).state).toBe('free');
+  });
+
+  test('a marker naming a LIVE process is held', () => {
+    const root = throwawayRoot();
+    writeMarker(root, { pid: process.pid, startedAt: new Date().toISOString(), command: 'bench run' });
+    const state = readBenchLock(root);
+    expect(state.state).toBe('held');
+    expect(state.state === 'held' && state.record.pid).toBe(process.pid);
+  });
+
+  test('a marker naming a DEAD process is stale — a SIGKILLed run must not block the next round', () => {
+    const root = throwawayRoot();
+    const pid = deadPid();
+    writeMarker(root, { pid, startedAt: new Date().toISOString(), command: 'bench run' });
+    const state = readBenchLock(root);
+    expect(state.state).toBe('stale');
+    expect(state.state === 'stale' && state.why).toContain(`pid ${pid}`);
+  });
+
+  test('a marker that names no pid at all is stale — nobody could ever clear it by waiting', () => {
+    const root = throwawayRoot();
+    writeMarker(root, '{ half-writ');
+    expect(readBenchLock(root).state).toBe('stale');
+    writeMarker(root, { startedAt: 'now' });
+    expect(readBenchLock(root).state).toBe('stale');
+  });
+});
+
+describe('taking and releasing it', () => {
+  test('acquire records this pid, the time and the argv; release removes it', () => {
+    const root = throwawayRoot();
+    const path = acquireBenchLock('bench run --tier real', root);
+    const record = JSON.parse(readFileSync(path, 'utf8')) as { pid: number; startedAt: string; command: string };
+    expect(record.pid).toBe(process.pid);
+    expect(record.command).toBe('bench run --tier real');
+    expect(Number.isNaN(Date.parse(record.startedAt))).toBe(false);
+    expect(readBenchLock(root).state).toBe('held');
+    releaseBenchLock(root);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test('release leaves SOMEONE ELSE’s marker alone — clearing a live run would be the whole bug', () => {
+    const root = throwawayRoot();
+    writeMarker(root, { pid: process.pid + 1, startedAt: new Date().toISOString(), command: 'bench run' });
+    releaseBenchLock(root);
+    expect(existsSync(benchLockPath(root))).toBe(true);
+  });
+
+  test('releasing when there is no marker is not an error', () => {
+    expect(() => releaseBenchLock(throwawayRoot())).not.toThrow();
+  });
+});
+
+describe('what a tree-editing phase is told', () => {
+  test('a held worktree refuses, naming the marker, the pid and the sticky sampler', () => {
+    const root = throwawayRoot();
+    writeMarker(root, { pid: process.pid, startedAt: new Date().toISOString(), command: 'bench run' });
+    const msg = benchInFlightRefusal(readBenchLock(root));
+    expect(msg).toBeDefined();
+    expect(msg).toContain(BENCH_LOCK_FILE);
+    expect(msg).toContain(`pid ${process.pid}`);
+    expect(msg).toMatch(/STICKY/);
+  });
+
+  test('a free or stale worktree does not — the phase proceeds', () => {
+    const free = throwawayRoot();
+    expect(benchInFlightRefusal(readBenchLock(free))).toBeUndefined();
+    const stale = throwawayRoot();
+    writeMarker(stale, { pid: deadPid(), startedAt: new Date().toISOString(), command: 'bench run' });
+    expect(benchInFlightRefusal(readBenchLock(stale))).toBeUndefined();
+  });
+
+  test('`bench lock` exits 1 while a run is in flight and 0 otherwise', () => {
+    const held = throwawayRoot();
+    writeMarker(held, { pid: process.pid, startedAt: new Date().toISOString(), command: 'bench run' });
+    expect(benchLockStatus(held)).toBe(1);
+    expect(benchLockStatus(throwawayRoot())).toBe(0);
+    const stale = throwawayRoot();
+    writeMarker(stale, { pid: deadPid(), startedAt: new Date().toISOString(), command: 'bench run' });
+    expect(benchLockStatus(stale)).toBe(0);
+  });
+});
+
+describe('what a SECOND bench run is told', () => {
+  test('it refuses, and says what two runs do to one tier file', () => {
+    const root = throwawayRoot();
+    writeMarker(root, { pid: process.pid, startedAt: new Date().toISOString(), command: 'bench run' });
+    const msg = concurrentRunRefusal(readBenchLock(root));
+    expect(msg).toContain('bench run REFUSED');
+    expect(msg).toContain('results/<tier>.json');
+    expect(concurrentRunRefusal(readBenchLock(throwawayRoot()))).toBeUndefined();
+  });
+
+  test('a STALE marker does not refuse it — the next run overwrites what a SIGKILL left', () => {
+    const root = throwawayRoot();
+    writeMarker(root, { pid: deadPid(), startedAt: new Date().toISOString(), command: 'bench run' });
+    expect(concurrentRunRefusal(readBenchLock(root))).toBeUndefined();
+    acquireBenchLock('bench run', root);
+    const state = readBenchLock(root);
+    expect(state.state === 'held' && state.record.pid).toBe(process.pid);
+    releaseBenchLock(root);
+  });
+});
+
+describe('the marker is invisible to git', () => {
+  // Load-bearing rather than tidy: an untracked file at the repo root is what `preflight.ts`
+  // refuses to start on and what `provenance.ts` stamps a run dirty for, so a marker git can see
+  // causes the loss it exists to prevent.
+  const ignored = (path: string) =>
+    spawnSync('git', ['-C', REPO_ROOT, 'check-ignore', '-q', path], { encoding: 'utf8' }).status === 0;
+
+  test('the repo-root marker is gitignored', () => {
+    expect(ignored(BENCH_LOCK_FILE)).toBe(true);
+  });
+
+  test('and the pattern is ANCHORED — it hides nothing of that name deeper in the tree', () => {
+    expect(ignored(join('apps', 'benchmark', BENCH_LOCK_FILE))).toBe(false);
+  });
+});
+
+describe('the CLI is wired to it', () => {
+  // The dispatch lines themselves: `benchLockStatus`/`acquireBenchLock` are tested above against a
+  // throwaway root, but nothing else notices if `cli.ts` stops calling them.
+  const cli = readFileSync(join(REPO_ROOT, 'apps', 'benchmark', 'src', 'cli.ts'), 'utf8');
+
+  test('`bench run` takes the marker, and refuses when another run holds it', () => {
+    const runCase = cli.slice(cli.indexOf("case 'run': {"), cli.indexOf("case 'lock': {"));
+    expect(runCase).toContain('acquireBenchLock(');
+    expect(runCase).toContain('concurrentRunRefusal(');
+    // A shard CHILD must take nothing: eight of them clear the parent's marker on first exit.
+    expect(runCase).toContain('isShardChild(');
+  });
+
+  test('`bench lock` is a subcommand and is listed in the usage line', () => {
+    expect(cli).toContain("case 'lock': {");
+    expect(cli).toMatch(/usage: bench <run\|lock\|/);
+  });
+});

--- a/apps/benchmark/test/bench-lock.test.ts
+++ b/apps/benchmark/test/bench-lock.test.ts
@@ -5,7 +5,7 @@
 // one — would be the mid-run tree mutation this file exists to prevent, from inside the suite the
 // briefs tell you to run beside a bench.
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, test } from 'vitest';
@@ -13,6 +13,7 @@ import { describe, expect, test } from 'vitest';
 import { REPO_ROOT } from '../src/config';
 import {
   BENCH_LOCK_FILE,
+  type BenchLockRecord,
   acquireBenchLock,
   benchInFlightRefusal,
   benchLockPath,
@@ -26,66 +27,122 @@ function throwawayRoot(): string {
   return mkdtempSync(join(tmpdir(), 'asmlift-lock-'));
 }
 
-/** A pid that certainly names no process: one we watched exit. Better than a magic number, which
- *  a busy machine can hand to something real. */
+/** A pid that certainly names no process: one we watched exit, CONFIRMED gone before we hand it to
+ *  a test. A busy machine recycles pids, and an unconfirmed one flips the assertion to `held`. */
 function deadPid(): number {
-  const r = spawnSync('sh', ['-c', 'echo $$']);
-  return Number(r.stdout.toString().trim());
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const pid = Number(spawnSync('sh', ['-c', 'echo $$']).stdout.toString().trim());
+    try {
+      process.kill(pid, 0);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ESRCH') {
+        return pid;
+      }
+    }
+  }
+  throw new Error('could not obtain a pid that is certainly dead');
 }
 
-function writeMarker(root: string, record: unknown): void {
-  writeFileSync(benchLockPath(root), typeof record === 'string' ? record : JSON.stringify(record));
+function writeRecord(root: string, pid: number, record?: unknown): void {
+  const dir = benchLockPath(root);
+  spawnSync('mkdir', ['-p', dir]);
+  const body = record ?? { pid, startedAt: new Date().toISOString(), command: 'bench run', tiers: ['synthetic'] };
+  writeFileSync(join(dir, `${pid}.json`), typeof body === 'string' ? body : JSON.stringify(body));
 }
+
+const SYNTH = ['synthetic'];
+
+/** Another process that is certainly ALIVE. `process.pid + 1` is not: whether it names anything is
+ *  a lottery the sweep then wins, and this suite is run beside a bench. */
+const LIVE_OTHER = process.ppid;
 
 describe('reading the marker', () => {
   test('no marker is a free worktree', () => {
     expect(readBenchLock(throwawayRoot()).state).toBe('free');
   });
 
-  test('a marker naming a LIVE process is held', () => {
+  test('a record naming a LIVE process is held', () => {
     const root = throwawayRoot();
-    writeMarker(root, { pid: process.pid, startedAt: new Date().toISOString(), command: 'bench run' });
+    writeRecord(root, process.pid);
     const state = readBenchLock(root);
     expect(state.state).toBe('held');
-    expect(state.state === 'held' && state.record.pid).toBe(process.pid);
+    expect(state.state === 'held' && state.records[0].pid).toBe(process.pid);
   });
 
-  test('a marker naming a DEAD process is stale — a SIGKILLed run must not block the next round', () => {
+  test('a record naming a DEAD process is stale — a SIGKILLed run must not block the next round', () => {
     const root = throwawayRoot();
-    const pid = deadPid();
-    writeMarker(root, { pid, startedAt: new Date().toISOString(), command: 'bench run' });
-    const state = readBenchLock(root);
-    expect(state.state).toBe('stale');
-    expect(state.state === 'stale' && state.why).toContain(`pid ${pid}`);
-  });
-
-  test('a marker that names no pid at all is stale — nobody could ever clear it by waiting', () => {
-    const root = throwawayRoot();
-    writeMarker(root, '{ half-writ');
+    writeRecord(root, deadPid());
     expect(readBenchLock(root).state).toBe('stale');
-    writeMarker(root, { startedAt: 'now' });
+  });
+
+  test('a record that names no pid at all is stale — nobody could ever clear it by waiting', () => {
+    const root = throwawayRoot();
+    writeRecord(root, 1234, '{ half-writ');
+    expect(readBenchLock(root).state).toBe('stale');
+    writeRecord(root, 1234, { startedAt: 'now' });
+    expect(readBenchLock(root).state).toBe('stale');
+  });
+
+  test('a live record among dead ones still holds the worktree', () => {
+    const root = throwawayRoot();
+    writeRecord(root, deadPid());
+    writeRecord(root, deadPid());
+    writeRecord(root, process.pid);
+    const state = readBenchLock(root);
+    expect(state.state).toBe('held');
+    expect(state.state === 'held' && state.records.map((r) => r.pid)).toEqual([process.pid]);
+  });
+
+  test('a plain FILE where the directory belongs names no live run, so it is stale not held', () => {
+    const root = throwawayRoot();
+    writeFileSync(benchLockPath(root), JSON.stringify({ pid: process.pid, command: 'bench run' }));
     expect(readBenchLock(root).state).toBe('stale');
   });
 });
 
 describe('taking and releasing it', () => {
-  test('acquire records this pid, the time and the argv; release removes it', () => {
+  test('acquire records this pid, the time, the argv and the tiers; release removes it', () => {
     const root = throwawayRoot();
-    const path = acquireBenchLock('bench run --tier real', root);
-    const record = JSON.parse(readFileSync(path, 'utf8')) as { pid: number; startedAt: string; command: string };
+    const path = acquireBenchLock('bench run --tier real', ['real'], root);
+    const record = JSON.parse(readFileSync(path, 'utf8')) as BenchLockRecord;
     expect(record.pid).toBe(process.pid);
     expect(record.command).toBe('bench run --tier real');
+    expect(record.tiers).toEqual(['real']);
     expect(Number.isNaN(Date.parse(record.startedAt))).toBe(false);
     expect(readBenchLock(root).state).toBe('held');
     releaseBenchLock(root);
     expect(existsSync(path)).toBe(false);
+    // And the directory goes with the last record, so `free` is the resting state a reader sees.
+    expect(existsSync(benchLockPath(root))).toBe(false);
   });
 
-  test('release leaves SOMEONE ELSE’s marker alone — clearing a live run would be the whole bug', () => {
+  test('release leaves SOMEONE ELSE’s record alone — clearing a live run would be the whole bug', () => {
     const root = throwawayRoot();
-    writeMarker(root, { pid: process.pid + 1, startedAt: new Date().toISOString(), command: 'bench run' });
+    writeRecord(root, LIVE_OTHER);
     releaseBenchLock(root);
-    expect(existsSync(benchLockPath(root))).toBe(true);
+    expect(existsSync(join(benchLockPath(root), `${LIVE_OTHER}.json`))).toBe(true);
+  });
+
+  test('acquire cannot EVICT a live run — one slot would make the guard lie when the second run ends', () => {
+    // The failure this shape exists to prevent: a second run takes the marker, finishes, removes
+    // it, and `bench lock` then clears an audit to edit the tree under a run still in flight.
+    const root = throwawayRoot();
+    const other = LIVE_OTHER;
+    writeRecord(root, other);
+    acquireBenchLock('bench run --tier synthetic', SYNTH, root);
+    expect(readdirSync(benchLockPath(root)).sort()).toEqual([`${other}.json`, `${process.pid}.json`].sort());
+    releaseBenchLock(root);
+    expect(existsSync(join(benchLockPath(root), `${other}.json`))).toBe(true);
+    expect(readBenchLock(root).state).toBe('held');
+  });
+
+  test('acquire SWEEPS the records of dead runs', () => {
+    const root = throwawayRoot();
+    const gone = deadPid();
+    writeRecord(root, gone);
+    acquireBenchLock('bench run', SYNTH, root);
+    expect(existsSync(join(benchLockPath(root), `${gone}.json`))).toBe(false);
+    releaseBenchLock(root);
   });
 
   test('releasing when there is no marker is not an error', () => {
@@ -94,9 +151,9 @@ describe('taking and releasing it', () => {
 });
 
 describe('what a tree-editing phase is told', () => {
-  test('a held worktree refuses, naming the marker, the pid and the sticky sampler', () => {
+  test('a held worktree refuses, naming the record, the pid and the sticky sampler', () => {
     const root = throwawayRoot();
-    writeMarker(root, { pid: process.pid, startedAt: new Date().toISOString(), command: 'bench run' });
+    writeRecord(root, process.pid);
     const msg = benchInFlightRefusal(readBenchLock(root));
     expect(msg).toBeDefined();
     expect(msg).toContain(BENCH_LOCK_FILE);
@@ -108,51 +165,156 @@ describe('what a tree-editing phase is told', () => {
     const free = throwawayRoot();
     expect(benchInFlightRefusal(readBenchLock(free))).toBeUndefined();
     const stale = throwawayRoot();
-    writeMarker(stale, { pid: deadPid(), startedAt: new Date().toISOString(), command: 'bench run' });
+    writeRecord(stale, deadPid());
     expect(benchInFlightRefusal(readBenchLock(stale))).toBeUndefined();
+  });
+
+  test('the tree-edit refusal is NOT tier-gated — any live run makes an edit cost the run', () => {
+    const root = throwawayRoot();
+    writeRecord(root, process.pid, {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      command: 'bench run --tier real',
+      tiers: ['real'],
+    });
+    expect(benchInFlightRefusal(readBenchLock(root))).toBeDefined();
   });
 
   test('`bench lock` exits 1 while a run is in flight and 0 otherwise', () => {
     const held = throwawayRoot();
-    writeMarker(held, { pid: process.pid, startedAt: new Date().toISOString(), command: 'bench run' });
+    writeRecord(held, process.pid);
     expect(benchLockStatus(held)).toBe(1);
     expect(benchLockStatus(throwawayRoot())).toBe(0);
     const stale = throwawayRoot();
-    writeMarker(stale, { pid: deadPid(), startedAt: new Date().toISOString(), command: 'bench run' });
+    writeRecord(stale, deadPid());
     expect(benchLockStatus(stale)).toBe(0);
   });
 });
 
 describe('what a SECOND bench run is told', () => {
-  test('it refuses, and says what two runs do to one tier file', () => {
+  const held = (tiers: string[]): ReturnType<typeof readBenchLock> => {
     const root = throwawayRoot();
-    writeMarker(root, { pid: process.pid, startedAt: new Date().toISOString(), command: 'bench run' });
-    const msg = concurrentRunRefusal(readBenchLock(root));
+    writeRecord(root, process.pid, {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      command: `bench run --tier ${tiers.join('+')}`,
+      tiers,
+    });
+    return readBenchLock(root);
+  };
+
+  test('a run writing the SAME tier file is refused, and told what two runs do to it', () => {
+    const msg = concurrentRunRefusal(held(SYNTH), SYNTH);
     expect(msg).toContain('bench run REFUSED');
-    expect(msg).toContain('results/<tier>.json');
-    expect(concurrentRunRefusal(readBenchLock(throwawayRoot()))).toBeUndefined();
+    expect(msg).toContain('apps/benchmark/results/synthetic.json');
+    expect(concurrentRunRefusal(readBenchLock(throwawayRoot()), SYNTH)).toBeUndefined();
   });
 
-  test('a STALE marker does not refuse it — the next run overwrites what a SIGKILL left', () => {
+  test('a scoped run on a tier the live run is NOT writing is allowed through', () => {
+    // The dev loop HARD RULE 2 and both briefs prescribe. Refusing it would send the round looking
+    // for a way past the guard, and the only way past is the `rm` that unprotects the live run.
+    expect(concurrentRunRefusal(held(['real']), SYNTH)).toBeUndefined();
+    expect(concurrentRunRefusal(held(SYNTH), ['real'])).toBeUndefined();
+    expect(concurrentRunRefusal(held(['synthetic', 'real']), SYNTH)).toBeDefined();
+  });
+
+  test('a record carrying NO tiers is assumed to collide — an unknown is not a clearance', () => {
     const root = throwawayRoot();
-    writeMarker(root, { pid: deadPid(), startedAt: new Date().toISOString(), command: 'bench run' });
-    expect(concurrentRunRefusal(readBenchLock(root))).toBeUndefined();
-    acquireBenchLock('bench run', root);
+    writeRecord(root, process.pid, { pid: process.pid, startedAt: new Date().toISOString(), command: 'bench run' });
+    expect(concurrentRunRefusal(readBenchLock(root), ['real'])).toBeDefined();
+  });
+
+  test('a STALE record does not refuse it — the next run sweeps what a SIGKILL left', () => {
+    const root = throwawayRoot();
+    writeRecord(root, deadPid());
+    expect(concurrentRunRefusal(readBenchLock(root), SYNTH)).toBeUndefined();
+    acquireBenchLock('bench run', SYNTH, root);
     const state = readBenchLock(root);
-    expect(state.state === 'held' && state.record.pid).toBe(process.pid);
+    expect(state.state === 'held' && state.records[0].pid).toBe(process.pid);
     releaseBenchLock(root);
   });
 });
 
+describe('the marker survives the ways a run actually ends', () => {
+  // The item's second design point, and the one nothing in-process can check: these spawn a real
+  // child, so `process.on('exit')` and the ABSENCE of signal handlers are what is under test.
+  const child = (root: string, body: string): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'asmlift-lock-child-'));
+    const script = join(dir, 'child.mjs');
+    const lock = join(REPO_ROOT, 'apps', 'benchmark', 'src', 'run', 'lock.ts');
+    writeFileSync(
+      script,
+      `import { acquireBenchLock } from ${JSON.stringify(lock)};\n` +
+        `acquireBenchLock('bench run --tier synthetic', ['synthetic'], ${JSON.stringify(root)});\n` +
+        `console.log('ACQUIRED');\n${body}\n`,
+    );
+    return script;
+  };
+
+  test('a normal exit removes the record', () => {
+    const root = throwawayRoot();
+    const r = spawnSync('npx', ['tsx', child(root, 'process.exit(0);')], { cwd: REPO_ROOT, encoding: 'utf8' });
+    expect(r.stdout).toContain('ACQUIRED');
+    expect(readBenchLock(root).state).toBe('free');
+  }, 60_000);
+
+  test('an uncaught throw removes it too — `cli.ts` leaves through a dozen exits', () => {
+    const root = throwawayRoot();
+    spawnSync('npx', ['tsx', child(root, 'throw new Error("boom");')], { cwd: REPO_ROOT, encoding: 'utf8' });
+    expect(readBenchLock(root).state).toBe('free');
+  }, 60_000);
+
+  test('acquiring installs NO signal handler, so SIGTERM still kills at once — and what it leaves reads stale', async () => {
+    // The rule, not the tidiness. A JS SIGTERM listener cannot run while `spawnSync` holds the
+    // loop, which is every case of a run: measured in isolation, a listener made a blocked process
+    // survive the full 10 s and exit 0 with the listener never running. So `acquireBenchLock`
+    // registers none, and this child — which imports lock.ts and nothing else — must die on the
+    // default action while blocked in `spawnSync`, leaving a record that reads stale.
+    //
+    // It does NOT follow that `bench run` is killable: importing `run/orchestrate.ts` makes tsx
+    // bind a hidden handler of its own, and a real run sent SIGTERM finishes every remaining case
+    // and rewrites `results/<tier>.json` first. That is true on `origin/main` too. `kill -9`.
+    const root = throwawayRoot();
+    const script = child(root, 'import { spawnSync as s } from "node:child_process"; s("sleep", ["30"]);');
+    const { spawn } = await import('node:child_process');
+    const proc = spawn('npx', ['tsx', script], { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'inherit'] });
+    await new Promise<void>((resolve, reject) => {
+      let out = '';
+      proc.stdout.on('data', (d: Buffer) => {
+        out += d.toString();
+        if (out.includes('ACQUIRED')) {
+          resolve();
+        }
+      });
+      proc.on('exit', () => reject(new Error(`child exited before acquiring: ${out}`)));
+      setTimeout(() => reject(new Error('child never acquired')), 45_000);
+    });
+    const marked = readBenchLock(root);
+    expect(marked.state).toBe('held');
+    const t0 = Date.now();
+    // The pid the marker names is the one an operator kills, and it is blocked in `spawnSync`.
+    process.kill(marked.state === 'held' ? marked.records[0].pid : 0, 'SIGTERM');
+    const code = await new Promise<number | null>((resolve) =>
+      proc.on('exit', (c, sig) => resolve(c ?? (sig ? -1 : 0))),
+    );
+    expect(Date.now() - t0).toBeLessThan(5_000);
+    expect(code).not.toBe(0);
+    // Left behind on purpose, and harmless: it names a pid that is gone.
+    expect(readBenchLock(root).state).toBe('stale');
+    expect(benchLockStatus(root)).toBe(0);
+  }, 60_000);
+});
+
 describe('the marker is invisible to git', () => {
-  // Load-bearing rather than tidy: an untracked file at the repo root is what `preflight.ts`
+  // Load-bearing rather than tidy: an untracked path at the repo root is what `preflight.ts`
   // refuses to start on and what `provenance.ts` stamps a run dirty for, so a marker git can see
   // causes the loss it exists to prevent.
   const ignored = (path: string) =>
     spawnSync('git', ['-C', REPO_ROOT, 'check-ignore', '-q', path], { encoding: 'utf8' }).status === 0;
 
-  test('the repo-root marker is gitignored', () => {
+  test('the repo-root marker is gitignored, records and all', () => {
     expect(ignored(BENCH_LOCK_FILE)).toBe(true);
+    expect(ignored(join(BENCH_LOCK_FILE, '12345.json'))).toBe(true);
   });
 
   test('and the pattern is ANCHORED — it hides nothing of that name deeper in the tree', () => {
@@ -165,16 +327,28 @@ describe('the CLI is wired to it', () => {
   // throwaway root, but nothing else notices if `cli.ts` stops calling them.
   const cli = readFileSync(join(REPO_ROOT, 'apps', 'benchmark', 'src', 'cli.ts'), 'utf8');
 
-  test('`bench run` takes the marker, and refuses when another run holds it', () => {
-    const runCase = cli.slice(cli.indexOf("case 'run': {"), cli.indexOf("case 'lock': {"));
+  /** Slice one `switch` case out of `cli.ts`, LOUDLY. A bare `indexOf`/`indexOf` pair returns ''
+   *  when the cases are reordered and the rest of the file when one is renamed — failing, or
+   *  passing, for a reason no reader would guess. */
+  function switchCase(name: string): string {
+    const from = cli.indexOf(`case '${name}': {`);
+    expect(from, `cli.ts has no \`case '${name}'\``).toBeGreaterThan(-1);
+    const to = cli.indexOf("\n  case '", from + 1);
+    expect(to, `\`case '${name}'\` is the last case in cli.ts`).toBeGreaterThan(from);
+    return cli.slice(from, to);
+  }
+
+  test('`bench run` records the run, and refuses one that writes the same tier file', () => {
+    const runCase = switchCase('run');
     expect(runCase).toContain('acquireBenchLock(');
-    expect(runCase).toContain('concurrentRunRefusal(');
-    // A shard CHILD must take nothing: eight of them clear the parent's marker on first exit.
+    // Tier-gated: a refusal that ignored the tiers would refuse the scoped dev loop.
+    expect(runCase).toMatch(/concurrentRunRefusal\(readBenchLock\(\), tiers\)/);
+    // A shard CHILD records nothing: eight of them would say eight runs are in flight.
     expect(runCase).toContain('isShardChild(');
   });
 
   test('`bench lock` is a subcommand and is listed in the usage line', () => {
-    expect(cli).toContain("case 'lock': {");
+    expect(switchCase('lock')).toContain('benchLockStatus(');
     expect(cli).toMatch(/usage: bench <run\|lock\|/);
   });
 });

--- a/apps/benchmark/test/preflight.test.ts
+++ b/apps/benchmark/test/preflight.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, test } from 'vitest';
 
+import type { BenchLockState } from '../src/run/lock';
 import {
   CPP_TOOLCHAINS,
   LOCAL_ENV_FILE,
@@ -17,6 +18,7 @@ import {
   preflightRefusals,
   probeCpp,
   runIsWholeTier,
+  runTakesTheBenchLock,
   runUsesHostCpp,
 } from '../src/run/preflight';
 
@@ -193,6 +195,75 @@ describe('the whole preflight, against a real throwaway checkout', () => {
         r.includes('differs from HEAD'),
       ),
     ).toBe(false);
+  });
+});
+
+// The THIRD verdict, and the one whose answer changes while you read it: is another `bench run`
+// already measuring something? Tested here, through the injected `lockState`, and not by grepping
+// `cli.ts` for the call — a grep on source text passes for a file that no longer works and fails
+// for one that was correctly refactored. `bench-lock.test.ts` owns the register on disk; this owns
+// the wiring, which is the thing a future edit could quietly drop.
+describe('the concurrent-run verdict', () => {
+  const ok = () => ({ ok: true, how: 'ok' });
+  const MINE = '/tmp/pretend-worktree-a';
+  const THEIRS = '/tmp/pretend-worktree-b';
+
+  const live = (over: Partial<{ tiers: string[]; whole: boolean; root: string }> = {}): (() => BenchLockState) => {
+    const record = {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      command: 'bench run',
+      tiers: ['synthetic'],
+      whole: true,
+      root: MINE,
+      ...over,
+    };
+    return () => ({ state: 'held', path: '/tmp/pretend-register', records: [record] });
+  };
+  const free = (): BenchLockState => ({ state: 'free', path: '/tmp/pretend-register' });
+
+  /** The verdicts of a run in MINE, with the register saying whatever the case says. */
+  const refusalsFor = (
+    opts: Parameters<typeof preflightRefusals>[0],
+    lockState: () => BenchLockState,
+    over: Parameters<typeof preflightRefusals>[1] = {},
+  ) => preflightRefusals(opts, { repoRoot: MINE, probe: ok, lockState, ...over }).refusals;
+
+  test('a second run on a tier the live one is writing is refused, here, before anything costs', () => {
+    const refusals = refusalsFor({ tiers: ['synthetic'] }, live());
+    expect(refusals.some((r) => r.includes('bench run REFUSED') && r.includes('results/synthetic.json'))).toBe(true);
+    expect(refusalsFor({ tiers: ['synthetic'] }, free)).toEqual([]);
+  });
+
+  test('the scoped dev loop on the OTHER tier is not refused', () => {
+    expect(refusalsFor({ tiers: ['real'], only: 'dmaback' }, live())).toEqual([]);
+  });
+
+  test('a second FULL bench is refused even from another worktree; a scoped probe is not', () => {
+    expect(refusalsFor({ tiers: ['real'] }, live({ root: THEIRS, tiers: ['real'] })).length).toBe(1);
+    expect(refusalsFor({ tiers: ['real'], only: 'dmaback' }, live({ root: THEIRS, tiers: ['real'] }))).toEqual([]);
+  });
+
+  test('a SHARD CHILD is exempt — eight of them would refuse each other', () => {
+    const child = { tiers: ['synthetic' as const], shard: '0/8', serial: true };
+    expect(runTakesTheBenchLock(child)).toBe(false);
+    expect(refusalsFor(child, live())).toEqual([]);
+  });
+
+  test('`--no-lock` is the sanctioned door past it, and past NOTHING else', () => {
+    // It exists so that the way past a wrong refusal is not `rm`ing a record a live run depends on.
+    // It must not also switch off the dirty-tree or `cpp` verdicts, which is what a blanket
+    // "skip the preflight" flag would have become.
+    expect(refusalsFor({ tiers: ['synthetic'] }, live(), { ignoreLock: true })).toEqual([]);
+    const dir = mkdtempSync(join(tmpdir(), 'asmlift-preflight-nolock-'));
+    execFileSync('git', ['-C', dir, 'init', '-q']);
+    writeFileSync(join(dir, '.envrc.probe'), 'export FOO=1\n');
+    const both = preflightRefusals(
+      { tiers: ['real'] },
+      { repoRoot: dir, probe: ok, lockState: live({ root: dir }), ignoreLock: true },
+    ).refusals;
+    expect(both.length).toBe(1);
+    expect(both[0]).toContain("working tree's code differs");
   });
 });
 

--- a/apps/benchmark/test/provenance.test.ts
+++ b/apps/benchmark/test/provenance.test.ts
@@ -5,7 +5,7 @@
 import type { BenchOutput } from '@asmlift/bench-schema';
 import { describe, expect, test } from 'vitest';
 
-import { codeDirtyFrom, codeDirtyPaths, combineProvenance } from '../src/provenance';
+import { codeDirtyFrom, codeDirtyPaths, combineProvenance, wentDirtyNotice } from '../src/provenance';
 import { checkTierProvenance } from '../src/report/merge';
 
 const tier = (asmlift?: { commit: string; dirty: boolean }): BenchOutput =>
@@ -103,5 +103,32 @@ describe('the run stamp survives the stitch', () => {
 
   test('a dirty ORCHESTRATOR sample still counts — this only ever adds evidence', () => {
     expect(combineProvenance([clean], { commit: 'aaaa', dirty: true })?.dirty).toBe(true);
+  });
+});
+
+// The DETECTIVE half. The merge refusal below is correct and 39 minutes late; the sample that
+// decides it is taken after every case, so a run that goes dirty is knowable within ~2 s — and one
+// round paid 2,420 s for measurement that had been worthless for 30 of its 40 minutes.
+describe('saying it out loud, at the moment it happens', () => {
+  test('the false -> true edge speaks, names the paths, and says the sample is sticky', () => {
+    const msg = wentDirtyNotice(false, true, ['packages/core/src/structure/structure.ts']);
+    expect(msg).toContain('THE TREE WENT DIRTY MID-RUN');
+    expect(msg).toContain('packages/core/src/structure/structure.ts');
+    expect(msg).toMatch(/STICKY/);
+    // The actionable half: reverting does not undo it, so the answer is to stop, not to fix.
+    expect(msg).toMatch(/STOP NOW/);
+    expect(msg).toContain('pnpm bench in-flight');
+  });
+
+  test('and NOTHING else does — 291 cases of a sticky true would bury the line that matters', () => {
+    expect(wentDirtyNotice(false, false, [])).toBeUndefined();
+    expect(wentDirtyNotice(true, true, ['a'])).toBeUndefined();
+  });
+
+  test('a long list is capped, and says how many it did not print', () => {
+    const msg = wentDirtyNotice(false, true, ['a', 'b', 'c', 'd', 'e', 'f', 'g']) ?? '';
+    expect(msg).toContain('in 7 path(s)');
+    expect(msg).toContain('…and 2 more');
+    expect(msg).not.toContain('  g');
   });
 });

--- a/apps/web/src/data/summary.json
+++ b/apps/web/src/data/summary.json
@@ -4,7 +4,7 @@
     "asmlift": 598,
     "m2c": 412
   },
-  "commit": "f6569f61aa295ae5acc7faf7f3f6f69f88dfaee3",
+  "commit": "47ca9f8c3e716926e0a9f84bce22a9ddd054d9fa",
   "m2cCommit": "ad5c529a65ca1e5191b00a4a7b4cbfe79a7b45a0",
   "dirty": false
 }


### PR DESCRIPTION
## What this is

A `bench run` writes a record while it works, and every phase that edits the tree can ask.

The harness already had two provenance checks and they leave a hole between them.
`preflight.ts` asks *"is the tree dirty at second 0"* — one `git status --porcelain` before the run
starts, so a tree clean at second 0 passes. `provenance.ts` then samples after every case and ORs
`dirty` into a **sticky** verdict, and `report/merge.ts` refuses the tier. Between them sits the run
that starts clean and is dirtied while it is in flight: a comment audit, a `pnpm format`, an editor
save. Nothing fails at the time — the run finishes, 39 minutes later `bench:merge` refuses it, and
the measurement is gone.

That shape has a bill. One round (#164) lost **2,420.1 s** to exactly it, and the round's own agent
wrote down why: *"the first was launched on a verified-clean tree and came back stamped `dirty` … I
did a comment audit while it was in flight."* The mining round that produced this item books that
incident with "preflight would have caught it: **NO**".

So: an advisory, machine-wide register in `/tmp/asmlift-bench-running-<uid>/`. `bench run` writes
`<pid>.json` (pid, startedAt, argv, `root`, `tiers`, `whole`) on the way in and removes it on the
way out; `pnpm bench in-flight` reads it — **exit 1** while a run is measuring this worktree, naming
the record, its pid, argv and age; exit 0 when free or stale. The same register answers a second
question, the one with two recorded incidents: **`bench run` refuses a second whole-tier bench
anywhere on this machine**, and a second run writing a tier file the live one is writing. Both
refusals name a scoped `--only` probe as the thing you *can* run, `--no-lock` as the sanctioned way
past, and `rm <the exact record>` as the last resort.

And the involuntary half, which is what works when nobody asks: `provenance.ts` was already
computing "the tree went dirty" within ~2 s of it happening and telling nobody until merge. It now
prints, once, at the false→true edge:

```
[provenance] THE TREE WENT DIRTY MID-RUN, in N path(s):
  <up to five>
This sample is STICKY: every tier this process writes is now stamped dirty, `bench:merge`
will refuse it, and reverting the edit does not undo that. STOP NOW rather than at the end …
```

2,420 s becomes ~60 s, for an agent that never read a brief, an editor autosave, or a neighbour
worktree's `pnpm format` sweeping this one.

## What was verified of the premise, and what turned out false

**Held.** Read on `origin/main`: `preflight.ts`'s git verdict really is one `git status --porcelain`
at second 0, so it structurally cannot see a mid-run edit. `provenance.ts` really does OR a sticky
dirty sample after every case and tell nobody until `bench:merge`
(`grep -rn '\.dirty' apps/benchmark/src` outside `report/` returns only the definition and two
different questions). The refuter's standing warning — *"this project's problem is not missing
diagnostics, it is diagnostics nobody is pointed at"*, `bench target` at 6 calls against `bench run`'s
594 — is why the brief wiring is in this branch and not a follow-up.

**False, and the branch changed because of it:**

- **"The marker has to live at the repo root and be gitignored."** It was, for two commits, with the
  anchoring pinned by tests. A reviewer priced the scope instead: the same-worktree collision has no
  incident, the cross-worktree one has two. The register moved to `/tmp`, outside every worktree —
  where it *cannot* dirty the run it protects, and where the `.gitignore` entry, the "GITIGNORED …
  load-bearing" paragraph and both anchoring tests are simply deleted.
- **`os.tmpdir()` is not the path, and that is a measurement.** `echo $TMPDIR` in an interactive
  shell → `/var/folders/q_/…/T/`; `env -u TMPDIR node -e 'tmpdir()'` → `/tmp`. Two agents would hold
  two registers and each read the other as absent — the guard green while the hazard is live, worse
  than no guard. `/tmp/asmlift-bench-running-<uid>` is derived from no environment variable. Pinned
  as a test.
- **"Signal handlers make the run exit cleanly."** They make it worse. Node blocked in
  `spawnSync('sleep',['10'])`, SIGTERM at 600 ms: **no** listener → dead at 608 ms, rc 143; **with**
  the branch's listener → ran the full 10,022 ms, exited **0**, listener never ran. The handlers were
  deleted. But the follow-on claim *"kill behaviour returns to main's, so the run becomes killable"*
  is **also false**: importing `run/orchestrate.ts` makes **tsx** bind a hidden SIGINT/SIGTERM
  handler (hidden — it patches `process.listenerCount`, which reports 0 while `rawListeners` has
  one), so `bench run` was already un-SIGTERM-able on `origin/main`. Measured with no handler of
  ours: SIGTERM 6 s in ran all 291 cases, **rewrote `results/synthetic.json`**, exited 143 at
  +5,101 ms. `kill -9` is the stop that works, and the header says so.
- **"A single marker slot is enough."** It converts the guard from loud to silent: a second run
  taking the slot deletes the first run's protection when *it* finishes, and a tree-editing phase is
  then cleared to edit under a bench still in flight. One record per pid; acquire only ever writes
  its own, release only ever unlinks its own.
- **"A `bench merge` mid-run would dirty the run."** Expected and **false**: `provenance.ts`'s
  exclusions are exactly `apps/benchmark/results/`, `apps/web/src/pages/benchmark/data/` and
  `apps/web/src/data/`, which is precisely what `publish()` writes.
- **A brief's own justification was wrong.** Two briefs justified `bench in-flight` by *"one of the
  five paths `scripts/check-artifact-provenance.sh` measures"*. Wrong rule, and it **under-warns**:
  the mid-run sampler is `codeDirtyPaths`, which counts every path except the benchmark's own
  regenerated artifacts. `update-m2c.md`'s own edit target, `apps/benchmark/M2C_COMMIT`, is **not**
  on the five-path list and *does* dirty a run. An agent reading the old sentence would conclude
  edits off that list were safe mid-bench. Both rewritten to the real rule.
- **A comment named a symbol that does not exist.** `provenance.ts:15` announced the notice as
  `announceWentDirty`; the function is `wentDirtyNotice`. `grep -rn announceWentDirty` returned
  exactly one line — the comment itself.
- **A test built every refusal's `rm` path from the `BENCH_LOCK_DIR` constant** rather than the
  register it had read, so the suite printed a real `/tmp/…` path while reading a throwaway one.
  Every refusal now quotes `state.path`, pinned by `expect(msg).not.toContain(BENCH_LOCK_DIR)`.

## Commits

- `83422060` — the mechanism: `run/lock.ts`, the record, `bench lock`, the refusal, the tests.
- `fd6b8606` — name it in the briefs that edit the tree beside a run.
- `9062d77e` — one record per run, tier-gated, so finishing one cannot unprotect another.
- `f501a296` — put the pointer in `attribute-function.md`'s Phase 6, the phase that actually writes.
- `476c731f` — machine-wide register with `root`/`whole`; the refusal becomes a `preflightRefusals`
  verdict; `--no-lock`; `bench lock` → `bench in-flight`; the mid-run `[provenance]` notice.
- `f1483464` — comment audit: the false symbol name, the two wrong brief justifications, the stale
  "two verdicts" line the branch itself made false, and ~40 lines of retold-five-times trimmed.
- `47ca9f8c` — correct the briefs' claim that the unit suites are read-only beside a bench (found by
  this branch's own mid-run notice, during this branch's own gate).
- `3af79755` — refresh the benchmark artifact: zero rows moved.

## Measured, on the real CLI

Live full run in this worktree, second shell acting on it:

| observation | result |
| --- | --- |
| `git status --porcelain` **during** the run, record live | **0 lines** — the register cannot dirty what it protects |
| stray records from the 8 shard children | none; one file, `root=/private/tmp/wt-i9`, `whole=true` |
| `pnpm bench in-flight` while running | refusal naming the record, pid, argv, age — **exit 1** |
| a second `bench run` same tier | REFUSED, naming `results/<tier>.json` — exit 1, live record survives |
| a second whole bench at a **foreign** root | REFUSED: *"a full bench is already running on this machine … in /private/tmp/wt-NEIGHBOUR"* |
| a **scoped** `--only` probe against a foreign record | allowed straight through |
| `--tier real` probe against a live `["synthetic"]` record | allowed; the synthetic record survived it |
| a record with **no** `tiers` key (older build) | refused — an unknown is not a clearance |
| `--no-lock` past a live record | past the lock, then **refused by the dirty-tree verdict** — scope pinned both ways |
| SIGTERM / SIGINT to the parent | record removed |
| SIGKILL | record left → `in-flight` prints `stale (pid N is gone)`, **exit 0**, blocks nothing |
| throw out of `assertM2cPinned` (after acquire) | own record released, co-tenant's untouched |
| `mkdir -p <reg>/99999.json` | swept cleanly (was `ERR_FS_EISDIR`, which bricked every later run) |
| `[provenance] THE TREE WENT DIRTY MID-RUN` | **observed firing at case 1/291** on a real run in a dirtied worktree |

## The bench, and the moved-row inventory

A full `pnpm bench run` was **required**: the diff touches `apps/benchmark/src`, one of the five
paths `scripts/check-artifact-provenance.sh` measures. Unavoidable — the record has to be taken by
`bench run` itself.

```
✓ synthetic: 783 results in  796.8s → results/synthetic.json
✓ real:      252 results in 2799.9s → results/real.json
Done in 2800.1s.   EXIT=0,  zero `[provenance] THE TREE WENT DIRTY` lines
```

**Moved-row inventory: nothing.**

```
bench regression --base origin/main
  0 lost, 0 missing, 0 gained, 0 other flips (1035 committed rows)
bench diff --base origin/main
  0 field change(s), 0 added, 0 removed (1035 base rows, 1035 fresh rows)
```

asmlift 598 / m2c 412, unchanged. The artifact commit moves provenance stamps and nothing else —
1035 rows byte-identical to `origin/main`'s. That is the expected result and the point: no compile,
eval, case or dataset file is touched, and `preflight.ts`'s only functional edit is a third verdict
read through `deps`.

### Three things the gate measured that the branch did not predict

- **The mechanism worked live, on the real gate run.** The record appeared at acquire
  (`{pid, root:/private/tmp/wt-i9, whole:true}`), `git status --porcelain` stayed empty for all
  2800 s, the 8+8 shard children wrote no records of their own, and the record was gone on exit 0.
- **`[provenance] THE TREE WENT DIRTY MID-RUN` fired on a real full bench, and caught a real
  defect** — the gate's own first attempt, in 1 path: `?? packages/cli/test/offline/__provenance-probe__/`,
  at real shard 7 case 26/31. It named the loss ~35 minutes before `bench:merge` would have. That
  run was thrown away and restarted, which is exactly what the notice is for.
- **The dirt came from a sentence in these very briefs.** Both told the agent that "running the unit
  tests" was part of the read-only work you may do beside a bench. It is not:
  `packages/cli/test/offline/provenance.test.ts:134` writes an untracked `__provenance-probe__/`
  into `packages/` for the length of one test — it must, because it asserts the sampler can tell
  three dirty states apart — and a bench sampling inside that window is stamped dirty for good.
  Commit `47ca9f8c` corrects both briefs. This is the branch's own instrument finding a false claim
  in the branch's own documentation, at the only moment it could have been found.

### And one finding about `bench run` itself, not about this change

The gate's first attempt was reported up the chain as a **hang**: all 16 shard part files written,
the parent at 0.0% CPU in state `SN` for 38 minutes, no tier line. It was not hung. `pnpm bench run`
has one row, **`kleod:ProcessInputAndUpdateEntities:agbcc`, that takes 2714.2 s** — **97% of the
real tier's entire 2799.9 s wall clock**, alone, on shard 2, while the other seven shards sat
finished. A parent waiting on it is indistinguishable from a dead one by CPU or by part-file count.
The waiting idiom that works is *poll for the marker and check that the log has grown*, with a
stated bound. (`UpdateCameraScroll` 976.5 s, `CountCollectedGems` 474.7 s are the next two; nothing
else clears 330 s.) Separately: `kill -9`ing a parent leaves its shard children **orphaned and still
compiling into `results/`** — one was found 42 minutes after its parent died. Neither is in scope
here; both are written down.

## Gate counts

`npx vitest run` **3857 passed / 2 skipped, 218 files** · `pnpm test:matching` **359 passed, 41
files** (needs the pinned toolchains in the environment; without them it exits 1 at global setup
before collecting a single file) · `pnpm exec vitest run apps/benchmark/test` **912 passed / 2
skipped, 37 files** · `pnpm typecheck` clean · `pnpm lint` **0 errors**, 126 pre-existing `curly`
warnings, none in changed files · `pnpm format` rewrote nothing ·
`scripts/check-artifact-provenance.sh` **OK**. Base did not move: `origin/main` is still
`2aeaa846`, the commit this branch was cut from.

## Reviewer findings DECLINED, with reasons

- **`acquireBenchLock` is not atomic** (architect, MAJOR → downgraded). The destructive half is
  gone: with one record per pid a racing pair can only DUPLICATE work, where the single slot had the
  second run EVICT the first's protection. Closing the rest needs a post-write re-scan with a
  `startedAt` tiebreak — a second refusal path in acquire — for a window measured in milliseconds
  that nobody has hit (launches are seconds apart). Written down in `acquireBenchLock`'s doc-comment
  as knowingly open. `flag: 'wx'` is not even applicable any more: there is no shared file.
- **`bench in-flight` prints the stale line on stdout and the refusal on stderr** (NIT). The breaker
  called it cosmetic and I agree: the exit code carries the decision, every brief tells the reader to
  read the exit code, and duplicating a 7-line refusal onto both streams is noise in a log.
- **A `PreToolUse` hook that blocks edits on a live record** (architect, raised already
  not-recommended). The repo commits no `.claude/settings.json`, and a hook that blocked every edit
  on a *stale* record would be a worse failure than the one it prevents.
- **A queue / wait / retry, machine-wide blocking scope, an `ASMLIFT_BENCH_LOCK=0` env override.**
  The refuter priced the queue as not paying, and `preflight.ts`'s own rule — *one sanctioned name
  beats an escape hatch* — argues against an env switch. `--no-lock` is the one sanctioned way past,
  and it is loud.
- **"Refuse any second run while a neighbour is busy"** — narrowed deliberately to whole-vs-whole. A
  15 s `--only` probe is not what fans 8 shards, and refusing it because a neighbour is busy would be
  the guard inventing a rule nobody has an incident for.
- **The `EXIT=` marker in the refusal text** is only true for a run backgrounded the way the briefs
  background one. Accepted, not reworded: it is how both briefs launch a bench, and rewording costs
  more than it buys.

## What this does NOT do

It does not queue, wait, retry or block — nothing here is a mutex, and the word "lock" survives only
inside `run/lock.ts`. It does not make `bench run` killable (see above; that is tsx, and it is on
main). It cannot stop an agent that does not ask — that is what the `[provenance]` notice is for, and
that notice is detective, not preventive: it tells you the run is already lost. A **recycled pid**
reads as held; that is the deliberate direction to be wrong in — one `rm`, named on screen, against
2,420 s. And it changes no raising pass, no candidate, no score: the ranked path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
