### PR TITLE
Spell a cross-jumped store tail once after the `if`, with every other path returning early

### DIFF
--- a/apps/benchmark/dataset/synthetic.ts
+++ b/apps/benchmark/dataset/synthetic.ts
@@ -7647,8 +7647,8 @@ export const SYNTHETIC: SynthSpec[] = [
   },
   // ── THE SHARED DEFAULT TAIL (attr3/CountCollectedGems) ──────────────────────────────────────
   // The THIRD attribution round on `kleod:CountCollectedGems:agbcc`, at the 18/344 the C1a, C2 and
-  // C3 builds (#184, #185, #187) left it at. Ten rows: seven gaps, three controls. Every number
-  // below was measured at `2bd229a` (#188) plus this family's rows.
+  // C3 builds (#184, #185, #187) left it at, and the build that CLOSED it. Eleven rows: eight
+  // gaps, all MATCH, and three controls.
   //
   // THE CAPABILITY, in one line: spell a tail the compiler shares ONCE, after the `if`, and write
   // every other path into it as an early `return;`. The rest of this comment is evidence for that
@@ -7664,7 +7664,7 @@ export const SYNTHETIC: SynthSpec[] = [
   // differing rows are where the else-ladder's arms 1–3 reach the tail store: each of those arms
   // loads `&gCallbackQueue` itself and branches past the shared base reload. That is 3 per-arm
   // loads the winner lacks, 3 branch targets, 3 pool words, the pool shifts that follow, and 2
-  // register rows. Those three arms are exactly the ones the forwarder of part (iii) below
+  // register rows. Those three arms are exactly the ones the pure forwarder in front of the tail
   // separates from the rest, and the C tail spelling cannot produce them while `/livebase` holds
   // the base in a local. The residual is {the shared tail} AND {`/offmember` in place of
   // `/livebase`}, and only the first term is missing from the fan. The rewrite is a regex. It
@@ -7709,185 +7709,153 @@ export const SYNTHETIC: SynthSpec[] = [
   // has one `br` and one `cond_br` predecessor and nothing is merged. `gcseflat` has one arm of
   // each kind. `gcsearms6` has a SECOND merged tail: two loop-free arms cross-jumped into their
   // own `store; store; ret`. Those three lift with one bare `ret`: their separate `ret`s are
-  // `sinkReturns`' tail-duplicates. In every spelling each path ends in a `ret`, the outer `if`
-  // has no post-dominator, and the structurer copies the default store into both arms.
+  // `sinkReturns`' tail-duplicates. In every spelling each path ends in a `ret` and the outer `if`
+  // has no post-dominator, so WITHOUT a follow over the early-returning paths the structurer copies
+  // the default store into both arms.
   //
   // THE IR CANNOT DECIDE IT, and that is why `gcsepredup` exists. `gcsepre` and `gcsepredup`
   // compile to different objects (an r4/r5 swap of the two globals' bases), but their lifted IR is
   // byte-identical, so asmlift emits byte-identical C for both. One target needs the shared tail
   // and the other does not, so any DEFAULT keyed on the IR loses one of the two. `gcsedup` cannot
-  // catch that, and why depends on the stage. At `sinkReturns`' input its IR tail is a bare `ret`.
-  // After `sinkReturns`, where the prototype's (i) ran, it has a merged `store; ret` whose two `br`
-  // predecessors are both single-predecessor arms, so what keeps (i) off it there is the join
-  // clause, not the shape of the IR.
+  // catch that: no `ret` of its own is reached from both sides of the outer `if`, before the sink
+  // or after it, so both twins' gates are false there and its fan carries neither. `gcsepredup`
+  // carries the sunk twin and is the row that scores the trade.
   //
-  // THE BUILD. Every number in this section comes from an uncommitted prototype or from tree edits
-  // of candidates the fan already emits, so the build must re-measure all of it. Two routes reach
-  // the capability. They sit at different LEVELS, and each one's price is a bound, not a count.
+  // THE BUILD, MEASURED. ROUTE A SHIPPED, at the IR level: a store-tail sink
+  // (`raise/tailsink.ts`) and a follow over the paths that do not return early
+  // (`StructureOptions.followEarlyReturns`), which rank.ts enumerates as two lift-variant twins —
+  // `/shared-ret`, the follow on the fn as raised, and `/shared-tail`, the follow after the sink.
+  // All eleven rows below MATCH. #189's third step, threading a pure parameter forwarder into the
+  // tail, was NOT needed: the sink's source walk sees through `^f(v): br ^t(v)` by construction,
+  // and `gcsefwd` and CountCollectedGems MATCH with no threading step.
   //
-  // ROUTE A, at the IR level, is a LIFT VARIANT. It cannot be a `StructuringAxis` (core
-  // rank-axes.ts): those re-run `structure()` over the same raised function and cannot toggle a
-  // raise pass. A lift variant re-lifts, the way `/connective` does in core's rank.ts. It has three
-  // parts, listed in the order to build them:
-  //   (ii)  THE CORE: compute each `if`'s follow over the paths that do not return, i.e. a post-
-  //         dominator with the early-returning REGIONS deleted. The `clampToLoop` comment in
-  //         structure/structure.ts already names this gap. It must cover the arms the compiler
-  //         itself left returning, not only the ones (i) sinks. Measured by marking blocks by hand:
-  //         `gcseinner` MATCHes when the whole region that can only reach the arm's `ret` is
-  //         deleted. It stays at 21/55 when only the `ret` block is deleted, and it drops to 27/59
-  //         when the OTHER `ret` is marked, so the choice has a sign. The predicted rule is not
-  //         built: the follow is the `ret` region reached from BOTH successors of the `if`, and
-  //         every other `ret` region is an early return. That rule is per `if`. The prototype
-  //         instead edited the function-global `postDominators` with one deletion set, which is
-  //         safe only because every inhabitant has a single nest. Together with (i), the same
-  //         hand-marking rule MATCHes `gcsearms6`, whose early-return region ends in a merged
-  //         tail of its own.
-  //   (i)   AN ADAPTER from the cross-jumped spelling to the other one. Sink a merged tail whose
-  //         body is stores only, ending in a void `ret`, into its single-predecessor `br` arms,
-  //         and keep it for the predecessor that is the `if`'s fallthrough. The prototype
-  //         recognised the fallthrough as "a predecessor that is itself a join (≥2 preds)". That is
-  //         a PROXY, and on `gcseinnerdup` it fires backwards: there the ARM's predecessor is the
-  //         inner `if`/`else` join and the fallthrough has one predecessor. As a default the
-  //         prototype takes that row from MATCH to 16/57. State the decision structurally. On the
-  //         pre pair no IR rule can decide it, which is why (i) must be ranked.
-  //   (iii) Thread a pure parameter forwarder into the tail (`^bb34(v): br ^bb35(v)` in the real
-  //         function). It is needed only because the prototype's (i) admits `br` arms that point
-  //         straight at the tail. A reachability predicate would see through the forwarder by
-  //         construction. That is a prediction, so check whether your (i) needs (iii) before
-  //         building it.
-  // ROUTE B, at L3, is a re-spelling: a `PRE_FAN_PRODUCTS` entry beside `/unmerge` (core
-  // rank-axes.ts). In tail position it hoists one leaf statement S out of the `if` and ends every
-  // other leaf path with `return;`. Tree edits of candidates the fan already emits reach every
-  // inhabitant: `gcsetail` MATCH, `gcsepre` 0/45, `gcsearms` 0/59, `gcseinner` 0/50, `gcseflat`
-  // 0/49, `gcsefwd` 0/85, `gcsearms6` 0/84, and CountCollectedGems 0/344 (the regex rewrite
-  // above). It needs no (iii), no post-dominator change, and no stamp that crosses levels. Its own
-  // per-site choice is S, and that choice has a sign too. Hoisting the MAJORITY leaf value on
-  // `gcsearms` (`fnA` at three leaves, `fnB` at two) gives 27/66, worse than today's 18/63. So S
-  // must come either from a structure-time stamp (the value on the in-edge from the predecessor
-  // reached from both sides; a stamp needs a test where it is produced) or from enumerating k
-  // values (k = 2 on every inhabitant).
-  // THE PRICE, as bounds on CountCollectedGems. Route A as a ranked variant costs at most 5952 +
-  // 1800 = 7752 candidates (+30 %); 1800 is the fan with the prototype on, enumerated. Route B
-  // costs at most +2880, one per `/unmerge` tree, and that number is inferred, not enumerated.
+  // ROUTE B WAS REJECTED, and the claim that recommended it is REFUTED. An L3 `PRE_FAN_PRODUCTS`
+  // re-spelling that hoists one leaf statement out of the `if` does NOT reach every inhabitant: on
+  // `gcseflat` and `gcsearms6` the `fnB` default is carried by ONE merge temp read at TWO join
+  // sites, `/unmerge`'s totality refuses, and no tree the fan emits has the duplicated leaves to
+  // hoist from. The 0/49 and 0/84 credited to Route B on those two rows were hand grafts that also
+  // un-merged that temp. Enumerated, Route B costs +5760 candidates on CountCollectedGems (k = 2:
+  // `UpdateWorldMapNodeAnim` ×7 and `GameplayMainLoop` ×2 both end ≥2 leaves), 1.8× what shipped.
+  // And nothing at L3 decides WHICH leaf is the default: on `gcsearms` `fnA` ends three leaves and
+  // `fnB` two, both in both top-level arms, and the tree has lost that the `fnB` copies were one IR
+  // block. The IR has not — it is the source reached from both successors — which is why the sink
+  // substitutes edge arguments before any merge temp exists.
   //
-  // THE PROTOTYPE'S NUMBERS (route A, applied as a DEFAULT). CountCollectedGems scores 18/344
-  // without (ii) and 11/344 without (iii). With all three it reaches 0/344, a MATCH, under
-  // `…/uns-cmp/offmember`, and `/unmerge`, `/site-sense` and `/livebase` all leave the label.
-  // `gcsetail` and `gcsepre` are unchanged without (ii) and MATCH with it, under
-  // `unsigned/uns-cmp`. `gcsearms` goes 18/63 → 26/66 without (ii) and MATCHes with it. That
-  // 26/66 is a DEFAULT-mode number: a ranked build keeps today's 18/63 candidate in the fan, so it
-  // cannot publish 26/66 (a prediction by construction). `gcsefwd` stays at 30/96 without (ii)
-  // and at 30/96 without (iii), and MATCHes with all three, which makes it the synthetic gate for
-  // (iii). `gcseinner` is NO REACH for the prototype: it stays at 21/55 and (i) never fires,
-  // because there is no merged `store; ret` to sink. `gcseflat` goes 19/53 → 20/54. (i) sinks the
-  // cross-jumped arm, the prototype's (ii) ignores the arm that returns on its own, and the
-  // structurer copies the default back into that arm. With that arm marked as well, `gcseflat`
-  // MATCHes; marked without (i) it is 20/54, so it needs both parts. `gcsearms6` is the same
-  // story with a sign trap in it: 29/89 today, 37/97 with (i) whether or not the prototype's
-  // (ii) runs, 23/87 with only its second tail's region marked, and MATCH with (i) and that mark
-  // together. So as a default, (i) plus a NARROW (ii) is worse than nothing there. Also as a
-  // default, the prototype takes `gcsepredup` from MATCH to 5/45 and `gcseinnerdup` from MATCH to
-  // 16/57, and it cuts CountCollectedGems' fan from 5952 to 1800.
+  // THE PRICE, enumerated. CountCollectedGems 5952 → 9192 (+3240: +1440 on the base lift's twins
+  // and +1800 on `/connective`'s, which the winner needs; #189's "≤ +1800" priced one variant, not
+  // the cross). Real +5078 over 7 rows and concentrated — `CheckWorldCompletion` 840 → 2520 buys
+  // one point. Synthetic 7330 → 7782. `ProcessInputAndUpdateEntities`, which is 97% of the real
+  // tier's wall clock, enumerates a byte-identical fan, so the tier's clock does not move.
   //
-  // BUILD ORDER, and the sign traps on it:
-  //   1. (ii), general and per `if`, gated by `gcseinner`, and by `gcseflat` and `gcsearms6`
-  //      together with (i). Predicted INERT on `gcsetail`, `gcsepre`, `gcsearms`, `gcsefwd` and
-  //      CountCollectedGems: at the prototype's stage each lifts with exactly one `ret` block, so
-  //      (ii) has nothing to delete until (i) runs. For the same reason only `gcseinner`,
-  //      `gcseflat` and `gcsearms6` can tell a narrow (ii), keyed on (i)'s output, from the
-  //      general one. Whether (ii) can be a DEFAULT is OPEN. It turns on whether agbcc ever lifts
-  //      a duplicated source into `gcseinner`'s IR. To falsify it, build (ii) as a default and run
-  //      `bench run --tier synthetic --toolchain agbcc`, counting MATCH losses, plus `--tier real
-  //      --only` on the reach set.
-  //   2. (i) as a ranked variant, NEVER before (ii): without (ii), (i) is inert on `gcsetail`,
-  //      `gcsepre` and CountCollectedGems and, as a default, worse on `gcsearms`.
-  //   3. (iii), only if step 2's predicate needs it on `gcsefwd` and CountCollectedGems.
-  // Route B replaces all three steps, not step 2 alone: its tree edits reach every inhabitant with
-  // no (ii) and no (iii).
-  // The per-`if` choice in (ii) and the per-predecessor choice in (i) are made per SITE, inside
-  // the variant's on point. A single boolean decides every store-tail merge in the function at
-  // once. At the structurer the real function and every inhabitant but two have exactly one such
-  // merge: `gcseinner` has none, and `gcsearms6` has two, only one of them (i)'s. The other is an
-  // early-return region for (ii).
+  // NEITHER TWIN CAN BE A DEFAULT, and the two halves fail differently. The follow as a default
+  // costs `sw_fallguard:ido7.1` 13/19 → 19/23 and `gcseflat` 19/53 → 22/54 (`findfirst:agbcc`
+  // 12/25 → 10/25 gains). The sink as a default takes `gcsepredup` MATCH → 5/45 and `gcseinnerdup`
+  // MATCH → 16/57 — the paragraph above, from the other side: their IR is the gap rows' IR.
+  // Ranked, `gcsepredup`'s fan carries 20 `/shared-tail` candidates and the un-sunk spelling still
+  // wins, which is the control doing its work rather than a gate refusing the shape.
   //
-  // DO NOT BREAK, each one measured: `gcsedup`, `gcsepredup` and `gcseinnerdup` above. As a
-  // default, `armexpr` → 37/40, `maskchain` → 37/69 and `mergeu16` → 2/13 once (i) drops its join
-  // requirement. `mergenarrow` → 2/15, `mergeldcast` → 4/10 and `mergepool` → 1/16 (the shared
-  // tail grafted onto their winners) if the tail is kept for a NON-join predecessor. The
-  // prototype never touches those three: none has a join predecessor, and none has a store-only
-  // tail (`sext`/`zext` precede the store, and `mergeldcast` returns a value). The ladder rows
-  // (`armcb`, `armcb2`, `ladder4`, `ladidx1`, `ladidx2`) stay MATCH under every form measured.
+  // TWO TWINS, NOT ONE, because the sink can DELETE the follow: a store tail that is itself the
+  // `ret` both sides of the `if` reach is copied into its `br` sources and no shared `ret` is left.
+  // `gcsejoin` is that shape and scored 7/37 while the follow was tried only behind the sink. No
+  // per-tail predicate on this IR picks between them — refusing to sink a tail that is already a
+  // follow costs `gcseflat` 19/53 and `gcsearms6` 23/87, and both need a tail that is BOTH — so the
+  // follow is enumerated on the fn as raised as well, at +76 candidates on exactly those two rows
+  // (`gcseflat` +32, `gcsearms6` +44) and +0 real.
+  //
+  // PER SITE, with inhabitants. The follow's deletion set is keyed on each `if`'s own shared-`ret`
+  // set, not on one function-wide set: `maskchain` carries two follow sites and `gcsearms6` two
+  // sunk tails, both MATCH, and a function-wide memo fails `shared-tail.test.ts`'s two-`if` test.
+  //
+  // DO NOT BREAK, and all fourteen MATCH as shipped: `gcsedup`, `gcsepredup` and `gcseinnerdup`
+  // above; `armexpr`, `maskchain` and `mergeu16`, which a sink that copied a tail into arms no `if`
+  // shares takes to 37/40, 37/69 and 2/13; `mergenarrow`, `mergeldcast` and `mergepool`, which a
+  // tail kept for the wrong path takes to 2/15, 4/10 and 1/16. Those last three are out of the
+  // rewrite's reach by shape — none has a store-only tail (`sext`/`zext` precede the store, and
+  // `mergeldcast` returns a value) — and their fans carry no twin. `maskchain`'s does, 32 of 64,
+  // and it MATCHes on a non-twin candidate. The ladder rows (`armcb`, `armcb2`, `ladder4`,
+  // `ladidx1`, `ladidx2`) MATCH under every form measured.
   //
   // THE BOUNDARY. These shapes were measured and got NO row:
-  //   - Loop-free, with the kept predecessor not a join. The three-byte-store body scores 6/31.
-  //     Grafting the shared tail onto its winner matches, and onto its duplicated twin's
-  //     (identical) winner costs 6/31. The `gQ.prev = fnA` body scores asmlift 8/29 against
-  //     m2c's MATCH, and 0/28 grafted. The prototype leaves both untouched in every mode.
+  //   - Loop-free, with the kept path not a join. The three-byte-store body scores 6/31. Grafting
+  //     the shared tail onto its winner matches, and onto its duplicated twin's (identical) winner
+  //     costs 6/31. The `gQ.prev = fnA` body scores asmlift 8/29 against m2c's MATCH, and 0/28
+  //     grafted. Neither was re-measured against the shipped twins: build the row to move them.
   //   - Low-pressure shapes with a SECOND `ret` block. Three `gcsearms` variants with two or more
-  //     arms on the loop-free side get WORSE under the prototype as a default (25/77 → 31/78,
-  //     17/68 → 29/71, 29/89 → 37/97). All three MATCH with (i) plus their other `ret` region
-  //     marked by the both-sides rule, so they are inhabitants of the general (ii), not a separate
-  //     gap. The third is booked as `gcsearms6`. The first two keep an arm's own `ret`, which
-  //     `gcseflat` already gates. Four CountCollectedGems-like low-pressure variants (e.g.
-  //     30/162 → 54/169) were not measured with marks, so for them this is a prediction.
-  //   - Two controls that gate nothing. `gcseflat`'s duplicated twin MATCHes today and under the
-  //     prototype. `gcsefwd`'s MATCHes in all five prototype modes.
+  //     arms on the loop-free side MATCH under the sink plus the both-sides follow, so they are
+  //     inhabitants of the same rule rather than a separate gap. The third is booked as
+  //     `gcsearms6`; the first two keep an arm's own `ret`, which `gcseflat` already gates. Four
+  //     CountCollectedGems-like low-pressure variants were never hand-marked, so that they are
+  //     inhabitants too is a PREDICTION — falsify it by building one and scoring its fan.
+  //   - Three duplicated twins that gate nothing: `gcseflat`'s and `gcsefwd`'s MATCH under every
+  //     form measured, and `gcsejoin`'s lifts with no shared `ret` at all, so it enumerates no twin
+  //     either way.
   //   - Why `gcsefwd` subtracts. Summing (`a += gP->f[i]`) gives the same forwarder, but both
   //     twins then keep a 4-row residual: the operand order of the add (`adds r0, r6, r0` in the
   //     target). That is a commutative operand-order gap, not this family's. With three
-  //     accumulators instead of four there is no forwarder at all (30/82, and 32/82 as a default),
-  //     so register pressure is what produces it, on one ablation.
+  //     accumulators instead of four there is no forwarder at all (30/82), so register pressure is
+  //     what produces it, on one ablation.
   //
-  //   gcsetail   GAP. A loop on one side, one `store; return;` arm on the other, and the default
-  //              store once after the join. 15/44 (`unsigned/uns-cmp/unmerge`; `/unmerge` plays no
-  //              part in the gap and goes inert under the lever). 0 of its 36 candidates share
-  //              the tail. The winner plus only the shared-tail edit compiles to the target byte
-  //              for byte. m2c 13/41: it shares the default BLOCK through a `goto` into the else
-  //              and stores a merged `void (*)()` local.
-  //   gcsedup    CONTROL: `gcsetail` written the way asmlift writes it. MATCH. Its winning C is
-  //              `gcsetail`'s except for where the `return;` lands. So it guards against a
-  //              rewrite keyed on the lifted C: the shared tail costs 18/44 here, grafted.
-  //              m2c 14/45.
-  //   gcsepre    GAP: the loop BEFORE the `if`, one arm on each side. 5/45 (`…/uns-cmp/unmerge`);
-  //              0 of its 40 candidates share the tail. m2c 12/47.
-  //   gcsepredup CONTROL: `gcsepre` with the default duplicated. MATCH, with the same IR and the
-  //              same C as `gcsepre`, and a DEFAULT drops it to 5/45. m2c 16/47.
-  //   gcsearms   GAP: three arms, two of them after the loop, and one join kept. 18/63
-  //              (`unsigned/uns-cmp`); 0 of its 36 candidates share the tail. m2c 8/59.
-  //   gcseinner  GAP for (ii): `gcsetail` with an inner `if`/`else` in the arm. agbcc does NOT
-  //              cross-jump it, so the arm keeps its own `ret` and (i) has nothing to sink. 21/55
-  //              (`unsigned/uns-cmp/unmerge`); 0 of its 76 candidates share the tail, and the
-  //              winner plus the shared-tail edit is 0/50. m2c 13/51.
-  //   gcseinnerdup CONTROL: `gcseinner` with the default duplicated. MATCH, and the shared tail
-  //              grafted onto its winner costs 23/55. Its IR IS cross-jumped (instrumented), with
-  //              the arm's predecessor a join, so the prototype's join clause inverts the roles
-  //              (MATCH → 16/57 as a default). m2c 14/52.
-  //   gcseflat   GAP for (i) and (ii) together: two arms in the else-ladder, storing `fnA` and
-  //              `fnC`. One is cross-jumped into the tail and the other keeps its own `ret`. 19/53
-  //              (`unsigned/uns-cmp`); 0 of its 32 candidates share the tail, and the winner plus
-  //              the shared-tail edit is 0/49. m2c 13/51 with `PROBE_SLOTFNC_MAP`.
-  //   gcsefwd    GAP for (iii): four `u8` accumulators live across the loop, two arms on each
+  //   gcsetail   A loop on one side, one `store; return;` arm on the other, and the default store
+  //              once after the join. Was 15/44 with 0 of its 36 candidates sharing the tail;
+  //              CLOSED: **MATCH** on `unsigned/shared-tail/uns-cmp`, fan 36 → 52 (16 twin).
+  //              m2c 13/41: it shares the default BLOCK through a `goto` into the else and stores
+  //              a merged `void (*)()` local.
+  //   gcsedup    CONTROL: `gcsetail` written the way asmlift writes it. MATCH on
+  //              `unsigned/uns-cmp/unmerge`, fan 64 and no twin — neither twin's gate fires, since
+  //              no `ret` is reached from both sides of its outer `if`. It guards against a rewrite
+  //              keyed on the lifted C: the shared tail costs 18/44 here, grafted. m2c 14/45.
+  //   gcsepre    The loop BEFORE the `if`, one arm on each side. Was 5/45 with 0 of its 40
+  //              candidates sharing the tail; CLOSED: **MATCH** on `unsigned/shared-tail/uns-cmp`,
+  //              fan 40 → 60 (20 twin). m2c 12/47.
+  //   gcsepredup CONTROL: `gcsepre` with the default duplicated. MATCH on
+  //              `unsigned/uns-cmp/unmerge`, with the same IR and the same C as `gcsepre`. The
+  //              sunk twin IS in its fan — 20 of 60 — and loses on score; as a DEFAULT it would
+  //              take the row to 5/45. That pair is why the sink is ranked. m2c 16/47.
+  //   gcsearms   Three arms, two of them after the loop, and one join kept. Was 18/63 with 0 of
+  //              its 36 candidates sharing the tail; CLOSED: **MATCH** on
+  //              `unsigned/shared-tail/uns-cmp`, fan 36 → 68 (32 twin). m2c 8/59.
+  //   gcseinner  THE FOLLOW ALONE: `gcsetail` with an inner `if`/`else` in the arm. agbcc does NOT
+  //              cross-jump it, so the arm keeps its own `ret` and the sink has nothing to copy.
+  //              Was 21/55 with 0 of its 76 candidates sharing the tail; CLOSED: **MATCH** on
+  //              `unsigned/shared-ret/uns-cmp/unmerge`, fan 76 → 114 (38 `/shared-ret`, 0
+  //              `/shared-tail`). m2c 13/51.
+  //   gcseinnerdup CONTROL: `gcseinner` with the default duplicated. MATCH on
+  //              `unsigned/uns-cmp/unmerge`, fan 76 and no twin, and the shared tail grafted onto
+  //              its winner costs 23/55. Its IR IS cross-jumped (instrumented), which is why a
+  //              sink run as a DEFAULT takes it to 16/57. m2c 14/52.
+  //   gcseflat   BOTH TERMS: two arms in the else-ladder, storing `fnA` and `fnC`. One is
+  //              cross-jumped into the tail and the other keeps its own `ret`, so its tail is both
+  //              a follow and a sink target. Was 19/53 with 0 of its 32 candidates sharing the
+  //              tail; CLOSED: **MATCH** on `unsigned/shared-tail/uns-cmp`, fan 32 → 96, the one
+  //              row besides `gcsearms6` carrying both twins (32 each). m2c 13/51 with
+  //              `PROBE_SLOTFNC_MAP`.
+  //   gcsefwd    THE FORWARDER: four `u8` accumulators live across the loop, two arms on each
   //              side. The target reaches the tail store through a base reload (`mov r1, ip`) that
   //              the loop-side arms branch to and the else-side arms skip, and it lifts as a
-  //              forwarder. 30/96 (`unsigned/reread-globals/uns-cmp/unmerge`); 0 of its 108
-  //              candidates share the tail, and the winner plus the shared-tail edit is 0/85. m2c
-  //              is `noncompile(1)` on its own output, which indexes `gP` as `*(gP + (i + 5))`
-  //              against the `struct Slots` the ctx declares ("invalid operands to binary -").
-  //   gcsearms6  GAP for (i) and (ii) together: three arms on each side, the closest synthetic to
+  //              forwarder. Was 30/96 with 0 of its 108 candidates sharing the tail; CLOSED:
+  //              **MATCH** on `unsigned/shared-tail/reread-globals/uns-cmp`, fan 108 → 204 (96
+  //              twin), with no threading step — the sink's source walk sees through the
+  //              forwarder. m2c is `noncompile(1)` on its own output, which indexes `gP` as
+  //              `*(gP + (i + 5))` against the `struct Slots` the ctx declares ("invalid operands
+  //              to binary -").
+  //   gcsearms6  BOTH TERMS, and TWO sunk tails: three arms on each side, the closest synthetic to
   //              the real function's seven. agbcc cross-jumps two of the loop-free arms into a
-  //              second tail of their own. 29/89 (`unsigned/uns-cmp`); 0 of its 44 candidates
-  //              share the tail, and the winner plus the shared-tail edit is 0/84. m2c 23/86.
-  //   gcsejoin   GAP for (ii) WHERE (i) DELETES IT, loop-free. The store after the join writes a
+  //              second tail of their own. Was 29/89 with 0 of its 44 candidates sharing the tail;
+  //              CLOSED: **MATCH** on `unsigned/shared-tail/uns-cmp`, fan 44 → 120 (32
+  //              `/shared-tail`, 44 `/shared-ret`). m2c 23/86.
+  //   gcsejoin   THE FOLLOW THE SINK DELETES, loop-free. The store after the join writes a
   //              PARAMETER (`p[20] = a`), so the tail block is stores-only and the sink sees a tail
   //              — but that tail is ALREADY the `ret` both sides of the outer `if` reach, and the
-  //              `fnA` arm keeps its own. Copying it into its `br` source leaves no shared `ret`, so
-  //              a follow enumerated only BEHIND the sink never runs: 7/37 (`unsigned`, 8
-  //              candidates, 0 twin) at `910fd416` and under a twin that bundles the two. With the
-  //              follow enumerated on the fn as raised as well it is MATCH (`unsigned/shared-ret`,
-  //              24 candidates). Its shape has no inhabitant among the other nine rows, which is why
-  //              they all MATCH under the bundled twin. m2c is `noncompile(1)` on its own output,
-  //              which spells the parameter store as `p->unk14 = a` against the `u8 *p` the ctx
-  //              declares ("request for member `unk14' in something not a structure or union").
+  //              `fnA` arm keeps its own. Copying it into its `br` source leaves no shared `ret`,
+  //              so a follow enumerated only BEHIND the sink never runs: it was 7/37 (8 candidates,
+  //              0 twin) both before this family's build and under a twin that bundled the follow
+  //              behind the sink. CLOSED by
+  //              enumerating the follow on the fn as raised too: **MATCH** on
+  //              `unsigned/shared-ret`, fan 24 (16 twin). No other row has this shape, which is
+  //              why the other ten MATCH under the bundled twin as well. m2c is `noncompile(1)` on
+  //              its own output, which spells the parameter store as `p->unk14 = a` against the
+  //              `u8 *p` the ctx declares ("request for member `unk14' in something not a
+  //              structure or union").
   //
   // agbcc ONLY. The other columns were measured on `gcsetail`, `gcsedup`, `gcsepre`, `gcsepredup`
   // and `gcsearms`:

--- a/apps/benchmark/dataset/synthetic.ts
+++ b/apps/benchmark/dataset/synthetic.ts
@@ -7877,6 +7877,17 @@ export const SYNTHETIC: SynthSpec[] = [
   //              the real function's seven. agbcc cross-jumps two of the loop-free arms into a
   //              second tail of their own. 29/89 (`unsigned/uns-cmp`); 0 of its 44 candidates
   //              share the tail, and the winner plus the shared-tail edit is 0/84. m2c 23/86.
+  //   gcsejoin   GAP for (ii) WHERE (i) DELETES IT, loop-free. The store after the join writes a
+  //              PARAMETER (`p[20] = a`), so the tail block is stores-only and the sink sees a tail
+  //              — but that tail is ALREADY the `ret` both sides of the outer `if` reach, and the
+  //              `fnA` arm keeps its own. Copying it into its `br` source leaves no shared `ret`, so
+  //              a follow enumerated only BEHIND the sink never runs: 7/37 (`unsigned`, 8
+  //              candidates, 0 twin) at `910fd416` and under a twin that bundles the two. With the
+  //              follow enumerated on the fn as raised as well it is MATCH (`unsigned/shared-ret`,
+  //              24 candidates). Its shape has no inhabitant among the other nine rows, which is why
+  //              they all MATCH under the bundled twin. m2c is `noncompile(1)` on its own output,
+  //              which spells the parameter store as `p->unk14 = a` against the `u8 *p` the ctx
+  //              declares ("request for member `unk14' in something not a structure or union").
   //
   // agbcc ONLY. The other columns were measured on `gcsetail`, `gcsedup`, `gcsepre`, `gcsepredup`
   // and `gcsearms`:
@@ -7886,8 +7897,8 @@ export const SYNTHETIC: SynthSpec[] = [
   //   - `gcc2.7.2kmc`: both decompilers are `noncompile(1)` on all five rows. m2c's error is
   //     ``gP' undeclared`, so the declarations the map carries never reached that compile.
   //   - `gcc2.7.2`: the same, except that asmlift compiles `gcsetail` (32/42).
-  //   The MIPS noncompiles are undiagnosed, and they are not this family's link. The other five
-  //   rows vary the same bodies and were NOT measured off agbcc; they are pinned for the same reason.
+  //   The MIPS noncompiles are undiagnosed, and they are not this family's link. The other rows
+  //   vary the same bodies and were NOT measured off agbcc; they are pinned for the same reason.
   // Every one of those columns measures a different link.
   {
     sym: 'gcsetail',
@@ -8179,6 +8190,34 @@ export const SYNTHETIC: SynthSpec[] = [
     ctx: 'void fnA(void); void fnB(void); void gcsearms6(void);',
     proto: {
       gcsearms6: { returnsVoid: true },
+      fnA: { params: 0, returnsVoid: true },
+      fnB: { params: 0, returnsVoid: true },
+    },
+    symbols: PROBE_SLOT_MAP,
+  },
+  {
+    sym: 'gcsejoin',
+    src:
+      'extern void fnA(void);\n' +
+      'extern void fnB(void);\n' +
+      'struct Q { void (*prev)(void); void (*cur)(void); };\n' +
+      'extern struct Q gQ;\n' +
+      'struct Slots { u8 f[64]; };\n' +
+      'extern struct Slots *gP;\n' +
+      'void gcsejoin(u8 *p, u8 a){\n' +
+      '  if ((gP->f[55] & 0x80) != 0) {\n' +
+      '    gP->f[1] = 7;\n' +
+      '  } else {\n' +
+      '    if (gP->f[8] == 0x7F) { gP->f[10] = 2; gQ.cur = fnA; return; }\n' +
+      '    gP->f[12] = 3;\n' +
+      '  }\n' +
+      '  p[20] = a;\n' +
+      '}',
+    features: ['global', 'pointer', 'struct', 'array', 'branch', 'store'],
+    toolchains: ['agbcc'],
+    ctx: 'void fnA(void); void fnB(void); void gcsejoin(u8 *p, u8 a);',
+    proto: {
+      gcsejoin: { params: 2, returnsVoid: true },
       fnA: { params: 0, returnsVoid: true },
       fnB: { params: 0, returnsVoid: true },
     },

--- a/apps/web/src/data/summary.json
+++ b/apps/web/src/data/summary.json
@@ -1,10 +1,10 @@
 {
-  "total": 1061,
+  "total": 1062,
   "match": {
-    "asmlift": 620,
+    "asmlift": 630,
     "m2c": 416
   },
-  "commit": "5f1913aff4eb2ff6ef04335b2340c214fc8166c9",
+  "commit": "b2a677a60c655ab78c117a87559c47a7fa8e1b98",
   "m2cCommit": "ad5c529a65ca1e5191b00a4a7b4cbfe79a7b45a0",
   "dirty": false
 }

--- a/packages/core/src/raise/retsink.ts
+++ b/packages/core/src/raise/retsink.ts
@@ -534,6 +534,8 @@ export function sinkReturns(
     return t?.opcode === 'br' && t.successors.length === 1 && t.successors[0].block === m;
   };
   for (const m of [...fn.blocks]) {
+    // RETURN-ONLY merges. A merged `store…; ret` is `raise/tailsink.ts`'s, and only as rank.ts's
+    // `/shared-tail` twin: its IR comes from both spellings.
     if (m.ops.length !== 1) {
       continue;
     }

--- a/packages/core/src/raise/tailsink.ts
+++ b/packages/core/src/raise/tailsink.ts
@@ -1,4 +1,4 @@
-// asmlift — sink a shared STORE tail into the arms that did not share it in the source.
+// asmlift — sink a shared STORE tail back into the paths that branch to it.
 //
 // agbcc's gcse.c PRE finds a trailing store's base partially redundant, INSERTS it at the end of
 // every predecessor of the join, and the arms then cross-jump into one `store; ret`:
@@ -8,18 +8,16 @@
 //
 // lifts as ONE tail block `^t(v): store gQ.cur, v; ret` that the `fnA` arm and the join the two
 // sides reach both branch to. The structurer can spell that tail once, after the `if`, only if the
-// `fnA` path returns before it — so this duplicates the tail back into every arm the source wrote
-// it in, and leaves it for the one path the source fell into it on. With `structure()`'s
-// `followEarlyReturns`, the `if`'s follow is then the kept path and each sunk arm an early
-// `return;` (`synthetic:gcsetail`). Under `-fno-gcse` the tail/duplicated pairs compile
-// byte-identical, and there is no loop gate: a loop before the join is a sample, not a law.
+// `fnA` path returns before it — so this duplicates the tail into every path that branches to it.
+// WHICH copy is the tail the source wrote once is not decided here: it is the `ret` reachable from
+// both successors of the `if`, which `structure()`'s `followEarlyReturns` finds and spells after
+// the `if`, with every other copy an early `return;` (`synthetic:gcsetail`). Under `-fno-gcse` the
+// tail/duplicated pairs compile byte-identical, and there is no loop gate: a loop before the join
+// is a sample, not a law.
 //
-// WHICH PATH KEEPS THE TAIL: the value source reached from BOTH successors of the sources' nearest
-// common dominator — the path every side of that `if` falls into when none of its arms fired.
-// Every other source is an arm reached from one side, and receives its own copy. A source is the
-// block that supplies the tail's arguments: a PURE FORWARDER (`^f(v): br ^t(v)`, reached only by
-// `br`) is seen through to its own predecessors, so the arms that branch into the tail through a
-// shared base reload are arms like any other (`synthetic:gcsefwd`).
+// A block that supplies the tail's arguments is a SOURCE: a PURE FORWARDER (`^f(v): br ^t(v)`,
+// reached only by `br`) is seen through to its own predecessors, so the arms that branch into the
+// tail through a shared base reload are sources like any other (`synthetic:gcsefwd`).
 //
 // A LIFT VARIANT, NEVER A DEFAULT: `synthetic:gcsepre` and `synthetic:gcsepredup` compile to
 // different objects (an r4/r5 swap) and lift to byte-identical IR, the first written with the
@@ -28,60 +26,23 @@
 //
 // SOUND BY CONSTRUCTION: tail duplication. Each copy runs on exactly the paths that ran the tail,
 // immediately before the same `ret`, with the tail's parameters replaced by the arguments that
-// path carried; the stores' other operands dominate the tail and so every predecessor of it.
+// path carried; the stores' other operands dominate the tail and so every source of it. A copy
+// replaces a `br`, the source's only edge. A CONDITIONAL edge cannot carry one — splicing over it
+// would drop the branch's other successor — so the tail stays for the sources that reach it that
+// way; that restriction is the rewrite's own precondition, not a gate.
 //
-// REFUSES a tail (`TAIL_SINK_GATES`) when
-//   - its sources' nearest common dominator is not a two-way `cond_br`, so there are no two sides
-//     to be reached;
-//   - no source, or more than one, is reached from both sides — nothing says which path the source
-//     fell into it on (sinking with no kept path costs the `synthetic:armexpr`/`maskchain`/
-//     `mergeu16` controls their match);
-//   - an arm that must receive a copy reaches the tail by a CONDITIONAL edge, which cannot carry
-//     one. The kept path may: the tail simply stays for it.
-import { type Block, type Fn, type Value, dominators, mkOp, predecessors, terminator } from '../ir/core';
+// NO GATE: which copy stays shared is the follow's question, and whether a sunk function is worth
+// a candidate is rank.ts's, asked with the follow's own predicate (`hasDivergentSharedRet`) rather
+// than a copy of it here.
+import { type Block, type Fn, type Value, mkOp, predecessors, reachableBlocks, terminator } from '../ir/core';
 import { simplifyTrivialPhis } from '../ir/simplify';
-import { type Gate, firstRejection } from '../l3/gates';
 
-/** One edge that supplies the tail its arguments, composed through any forwarder between:
- *  `args` are the values the tail's parameters take on it. A CONDITIONAL edge can keep the tail
- *  and cannot receive a copy of it. */
+/** One edge that supplies the tail its arguments, composed through any forwarder between: `args`
+ *  are the values the tail's parameters take on it. */
 interface Source {
   readonly from: Block;
   readonly args: readonly Value[];
-  readonly conditional: boolean;
 }
-
-/** What `TAIL_SINK_GATES` judges: one store tail and the sources that reach it. */
-export interface TailSinkSite {
-  readonly tail: Block;
-  readonly sources: readonly Source[];
-  /** the sources' nearest common dominator's two successors, or null when it is not a two-way
-   *  `cond_br` */
-  readonly sides: readonly [Block, Block] | null;
-  /** the sources reached from both sides */
-  readonly kept: readonly Source[];
-}
-
-export const TAIL_SINK_GATES: readonly Gate<TailSinkSite>[] = [
-  {
-    id: 'dominator-is-not-a-branch',
-    why: 'with no two sides, no path is the one both sides fall into',
-    sound: false,
-    rejects: (c) => c.sides === null,
-  },
-  {
-    id: 'no-single-path-from-both-sides',
-    why: 'nothing says which path the source fell into the tail on',
-    sound: false,
-    rejects: (c) => c.kept.length !== 1,
-  },
-  {
-    id: 'conditional-arm',
-    why: 'an arm that reaches the tail by a conditional branch cannot carry its own copy',
-    sound: false,
-    rejects: (c) => c.sources.some((s) => s.conditional && s !== c.kept[0]),
-  },
-];
 
 /** A block whose ops are one or more `store`s and then a void `ret`. */
 function isStoreTail(b: Block): boolean {
@@ -94,26 +55,9 @@ function isStoreTail(b: Block): boolean {
   );
 }
 
-/** Blocks reachable from `from` (itself included) without passing through `avoid`. */
-function reachAvoiding(from: Block, avoid: Block): Set<Block> {
-  const out = new Set<Block>();
-  const stack = [from];
-  while (stack.length) {
-    const x = stack.pop()!;
-    if (x === avoid || out.has(x)) {
-      continue;
-    }
-    out.add(x);
-    for (const s of terminator(x)?.successors ?? []) {
-      stack.push(s.block);
-    }
-  }
-  return out;
-}
-
-/** Sink every admissible store tail into the arms reached from one side; returns whether anything
- *  changed. `gates` is the census/ablation seam, the shipped path passes nothing. */
-export function sinkStoreTails(fn: Fn, gates: readonly Gate<TailSinkSite>[] = TAIL_SINK_GATES): boolean {
+/** Copy every store tail that two or more sources reach into each source that reaches it by a
+ *  `br`; returns whether anything changed. */
+export function sinkStoreTails(fn: Fn): boolean {
   let changed = false;
   for (const tail of [...fn.blocks]) {
     if (tail === fn.blocks[0] || !fn.blocks.includes(tail) || !isStoreTail(tail)) {
@@ -124,58 +68,43 @@ export function sinkStoreTails(fn: Fn, gates: readonly Gate<TailSinkSite>[] = TA
     // being walked to the values the tail's parameters take on it.
     const forwarders = new Set<Block>();
     const sources: Source[] = [];
+    const conditional: Block[] = [];
     const walk = (to: Block, argsOf: (edge: readonly Value[]) => readonly Value[]) => {
       for (const p of preds.get(to) ?? []) {
         const t = terminator(p)!;
-        for (const e of t.successors.filter((x) => x.block === to)) {
-          const args = argsOf(e.args);
-          const isForwarder =
-            t.opcode === 'br' &&
-            p !== fn.blocks[0] &&
-            p.ops.length === 1 &&
-            !forwarders.has(p) &&
-            (preds.get(p) ?? []).every((q) => terminator(q)?.opcode === 'br');
-          if (isForwarder) {
-            forwarders.add(p);
-            walk(p, (inner) => args.map((a) => (p.params.includes(a) ? inner[p.params.indexOf(a)] : a)));
-          } else {
-            sources.push({ from: p, args, conditional: t.opcode !== 'br' });
-          }
+        if (t.opcode !== 'br') {
+          conditional.push(p);
+          continue;
+        }
+        const args = argsOf(t.successors[0].args);
+        const isForwarder =
+          p !== fn.blocks[0] &&
+          p.ops.length === 1 &&
+          !forwarders.has(p) &&
+          (preds.get(p) ?? []).every((q) => terminator(q)?.opcode === 'br');
+        if (isForwarder) {
+          forwarders.add(p);
+          walk(p, (inner) => args.map((a) => (p.params.includes(a) ? inner[p.params.indexOf(a)] : a)));
+        } else {
+          sources.push({ from: p, args });
         }
       }
     };
     walk(tail, (edge) => edge);
-    if (sources.length < 2) {
-      continue;
-    }
-    const dom = dominators(fn);
-    // The sources' nearest common dominator — the tail's own immediate dominator unless a
-    // forwarder stands between them.
-    const common = sources.map((x) => dom.get(x.from)!).reduce((acc, d) => new Set([...acc].filter((b) => d.has(b))));
-    const head = [...common].find((d) => [...common].every((x) => dom.get(d)!.has(x)));
-    const term = head ? terminator(head) : undefined;
-    const [s1, s2] = term?.opcode === 'cond_br' ? term.successors.map((s) => s.block) : [];
-    const sides: [Block, Block] | null = s1 && s2 && s1 !== s2 && s1 !== head && s2 !== head ? [s1, s2] : null;
-    let kept: Source[] = [];
-    if (sides && head) {
-      const [r1, r2] = [reachAvoiding(sides[0], head), reachAvoiding(sides[1], head)];
-      kept = sources.filter((s) => r1.has(s.from) && r2.has(s.from));
-    }
-    if (firstRejection(gates, { tail, sources, sides, kept }) !== null) {
+    if (sources.length === 0 || sources.length + conditional.length < 2) {
       continue;
     }
     const body = tail.ops.slice(0, -1);
     for (const src of sources) {
-      if (src === kept[0]) {
-        continue;
-      }
       const sub = (v: Value) => (tail.params.includes(v) ? src.args[tail.params.indexOf(v)] : v);
       const copies = body.map((o) => mkOp('store', { operands: o.operands.map(sub), attrs: { ...o.attrs } }));
       src.from.ops.splice(src.from.ops.length - 1, 1, ...copies, mkOp('ret'));
     }
-    // A forwarder or the tail left with no predecessor is unreachable.
-    const live = predecessors(fn);
-    fn.blocks = fn.blocks.filter((b) => b === fn.blocks[0] || (live.get(b) ?? []).length > 0);
+    // By REACHABILITY, not predecessor count: the tail (unless a conditional edge keeps it) and
+    // every forwarder on the way are left unreachable, however long the chain, and a forwarder's
+    // in-edge from another orphan still counts as a predecessor.
+    const live = reachableBlocks(fn);
+    fn.blocks = fn.blocks.filter((b) => live.has(b));
     changed = true;
   }
   if (changed) {

--- a/packages/core/src/raise/tailsink.ts
+++ b/packages/core/src/raise/tailsink.ts
@@ -1,0 +1,185 @@
+// asmlift — sink a shared STORE tail into the arms that did not share it in the source.
+//
+// agbcc's gcse.c PRE finds a trailing store's base partially redundant, INSERTS it at the end of
+// every predecessor of the join, and the arms then cross-jump into one `store; ret`:
+//
+//     if (c) { for (…) …; } else { if (x) { gQ.cur = fnA; return; } }
+//     gQ.cur = fnB;
+//
+// lifts as ONE tail block `^t(v): store gQ.cur, v; ret` that the `fnA` arm and the join the two
+// sides reach both branch to. The structurer can spell that tail once, after the `if`, only if the
+// `fnA` path returns before it — so this duplicates the tail back into every arm the source wrote
+// it in, and leaves it for the one path the source fell into it on. With `structure()`'s
+// `followEarlyReturns`, the `if`'s follow is then the kept path and each sunk arm an early
+// `return;` (`synthetic:gcsetail`). Under `-fno-gcse` the tail/duplicated pairs compile
+// byte-identical, and there is no loop gate: a loop before the join is a sample, not a law.
+//
+// WHICH PATH KEEPS THE TAIL: the value source reached from BOTH successors of the sources' nearest
+// common dominator — the path every side of that `if` falls into when none of its arms fired.
+// Every other source is an arm reached from one side, and receives its own copy. A source is the
+// block that supplies the tail's arguments: a PURE FORWARDER (`^f(v): br ^t(v)`, reached only by
+// `br`) is seen through to its own predecessors, so the arms that branch into the tail through a
+// shared base reload are arms like any other (`synthetic:gcsefwd`).
+//
+// A LIFT VARIANT, NEVER A DEFAULT: `synthetic:gcsepre` and `synthetic:gcsepredup` compile to
+// different objects (an r4/r5 swap) and lift to byte-identical IR, the first written with the
+// shared tail and the second with the default duplicated into each arm — no IR rule tells them
+// apart, so rank.ts enumerates this beside the unsunk lift and the differ referees.
+//
+// SOUND BY CONSTRUCTION: tail duplication. Each copy runs on exactly the paths that ran the tail,
+// immediately before the same `ret`, with the tail's parameters replaced by the arguments that
+// path carried; the stores' other operands dominate the tail and so every predecessor of it.
+//
+// REFUSES a tail (`TAIL_SINK_GATES`) when
+//   - its sources' nearest common dominator is not a two-way `cond_br`, so there are no two sides
+//     to be reached;
+//   - no source, or more than one, is reached from both sides — nothing says which path the source
+//     fell into it on (sinking with no kept path costs the `synthetic:armexpr`/`maskchain`/
+//     `mergeu16` controls their match);
+//   - an arm that must receive a copy reaches the tail by a CONDITIONAL edge, which cannot carry
+//     one. The kept path may: the tail simply stays for it.
+import { type Block, type Fn, type Value, dominators, mkOp, predecessors, terminator } from '../ir/core';
+import { simplifyTrivialPhis } from '../ir/simplify';
+import { type Gate, firstRejection } from '../l3/gates';
+
+/** One edge that supplies the tail its arguments, composed through any forwarder between:
+ *  `args` are the values the tail's parameters take on it. A CONDITIONAL edge can keep the tail
+ *  and cannot receive a copy of it. */
+interface Source {
+  readonly from: Block;
+  readonly args: readonly Value[];
+  readonly conditional: boolean;
+}
+
+/** What `TAIL_SINK_GATES` judges: one store tail and the sources that reach it. */
+export interface TailSinkSite {
+  readonly tail: Block;
+  readonly sources: readonly Source[];
+  /** the sources' nearest common dominator's two successors, or null when it is not a two-way
+   *  `cond_br` */
+  readonly sides: readonly [Block, Block] | null;
+  /** the sources reached from both sides */
+  readonly kept: readonly Source[];
+}
+
+export const TAIL_SINK_GATES: readonly Gate<TailSinkSite>[] = [
+  {
+    id: 'dominator-is-not-a-branch',
+    why: 'with no two sides, no path is the one both sides fall into',
+    sound: false,
+    rejects: (c) => c.sides === null,
+  },
+  {
+    id: 'no-single-path-from-both-sides',
+    why: 'nothing says which path the source fell into the tail on',
+    sound: false,
+    rejects: (c) => c.kept.length !== 1,
+  },
+  {
+    id: 'conditional-arm',
+    why: 'an arm that reaches the tail by a conditional branch cannot carry its own copy',
+    sound: false,
+    rejects: (c) => c.sources.some((s) => s.conditional && s !== c.kept[0]),
+  },
+];
+
+/** A block whose ops are one or more `store`s and then a void `ret`. */
+function isStoreTail(b: Block): boolean {
+  const t = b.ops[b.ops.length - 1];
+  return (
+    b.ops.length >= 2 &&
+    t.opcode === 'ret' &&
+    t.operands.length === 0 &&
+    b.ops.slice(0, -1).every((o) => o.opcode === 'store')
+  );
+}
+
+/** Blocks reachable from `from` (itself included) without passing through `avoid`. */
+function reachAvoiding(from: Block, avoid: Block): Set<Block> {
+  const out = new Set<Block>();
+  const stack = [from];
+  while (stack.length) {
+    const x = stack.pop()!;
+    if (x === avoid || out.has(x)) {
+      continue;
+    }
+    out.add(x);
+    for (const s of terminator(x)?.successors ?? []) {
+      stack.push(s.block);
+    }
+  }
+  return out;
+}
+
+/** Sink every admissible store tail into the arms reached from one side; returns whether anything
+ *  changed. `gates` is the census/ablation seam, the shipped path passes nothing. */
+export function sinkStoreTails(fn: Fn, gates: readonly Gate<TailSinkSite>[] = TAIL_SINK_GATES): boolean {
+  let changed = false;
+  for (const tail of [...fn.blocks]) {
+    if (tail === fn.blocks[0] || !fn.blocks.includes(tail) || !isStoreTail(tail)) {
+      continue;
+    }
+    const preds = predecessors(fn);
+    // The sources, seen through pure forwarders. `argsOf` sends the args of an edge into the block
+    // being walked to the values the tail's parameters take on it.
+    const forwarders = new Set<Block>();
+    const sources: Source[] = [];
+    const walk = (to: Block, argsOf: (edge: readonly Value[]) => readonly Value[]) => {
+      for (const p of preds.get(to) ?? []) {
+        const t = terminator(p)!;
+        for (const e of t.successors.filter((x) => x.block === to)) {
+          const args = argsOf(e.args);
+          const isForwarder =
+            t.opcode === 'br' &&
+            p !== fn.blocks[0] &&
+            p.ops.length === 1 &&
+            !forwarders.has(p) &&
+            (preds.get(p) ?? []).every((q) => terminator(q)?.opcode === 'br');
+          if (isForwarder) {
+            forwarders.add(p);
+            walk(p, (inner) => args.map((a) => (p.params.includes(a) ? inner[p.params.indexOf(a)] : a)));
+          } else {
+            sources.push({ from: p, args, conditional: t.opcode !== 'br' });
+          }
+        }
+      }
+    };
+    walk(tail, (edge) => edge);
+    if (sources.length < 2) {
+      continue;
+    }
+    const dom = dominators(fn);
+    // The sources' nearest common dominator — the tail's own immediate dominator unless a
+    // forwarder stands between them.
+    const common = sources.map((x) => dom.get(x.from)!).reduce((acc, d) => new Set([...acc].filter((b) => d.has(b))));
+    const head = [...common].find((d) => [...common].every((x) => dom.get(d)!.has(x)));
+    const term = head ? terminator(head) : undefined;
+    const [s1, s2] = term?.opcode === 'cond_br' ? term.successors.map((s) => s.block) : [];
+    const sides: [Block, Block] | null = s1 && s2 && s1 !== s2 && s1 !== head && s2 !== head ? [s1, s2] : null;
+    let kept: Source[] = [];
+    if (sides && head) {
+      const [r1, r2] = [reachAvoiding(sides[0], head), reachAvoiding(sides[1], head)];
+      kept = sources.filter((s) => r1.has(s.from) && r2.has(s.from));
+    }
+    if (firstRejection(gates, { tail, sources, sides, kept }) !== null) {
+      continue;
+    }
+    const body = tail.ops.slice(0, -1);
+    for (const src of sources) {
+      if (src === kept[0]) {
+        continue;
+      }
+      const sub = (v: Value) => (tail.params.includes(v) ? src.args[tail.params.indexOf(v)] : v);
+      const copies = body.map((o) => mkOp('store', { operands: o.operands.map(sub), attrs: { ...o.attrs } }));
+      src.from.ops.splice(src.from.ops.length - 1, 1, ...copies, mkOp('ret'));
+    }
+    // A forwarder or the tail left with no predecessor is unreachable.
+    const live = predecessors(fn);
+    fn.blocks = fn.blocks.filter((b) => b === fn.blocks[0] || (live.get(b) ?? []).length > 0);
+    changed = true;
+  }
+  if (changed) {
+    simplifyTrivialPhis(fn);
+  }
+  return changed;
+}

--- a/packages/core/src/raise/tailsink.ts
+++ b/packages/core/src/raise/tailsink.ts
@@ -25,11 +25,16 @@
 // apart, so rank.ts enumerates this beside the unsunk lift and the differ referees.
 //
 // SOUND BY CONSTRUCTION: tail duplication. Each copy runs on exactly the paths that ran the tail,
-// immediately before the same `ret`, with the tail's parameters replaced by the arguments that
-// path carried; the stores' other operands dominate the tail and so every source of it. A copy
-// replaces a `br`, the source's only edge. A CONDITIONAL edge cannot carry one — splicing over it
-// would drop the branch's other successor — so the tail stays for the sources that reach it that
-// way; that restriction is the rewrite's own precondition, not a gate.
+// immediately before the same `ret`. A value the tail reads is one of two things. It is a block
+// parameter of the tail OR OF A FORWARDER on the way, and the copy takes the argument that path's
+// edge into that block carried. Or it is defined elsewhere, dominates the tail, and so dominates
+// every source of it. The forwarder's own parameter is not a corner: a tail whose only predecessor
+// is a forwarder loses its parameter to raise's `simplifyTrivialPhis` and reads the forwarder's
+// directly — a jump pad `.L4: b .L6` in front of the store does exactly that — and the forwarder is
+// swept once every source holds its copy. A copy replaces a `br`, the source's only edge. A
+// CONDITIONAL edge cannot carry one — splicing over it would drop the branch's other successor — so
+// the tail stays for the sources that reach it that way; that restriction is the rewrite's own
+// precondition, not a gate.
 //
 // NO GATE: which copy stays shared is the follow's question, and whether a sunk function is worth
 // a candidate is rank.ts's, asked with the follow's own predicate (`hasDivergentSharedRet`) rather
@@ -37,11 +42,12 @@
 import { type Block, type Fn, type Value, mkOp, predecessors, reachableBlocks, terminator } from '../ir/core';
 import { simplifyTrivialPhis } from '../ir/simplify';
 
-/** One edge that supplies the tail its arguments, composed through any forwarder between: `args`
- *  are the values the tail's parameters take on it. */
+/** One edge that supplies the tail its arguments. `resolve` sends a value the tail reads to the
+ *  value it has at the end of `from`: a parameter of the tail or of any forwarder between becomes
+ *  the argument this path's edge into that block carried, and anything else is left alone. */
 interface Source {
   readonly from: Block;
-  readonly args: readonly Value[];
+  readonly resolve: (v: Value) => Value;
 }
 
 /** A block whose ops are one or more `store`s and then a void `ret`. */
@@ -64,19 +70,26 @@ export function sinkStoreTails(fn: Fn): boolean {
       continue;
     }
     const preds = predecessors(fn);
-    // The sources, seen through pure forwarders. `argsOf` sends the args of an edge into the block
-    // being walked to the values the tail's parameters take on it.
+    // The sources, seen through pure forwarders. `resolve` sends a value the tail reads to the value
+    // it has on entry to the block being walked; each edge out of a predecessor composes one more
+    // step onto it — `to`'s own parameters, not only the tail's, because the tail may read a
+    // forwarder's parameter directly.
     const forwarders = new Set<Block>();
     const sources: Source[] = [];
     const conditional: Block[] = [];
-    const walk = (to: Block, argsOf: (edge: readonly Value[]) => readonly Value[]) => {
+    const walk = (to: Block, resolve: (v: Value) => Value) => {
       for (const p of preds.get(to) ?? []) {
         const t = terminator(p)!;
         if (t.opcode !== 'br') {
           conditional.push(p);
           continue;
         }
-        const args = argsOf(t.successors[0].args);
+        const edge = t.successors[0].args;
+        const through = (v: Value): Value => {
+          const w = resolve(v);
+          const i = to.params.indexOf(w);
+          return i >= 0 ? edge[i] : w;
+        };
         const isForwarder =
           p !== fn.blocks[0] &&
           p.ops.length === 1 &&
@@ -84,20 +97,19 @@ export function sinkStoreTails(fn: Fn): boolean {
           (preds.get(p) ?? []).every((q) => terminator(q)?.opcode === 'br');
         if (isForwarder) {
           forwarders.add(p);
-          walk(p, (inner) => args.map((a) => (p.params.includes(a) ? inner[p.params.indexOf(a)] : a)));
+          walk(p, through);
         } else {
-          sources.push({ from: p, args });
+          sources.push({ from: p, resolve: through });
         }
       }
     };
-    walk(tail, (edge) => edge);
+    walk(tail, (v) => v);
     if (sources.length === 0 || sources.length + conditional.length < 2) {
       continue;
     }
     const body = tail.ops.slice(0, -1);
     for (const src of sources) {
-      const sub = (v: Value) => (tail.params.includes(v) ? src.args[tail.params.indexOf(v)] : v);
-      const copies = body.map((o) => mkOp('store', { operands: o.operands.map(sub), attrs: { ...o.attrs } }));
+      const copies = body.map((o) => mkOp('store', { operands: o.operands.map(src.resolve), attrs: { ...o.attrs } }));
       src.from.ops.splice(src.from.ops.length - 1, 1, ...copies, mkOp('ret'));
     }
     // By REACHABILITY, not predecessor count: the tail (unless a conditional edge keeps it) and

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -1720,8 +1720,9 @@ export function enumerateCandidates(
         //     is safe because `structure()` never mutates `fn`, so the earlier passes are done with it.
         //     It is enumerated only where the sink changed something AND some divergent `if` of the
         //     SUNK fn shares a `ret`. That is the sink's price gate: without it, a tail copied into
-        //     arms no `if` shares adds a twin spelling it in each, 204 synthetic candidates on 8 rows
-        //     (the `gcsedup`/`gcseinnerdup`/`armexpr`/`mergeu16` controls and four ladders).
+        //     arms no `if` shares adds a twin spelling it in each — 204 synthetic candidates on 8
+        //     rows (`gcsedup`, `gcseinnerdup`, `armexpr`, `mergeu16`, `ladder4`, `ladder5`,
+        //     `ladidx2`, `revlad5s`), every one of them MATCH today.
         // They are lift-variant twins rather than a structuring axis because the sink is an IR
         // rewrite, and they run here rather than in pipeline.ts's spine because that costs no second
         // lift. Neither is the default: the same IR comes from both sources (raise/tailsink.ts), and
@@ -1742,9 +1743,12 @@ export function enumerateCandidates(
         //
         // EACH BIT IS PER LIFT VARIANT, not per site: the `/shared-tail` pass sinks every store tail
         // and follows every divergent `if` at once, so a function with two sites gets the both-on
-        // candidate only. Over the rows the twins reach on both tiers, one function carries two
-        // follow sites (`synthetic:maskchain:agbcc`) and one two sunk tails
-        // (`synthetic:gcsearms6:agbcc`), both MATCH; every other carries at most one of each.
+        // candidate only. Counted over both tiers (`ProcessInputAndUpdateEntities` excepted), three
+        // functions carry two of something: `synthetic:maskchain:agbcc` two follow sites,
+        // `synthetic:gcsearms6:agbcc` two sunk tails — both MATCH — and
+        // `pokeemerald:SetMauvilleOldManLanguage:agbcc` two sunk tails after which no `if` shares a
+        // `ret`, so the price gate above refuses and its fan is unchanged. Every other function
+        // carries at most one of each.
         //
         // `droppedPrimary` is the PRIMARY pass's drops. Each twin pass reads it and keeps its own
         // drops in a copy, so one twin's structuring failure never removes the other's candidate.

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -1728,6 +1728,7 @@ export function enumerateCandidates(
         // Over the 21 rows the twin reaches on both tiers, one function carries two follow sites
         // (`synthetic:maskchain:agbcc`) and one two sunk tails (`synthetic:gcsearms6:agbcc`), both
         // MATCH; every other carries at most one of each.
+        const droppedPrimary = new Set<string>();
         for (const twin of [false, true]) {
           if (twin) {
             let sunk: boolean;
@@ -1754,8 +1755,14 @@ export function enumerateCandidates(
           // `/reread-globals/merge-names` candidate could ship where plain `/reread-globals` did not,
           // which is the same trade one level up. `senseCands` puts each `mergeNames:false` sibling
           // first, so the entry is always recorded before its merged twin is reached.
-          const droppedPrimary = new Set<string>();
+          //
+          // The shared-tail twin reads the UNSUNK pass's set as well: `X/shared-tail` never ships
+          // where `X` was dropped. The sink rewrites the IR into a shape the structurer can accept
+          // where the unsunk one declined — sound, but the same trade one level up again.
           for (const s of variantCands) {
+            if (twin && droppedPrimary.has(s.suffix)) {
+              continue;
+            }
             if (
               STRUCTURING_AXES.some(
                 (ax) => ax.strip && s[ax.flag] && droppedPrimary.has(s.suffix.replace(ax.suffix, '')),

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -83,8 +83,12 @@ import {
   bareGlobalSymbols,
   makeRefCollector,
 } from './rank-declare';
+import { hasDivergentSharedRet } from './structure/structure';
 import { type SymbolInfo, type SymbolMap, arrayInnerExtents, isPtrField, symbolsByName } from './symbols';
 import { type TargetDescription, structureOptionsFor } from './target';
+
+/** The shared-tail twin's label (see its loop in `enumerateCandidates`). */
+const SHARED_TAIL_SUFFIX = '/shared-tail';
 
 /** Pin every SCALAR entry param (index not in `ptrIdx`) to the candidate signedness, before
  *  recovery. Answers whether any param was PINNABLE — not whether its type moved: which of the
@@ -1705,193 +1709,207 @@ export function enumerateCandidates(
           opts.onLeverError?.(name + lv.suffix, firstLine(e));
           continue;
         }
-        // the per-variant axis gates, on THIS variant's lifted fn — see the table doc
-        const variantOff = STRUCTURING_AXES.filter((ax) => ax.variantGate !== undefined && !ax.variantGate(fn));
-        const variantCands = svCands.filter((s) => variantOff.every((ax) => !s[ax.flag]));
-        // `/merge-names` combinations whose un-merged sibling was DROPPED. `structure()` already
-        // refuses to let the axis unlock a function the primary declines, but it can only see its own
-        // refusals — a boundary contract fails out here, in `structureChecked`. Without this a
-        // `/reread-globals/merge-names` candidate could ship where plain `/reread-globals` did not,
-        // which is the same trade one level up. `senseCands` puts each `mergeNames:false` sibling
-        // first, so the entry is always recorded before its merged twin is reached.
-        const droppedPrimary = new Set<string>();
-        for (const s of variantCands) {
-          if (
-            STRUCTURING_AXES.some((ax) => ax.strip && s[ax.flag] && droppedPrimary.has(s.suffix.replace(ax.suffix, '')))
-          ) {
-            // A SKIPPED variant is recorded exactly like a dropped one, or the closure would not be
-            // transitive: with plain X dropped and X/inplace skipped-but-unrecorded,
-            // X/inplace/merge-names would find neither stripped key and run — shipping a
-            // double-lever candidate where its ancestor failed the boundary contracts.
-            droppedPrimary.add(s.suffix);
-            continue;
+        // THE SHARED-TAIL TWIN (`/shared-tail`): the same raised fn, structured a second time with
+        // `followEarlyReturns` — safe because `structure()` never mutates `fn`. A twin, not the
+        // default: as a default it costs `synthetic:sw_fallguard:ido7.1` 13/19 → 19/23 and
+        // `synthetic:gcseflat:agbcc` 19/53 → 22/54. Enumerated only where it can differ: some
+        // divergent `if` shares a `ret`.
+        for (const twin of [false, true]) {
+          if (twin && !hasDivergentSharedRet(fn)) {
+            break;
           }
-          // structure() reads `fn` and produces a fresh SFn (it does not mutate `fn`), so both branch
-          // senses structure the same recovered function without re-lifting.
-          let sfn: SFn;
-          try {
-            sfn = structureChecked(fn, {
-              ...svOpts,
-              ...(inferredSymbols.size ? { inferredSymbols } : {}),
-              ...(orderLicensed.size ? { orderLicensedGlobals: orderLicensed } : {}),
-              preserveDivergentBranchSense: s.sense,
-              negateJoinedBranchSense: s.join ? !defSense : defSense,
-              ...(s.flipSites ? { branchSenseFlipSites: s.flipSites } : {}),
-              anchorConstCopies: s.anchor,
-              anchorLoopEntryConsts: s.entry,
-              spellBitfieldMembers: s.bitfields,
-              spellPtrMemberElements: s.ptrElems,
-              spellDeclaredSubscripts: s.declRank,
-              ...STRUCTURING_AXES.reduce((acc, ax) => ({ ...acc, ...ax.options(s[ax.flag]) }), {}),
-            });
-          } catch (e) {
-            if (lv.suffix === '' && isBaseAxisPoint(s)) {
-              throw e; // the base lift's base axes keep their behavior: a failure aborts the row
-            }
-            // Recorded for EVERY dropped variant: a candidate with more axes on looks its siblings
-            // up by stripping one axis at a time, and the stripped key can itself carry the other.
-            droppedPrimary.add(s.suffix);
-            // an anchored variant that fails structuring or its contracts is a dropped lever, never
-            // an aborted enumeration — same rule as respell below
-            opts.onLeverError?.(name + lv.suffix + s.suffix, firstLine(e));
-            continue;
-          }
-          // A TREE another axis point already spelled. `fanOut` reads the tree and this call's own
-          // constants, nothing that varies per axis point — its signature is the argument — so a
-          // repeated tree can only re-emit sources `seen` already holds: the candidate list, its
-          // order and its labels are exactly the ones the whole fan produces, reached without
-          // re-deriving forty passes. An axis is INERT on most functions (nothing to re-read, no
-          // bitfield member, no joined if), and an inert axis is a factor of two in the cross that
-          // changes nothing: on the klonoa checkout's `LoadBGTilemapData` under
-          // docs/ranked-repro.md's flags, 640 of 1024 axis points (62.5%) re-derive a tree an
-          // earlier one already emitted.
-          //
-          // Keyed on the JSON text, in a Set of STRINGS — a value comparison, so it can never
-          // merge two trees the way a hash could. Its one direction of error is a MISS (a
-          // differing key order re-runs a fan whose spellings then dedup as they do today), and
-          // the property that rules the other direction out — that the text determines the tree —
-          // is pinned by rank-tree-key.test.ts rather than assumed.
-          //
-          // The key therefore spans EVIDENCE fields too, `index.operandOff` among them, which
-          // `exprEquals` deliberately ignores (l3/ast.ts). The two are right to disagree: two
-          // trees identical but for that field denote the same cells, so a CSE may collapse them,
-          // and they admit different bases under `BASEFOLD_GATES`, so a fan may not. Dropping it
-          // from the key would be the direction the paragraph above rules out. It carries a
-          // DISPLACEMENT rather than a presence flag, so it can split two trees that print the
-          // same subscript off different addends — re-priced when it widened, over klonoa's
-          // `LoadBGTilemapData` under docs/ranked-repro.md's flags: 66816 candidates either way,
-          // and all 66816 `[score]` lines identical. It splits 0 keys, so the miss it can cause
-          // has no inhabitant.
-          const treeKey = JSON.stringify(sfn);
-          if (seenTrees.has(treeKey)) {
-            opts.onTreeDeduped?.();
-            continue;
-          }
-          seenTrees.add(treeKey);
-          // The row's OWN tree, so this is the one call whose backend refusal is the row's cause.
-          const primary = fanOut(sfn);
-          const spellings = primary.spellings;
-          if (primary.emit) {
-            lastEmitError = primary.emit.error;
-          }
-          // The PRE-FAN products (PRE_FAN_PRODUCTS, the fourth mechanism the POLICY note names):
-          // rewrite the TREE, then fan the whole re-spelling set over the result, so every lever
-          // below derives from the rewrite instead of composing onto it. The gate is the pass's
-          // own decline; the contracts are `respell`'s three, for `respell`'s reasons.
-          for (const pf of PRE_FAN_PRODUCTS) {
-            try {
-              const made = pf.apply(sfn);
-              if (made === null) {
-                continue;
-              }
-              // The SAME tree dedup the primary above gets, and for the same reason: `fanOut` is a
-              // pure function of the tree, so re-fanning one already fanned buys nothing and makes
-              // the row's quoted fan cost a number that is partly duplicates. A SEPARATE set, not
-              // `seenTrees`: adding a rewritten tree there would let it skip a later PRIMARY tree
-              // that happens to equal it, and that primary's own pre-fan output — which nothing
-              // has computed — would go with it.
-              const madeKey = JSON.stringify(made);
-              if (seenPreFan.has(madeKey)) {
-                continue;
-              }
-              seenPreFan.add(madeKey);
-              assertResolved(made);
-              assertDerefsTyped(made);
-              assertLocalsWritten(made);
-              assertNoOrphanedLocals(sfn, made);
-              // A backend refusal on this REWRITTEN tree is not a refusal of the row's own
-              // spelling, so it never becomes the row's stated cause: `FanResult.emit` is dropped
-              // here and only the primary call above records one.
-              //
-              // It is reported instead through `onLeverError` under `pf.suffix`, which is what
-              // `fanOut`'s second argument is for: a primary emit refusal does not THROW —
-              // `fanOut` returns it — so the `catch` below never sees it, and under the bare
-              // function name it would read as a refusal of the primary spelling while the lever's
-              // whole half of the fan was deleted.
-              const fanned = fanOut(made, pf.suffix).spellings;
-              for (const sp of fanned) {
-                spellings.push({ ...sp, suffix: `${pf.suffix}${sp.suffix}` });
-              }
-            } catch (e) {
-              opts.onLeverError?.(`${name}${pf.suffix}`, firstLine(e));
-            }
-          }
-          for (const sp of spellings) {
-            const source = sp.source;
-            // Collapse a spelling that produced identical source (a function with no divergent `if`
-            // structures the same either way): no point scoring a duplicate spelling. Deduping the
-            // WHOLE emitted set (not just scored survivors) is equivalent — an identical source
-            // scores identically, so it can never change `best` — and it keeps the candidate set to
-            // the genuinely distinct spellings.
-            //
-            // THE PUBLISHED LABEL IS THEREFORE NOT AN ATTRIBUTION, and every argument in this tree
-            // that counts winning labels is unsound to exactly that extent. The label kept is the
-            // FIRST route's; the later routes are discarded, silently and by design. Adding one
-            // roster row renamed 21 agbcc rows whose emitted source sets were byte-identical —
-            // a CANDIDATE-SET census (whole fan unchanged, some candidate relabelled), which is a
-            // different population from a WINNING-label census: over published winners the same
-            // row moved 5 labels, 2 of them renames.
-            //
-            // AND A LABEL CENSUS CANNOT EVEN SEPARATE A RENAME FROM A RESPELLING. Of those 5
-            // winners, THREE changed the source they publish — `synthetic:unfoldpark`
-            // (402 → 397 bytes, score 9 → 0), `kleod:ConfigureEntityBehavior` (3677 → 3993,
-            // 233 → 230) and `synthetic:livepark` (337 → 346, both MATCH) — while
-            // `synthetic:foldpark` and `kleod:DecompressDma` are byte-identical renames. The two
-            // look the same from here; only the emitted SOURCE tells them apart (`bench diff`
-            // publishes that field, `bench regression` does not).
-            //
-            // So "N rows win under this family" bounds nothing: a family can win zero labels and
-            // still be the only route to a source, and a family can win five and have introduced
-            // three. Price a family by ABLATING it and re-running the rows
-            // (LIVEBASE_BLOCK_GATES carries the recipe); a zero census is not a death certificate,
-            // and a nonzero one is not a mechanism.
-            // THE SEAM FIX IS BOOKED AND NOT BUILT: keep the losing producers on the surviving
-            // candidate (`label` plus an `alsoReachedBy: string[]`) and a census by mechanism
-            // becomes one. It is not free — every consumer that reads `label` as the derivation
-            // would have to say which it means, and the published `candidateLabel` must not
-            // change — so build it when a round needs the census, not before. Until then the only
-            // sound census is an ablation.
-            const dup = seen.get(source);
-            if (dup !== undefined) {
-              // The same TEXT, reached twice. `matchOnly` is a property of the DERIVATION and the
-              // published artifact is the text, so a spelling some sound route also produces is a
-              // proven one however the first route reached it — clear the flag rather than keeping
-              // whichever route the enumeration happened to walk first.
-              if (sp.matchOnly === undefined) {
-                delete dup.matchOnly;
-              }
+          const vsuffix = twin ? lv.suffix + SHARED_TAIL_SUFFIX : lv.suffix;
+          // the per-variant axis gates, on THIS variant's lifted fn — see the table doc
+          const variantOff = STRUCTURING_AXES.filter((ax) => ax.variantGate !== undefined && !ax.variantGate(fn));
+          const variantCands = svCands.filter((s) => variantOff.every((ax) => !s[ax.flag]));
+          // `/merge-names` combinations whose un-merged sibling was DROPPED. `structure()` already
+          // refuses to let the axis unlock a function the primary declines, but it can only see its own
+          // refusals — a boundary contract fails out here, in `structureChecked`. Without this a
+          // `/reread-globals/merge-names` candidate could ship where plain `/reread-globals` did not,
+          // which is the same trade one level up. `senseCands` puts each `mergeNames:false` sibling
+          // first, so the entry is always recorded before its merged twin is reached.
+          const droppedPrimary = new Set<string>();
+          for (const s of variantCands) {
+            if (
+              STRUCTURING_AXES.some(
+                (ax) => ax.strip && s[ax.flag] && droppedPrimary.has(s.suffix.replace(ax.suffix, '')),
+              )
+            ) {
+              // A SKIPPED variant is recorded exactly like a dropped one, or the closure would not be
+              // transitive: with plain X dropped and X/inplace skipped-but-unrecorded,
+              // X/inplace/merge-names would find neither stripped key and run — shipping a
+              // double-lever candidate where its ancestor failed the boundary contracts.
+              droppedPrimary.add(s.suffix);
               continue;
             }
-            const made: Candidate = {
-              label: `${cand.label}${lv.suffix}${s.suffix}${sp.suffix}${sv.suffix}`,
-              source,
-              group: svIndex,
-              ...(sp.symbolRefs ? { symbolRefs: sp.symbolRefs } : {}),
-              ...(sp.deviceVolatile ? { deviceVolatile: sp.deviceVolatile } : {}),
-              ...(sp.matchOnly ? { matchOnly: sp.matchOnly } : {}),
-            };
-            seen.set(source, made);
-            out.push(made);
+            // structure() reads `fn` and produces a fresh SFn (it does not mutate `fn`), so both branch
+            // senses structure the same recovered function without re-lifting.
+            let sfn: SFn;
+            try {
+              sfn = structureChecked(fn, {
+                ...svOpts,
+                ...(inferredSymbols.size ? { inferredSymbols } : {}),
+                ...(orderLicensed.size ? { orderLicensedGlobals: orderLicensed } : {}),
+                preserveDivergentBranchSense: s.sense,
+                negateJoinedBranchSense: s.join ? !defSense : defSense,
+                ...(s.flipSites ? { branchSenseFlipSites: s.flipSites } : {}),
+                anchorConstCopies: s.anchor,
+                anchorLoopEntryConsts: s.entry,
+                spellBitfieldMembers: s.bitfields,
+                spellPtrMemberElements: s.ptrElems,
+                spellDeclaredSubscripts: s.declRank,
+                ...STRUCTURING_AXES.reduce((acc, ax) => ({ ...acc, ...ax.options(s[ax.flag]) }), {}),
+                ...(twin ? { followEarlyReturns: true } : {}),
+              });
+            } catch (e) {
+              if (vsuffix === '' && isBaseAxisPoint(s)) {
+                throw e; // the base lift's base axes keep their behavior: a failure aborts the row
+              }
+              // Recorded for EVERY dropped variant: a candidate with more axes on looks its siblings
+              // up by stripping one axis at a time, and the stripped key can itself carry the other.
+              droppedPrimary.add(s.suffix);
+              // an anchored variant that fails structuring or its contracts is a dropped lever, never
+              // an aborted enumeration — same rule as respell below
+              opts.onLeverError?.(name + vsuffix + s.suffix, firstLine(e));
+              continue;
+            }
+            // A TREE another axis point already spelled. `fanOut` reads the tree and this call's own
+            // constants, nothing that varies per axis point — its signature is the argument — so a
+            // repeated tree can only re-emit sources `seen` already holds: the candidate list, its
+            // order and its labels are exactly the ones the whole fan produces, reached without
+            // re-deriving forty passes. An axis is INERT on most functions (nothing to re-read, no
+            // bitfield member, no joined if), and an inert axis is a factor of two in the cross that
+            // changes nothing: on the klonoa checkout's `LoadBGTilemapData` under
+            // docs/ranked-repro.md's flags, 640 of 1024 axis points (62.5%) re-derive a tree an
+            // earlier one already emitted.
+            //
+            // Keyed on the JSON text, in a Set of STRINGS — a value comparison, so it can never
+            // merge two trees the way a hash could. Its one direction of error is a MISS (a
+            // differing key order re-runs a fan whose spellings then dedup as they do today), and
+            // the property that rules the other direction out — that the text determines the tree —
+            // is pinned by rank-tree-key.test.ts rather than assumed.
+            //
+            // The key therefore spans EVIDENCE fields too, `index.operandOff` among them, which
+            // `exprEquals` deliberately ignores (l3/ast.ts). The two are right to disagree: two
+            // trees identical but for that field denote the same cells, so a CSE may collapse them,
+            // and they admit different bases under `BASEFOLD_GATES`, so a fan may not. Dropping it
+            // from the key would be the direction the paragraph above rules out. It carries a
+            // DISPLACEMENT rather than a presence flag, so it can split two trees that print the
+            // same subscript off different addends — re-priced when it widened, over klonoa's
+            // `LoadBGTilemapData` under docs/ranked-repro.md's flags: 66816 candidates either way,
+            // and all 66816 `[score]` lines identical. It splits 0 keys, so the miss it can cause
+            // has no inhabitant.
+            const treeKey = JSON.stringify(sfn);
+            if (seenTrees.has(treeKey)) {
+              opts.onTreeDeduped?.();
+              continue;
+            }
+            seenTrees.add(treeKey);
+            // The row's OWN tree, so this is the one call whose backend refusal is the row's cause.
+            const primary = fanOut(sfn);
+            const spellings = primary.spellings;
+            if (primary.emit) {
+              lastEmitError = primary.emit.error;
+            }
+            // The PRE-FAN products (PRE_FAN_PRODUCTS, the fourth mechanism the POLICY note names):
+            // rewrite the TREE, then fan the whole re-spelling set over the result, so every lever
+            // below derives from the rewrite instead of composing onto it. The gate is the pass's
+            // own decline; the contracts are `respell`'s three, for `respell`'s reasons.
+            for (const pf of PRE_FAN_PRODUCTS) {
+              try {
+                const made = pf.apply(sfn);
+                if (made === null) {
+                  continue;
+                }
+                // The SAME tree dedup the primary above gets, and for the same reason: `fanOut` is a
+                // pure function of the tree, so re-fanning one already fanned buys nothing and makes
+                // the row's quoted fan cost a number that is partly duplicates. A SEPARATE set, not
+                // `seenTrees`: adding a rewritten tree there would let it skip a later PRIMARY tree
+                // that happens to equal it, and that primary's own pre-fan output — which nothing
+                // has computed — would go with it.
+                const madeKey = JSON.stringify(made);
+                if (seenPreFan.has(madeKey)) {
+                  continue;
+                }
+                seenPreFan.add(madeKey);
+                assertResolved(made);
+                assertDerefsTyped(made);
+                assertLocalsWritten(made);
+                assertNoOrphanedLocals(sfn, made);
+                // A backend refusal on this REWRITTEN tree is not a refusal of the row's own
+                // spelling, so it never becomes the row's stated cause: `FanResult.emit` is dropped
+                // here and only the primary call above records one.
+                //
+                // It is reported instead through `onLeverError` under `pf.suffix`, which is what
+                // `fanOut`'s second argument is for: a primary emit refusal does not THROW —
+                // `fanOut` returns it — so the `catch` below never sees it, and under the bare
+                // function name it would read as a refusal of the primary spelling while the lever's
+                // whole half of the fan was deleted.
+                const fanned = fanOut(made, pf.suffix).spellings;
+                for (const sp of fanned) {
+                  spellings.push({ ...sp, suffix: `${pf.suffix}${sp.suffix}` });
+                }
+              } catch (e) {
+                opts.onLeverError?.(`${name}${pf.suffix}`, firstLine(e));
+              }
+            }
+            for (const sp of spellings) {
+              const source = sp.source;
+              // Collapse a spelling that produced identical source (a function with no divergent `if`
+              // structures the same either way): no point scoring a duplicate spelling. Deduping the
+              // WHOLE emitted set (not just scored survivors) is equivalent — an identical source
+              // scores identically, so it can never change `best` — and it keeps the candidate set to
+              // the genuinely distinct spellings.
+              //
+              // THE PUBLISHED LABEL IS THEREFORE NOT AN ATTRIBUTION, and every argument in this tree
+              // that counts winning labels is unsound to exactly that extent. The label kept is the
+              // FIRST route's; the later routes are discarded, silently and by design. Adding one
+              // roster row renamed 21 agbcc rows whose emitted source sets were byte-identical —
+              // a CANDIDATE-SET census (whole fan unchanged, some candidate relabelled), which is a
+              // different population from a WINNING-label census: over published winners the same
+              // row moved 5 labels, 2 of them renames.
+              //
+              // AND A LABEL CENSUS CANNOT EVEN SEPARATE A RENAME FROM A RESPELLING. Of those 5
+              // winners, THREE changed the source they publish — `synthetic:unfoldpark`
+              // (402 → 397 bytes, score 9 → 0), `kleod:ConfigureEntityBehavior` (3677 → 3993,
+              // 233 → 230) and `synthetic:livepark` (337 → 346, both MATCH) — while
+              // `synthetic:foldpark` and `kleod:DecompressDma` are byte-identical renames. The two
+              // look the same from here; only the emitted SOURCE tells them apart (`bench diff`
+              // publishes that field, `bench regression` does not).
+              //
+              // So "N rows win under this family" bounds nothing: a family can win zero labels and
+              // still be the only route to a source, and a family can win five and have introduced
+              // three. Price a family by ABLATING it and re-running the rows
+              // (LIVEBASE_BLOCK_GATES carries the recipe); a zero census is not a death certificate,
+              // and a nonzero one is not a mechanism.
+              // THE SEAM FIX IS BOOKED AND NOT BUILT: keep the losing producers on the surviving
+              // candidate (`label` plus an `alsoReachedBy: string[]`) and a census by mechanism
+              // becomes one. It is not free — every consumer that reads `label` as the derivation
+              // would have to say which it means, and the published `candidateLabel` must not
+              // change — so build it when a round needs the census, not before. Until then the only
+              // sound census is an ablation.
+              const dup = seen.get(source);
+              if (dup !== undefined) {
+                // The same TEXT, reached twice. `matchOnly` is a property of the DERIVATION and the
+                // published artifact is the text, so a spelling some sound route also produces is a
+                // proven one however the first route reached it — clear the flag rather than keeping
+                // whichever route the enumeration happened to walk first.
+                if (sp.matchOnly === undefined) {
+                  delete dup.matchOnly;
+                }
+                continue;
+              }
+              const made: Candidate = {
+                label: `${cand.label}${vsuffix}${s.suffix}${sp.suffix}${sv.suffix}`,
+                source,
+                group: svIndex,
+                ...(sp.symbolRefs ? { symbolRefs: sp.symbolRefs } : {}),
+                ...(sp.deviceVolatile ? { deviceVolatile: sp.deviceVolatile } : {}),
+                ...(sp.matchOnly ? { matchOnly: sp.matchOnly } : {}),
+              };
+              seen.set(source, made);
+              out.push(made);
+            }
           }
         }
       }

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -1713,11 +1713,21 @@ export function enumerateCandidates(
         // THE SHARED-TAIL TWIN (`/shared-tail`): the same raised fn, structured a second time with
         // `followEarlyReturns`, after `sinkStoreTails` has rewritten it in place — safe because
         // `structure()` never mutates `fn`, so the first pass is done with it. A lift variant's twin
-        // rather than a structuring axis because the sink is an IR rewrite. Not the default: the
-        // same IR comes from both sources (raise/tailsink.ts), and the follow alone as a default
-        // costs `synthetic:sw_fallguard:ido7.1` 13/19 → 19/23 and `synthetic:gcseflat:agbcc`
-        // 19/53 → 22/54. Enumerated only where it can differ: the sink fired, or some divergent
-        // `if` shares a `ret`.
+        // rather than a structuring axis because the sink is an IR rewrite, and one run here rather
+        // than in pipeline.ts's spine because that costs no second lift. Not the default: the same
+        // IR comes from both sources (raise/tailsink.ts), and the follow alone as a default costs
+        // `synthetic:sw_fallguard:ido7.1` 13/19 → 19/23 and `synthetic:gcseflat:agbcc` 19/53 → 22/54.
+        //
+        // Enumerated only where the follow can differ — some divergent `if` of the SUNK fn shares a
+        // `ret` — and that is the sink's only price gate: without it, a tail copied into arms no `if`
+        // shares adds a twin spelling it in each, 204 synthetic candidates on 8 rows (the
+        // `gcsedup`/`gcseinnerdup`/`armexpr`/`mergeu16` controls and four ladders).
+        //
+        // ONE BIT PER LIFT VARIANT, not per site: the twin sinks every store tail and follows every
+        // divergent `if` at once, so a function with two sites gets the both-on candidate only.
+        // Over the 21 rows the twin reaches on both tiers, one function carries two follow sites
+        // (`synthetic:maskchain:agbcc`) and one two sunk tails (`synthetic:gcsearms6:agbcc`), both
+        // MATCH; every other carries at most one of each.
         for (const twin of [false, true]) {
           if (twin) {
             let sunk: boolean;
@@ -1730,7 +1740,7 @@ export function enumerateCandidates(
               opts.onLeverError?.(name + lv.suffix + SHARED_TAIL_SUFFIX, firstLine(e));
               break;
             }
-            if (!sunk && !hasDivergentSharedRet(fn)) {
+            if (!hasDivergentSharedRet(fn)) {
               break;
             }
           }

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -88,7 +88,9 @@ import { hasDivergentSharedRet } from './structure/structure';
 import { type SymbolInfo, type SymbolMap, arrayInnerExtents, isPtrField, symbolsByName } from './symbols';
 import { type TargetDescription, structureOptionsFor } from './target';
 
-/** The shared-tail twin's label (see its loop in `enumerateCandidates`). */
+/** The shared-tail twins' labels (see their loop in `enumerateCandidates`): the follow alone, on the
+ *  fn as raised, and the follow after the store-tail sink. */
+const SHARED_RET_SUFFIX = '/shared-ret';
 const SHARED_TAIL_SUFFIX = '/shared-tail';
 
 /** Pin every SCALAR entry param (index not in `ptrIdx`) to the candidate signedness, before
@@ -1710,27 +1712,48 @@ export function enumerateCandidates(
           opts.onLeverError?.(name + lv.suffix, firstLine(e));
           continue;
         }
-        // THE SHARED-TAIL TWIN (`/shared-tail`): the same raised fn, structured a second time with
-        // `followEarlyReturns`, after `sinkStoreTails` has rewritten it in place — safe because
-        // `structure()` never mutates `fn`, so the first pass is done with it. A lift variant's twin
-        // rather than a structuring axis because the sink is an IR rewrite, and one run here rather
-        // than in pipeline.ts's spine because that costs no second lift. Not the default: the same
-        // IR comes from both sources (raise/tailsink.ts), and the follow alone as a default costs
-        // `synthetic:sw_fallguard:ido7.1` 13/19 → 19/23 and `synthetic:gcseflat:agbcc` 19/53 → 22/54.
+        // THE SHARED-TAIL TWINS: the same raised fn, structured again with `followEarlyReturns`, in
+        // two passes after the primary one.
+        //   - `/shared-ret` is the follow ALONE, on the fn as raised. Some divergent `if` shares a
+        //     `ret` the compiler left in place (`synthetic:gcseinner`).
+        //   - `/shared-tail` is the follow after `sinkStoreTails` has rewritten the fn in place, which
+        //     is safe because `structure()` never mutates `fn`, so the earlier passes are done with it.
+        //     It is enumerated only where the sink changed something AND some divergent `if` of the
+        //     SUNK fn shares a `ret`. That is the sink's price gate: without it, a tail copied into
+        //     arms no `if` shares adds a twin spelling it in each, 204 synthetic candidates on 8 rows
+        //     (the `gcsedup`/`gcseinnerdup`/`armexpr`/`mergeu16` controls and four ladders).
+        // They are lift-variant twins rather than a structuring axis because the sink is an IR
+        // rewrite, and they run here rather than in pipeline.ts's spine because that costs no second
+        // lift. Neither is the default: the same IR comes from both sources (raise/tailsink.ts), and
+        // the follow alone as a default costs `synthetic:sw_fallguard:ido7.1` 13/19 → 19/23 and
+        // `synthetic:gcseflat:agbcc` 19/53 → 22/54.
         //
-        // Enumerated only where the follow can differ — some divergent `if` of the SUNK fn shares a
-        // `ret` — and that is the sink's only price gate: without it, a tail copied into arms no `if`
-        // shares adds a twin spelling it in each, 204 synthetic candidates on 8 rows (the
-        // `gcsedup`/`gcseinnerdup`/`armexpr`/`mergeu16` controls and four ladders).
+        // TWO BITS, NOT ONE, because the sink can DELETE the follow. A store tail that is itself the
+        // `ret` both sides of an `if` reach is copied into its `br` sources, and then no shared `ret`
+        // is left. `synthetic:gcsejoin:agbcc` is ordinary loop-free C of that shape, and it scored
+        // 7/37 while the follow was tried only behind the sink. No per-tail predicate on this IR picks
+        // between the two: refusing to sink a tail that is already a follow costs
+        // `synthetic:gcseflat:agbcc` 0/49 → 19/53 and `synthetic:gcsearms6:agbcc` 0/84 → 23/87, and
+        // those two need a tail that is BOTH. So the follow-alone candidate is enumerated wherever
+        // the fn as raised has a follow, sunk or not. Its price over the bundled twin is +76
+        // synthetic candidates, on those two rows, and +0 real: where the sink does not fire the
+        // `/shared-ret` pass is the old twin, and on every real row where it fires the fn as raised
+        // has no follow.
         //
-        // ONE BIT PER LIFT VARIANT, not per site: the twin sinks every store tail and follows every
-        // divergent `if` at once, so a function with two sites gets the both-on candidate only.
-        // Over the 21 rows the twin reaches on both tiers, one function carries two follow sites
-        // (`synthetic:maskchain:agbcc`) and one two sunk tails (`synthetic:gcsearms6:agbcc`), both
-        // MATCH; every other carries at most one of each.
+        // EACH BIT IS PER LIFT VARIANT, not per site: the `/shared-tail` pass sinks every store tail
+        // and follows every divergent `if` at once, so a function with two sites gets the both-on
+        // candidate only. Over the rows the twins reach on both tiers, one function carries two
+        // follow sites (`synthetic:maskchain:agbcc`) and one two sunk tails
+        // (`synthetic:gcsearms6:agbcc`), both MATCH; every other carries at most one of each.
+        //
+        // `droppedPrimary` is the PRIMARY pass's drops. Each twin pass reads it and keeps its own
+        // drops in a copy, so one twin's structuring failure never removes the other's candidate.
         const droppedPrimary = new Set<string>();
-        for (const twin of [false, true]) {
-          if (twin) {
+        for (const pass of ['primary', 'follow', 'sink'] as const) {
+          if (pass === 'follow' && !hasDivergentSharedRet(fn)) {
+            continue;
+          }
+          if (pass === 'sink') {
             let sunk: boolean;
             try {
               sunk = sinkStoreTails(fn);
@@ -1741,11 +1764,19 @@ export function enumerateCandidates(
               opts.onLeverError?.(name + lv.suffix + SHARED_TAIL_SUFFIX, firstLine(e));
               break;
             }
-            if (!hasDivergentSharedRet(fn)) {
+            // Unsunk, this fn is the `/shared-ret` pass's again.
+            if (!sunk || !hasDivergentSharedRet(fn)) {
               break;
             }
           }
-          const vsuffix = twin ? lv.suffix + SHARED_TAIL_SUFFIX : lv.suffix;
+          const twin = pass !== 'primary';
+          const dropped = twin ? new Set(droppedPrimary) : droppedPrimary;
+          const vsuffix =
+            pass === 'follow'
+              ? lv.suffix + SHARED_RET_SUFFIX
+              : pass === 'sink'
+                ? lv.suffix + SHARED_TAIL_SUFFIX
+                : lv.suffix;
           // the per-variant axis gates, on THIS variant's lifted fn — see the table doc
           const variantOff = STRUCTURING_AXES.filter((ax) => ax.variantGate !== undefined && !ax.variantGate(fn));
           const variantCands = svCands.filter((s) => variantOff.every((ax) => !s[ax.flag]));
@@ -1756,23 +1787,20 @@ export function enumerateCandidates(
           // which is the same trade one level up. `senseCands` puts each `mergeNames:false` sibling
           // first, so the entry is always recorded before its merged twin is reached.
           //
-          // The shared-tail twin reads the UNSUNK pass's set as well: `X/shared-tail` never ships
-          // where `X` was dropped. The sink rewrites the IR into a shape the structurer can accept
-          // where the unsunk one declined — sound, but the same trade one level up again.
+          // The shared-tail twins read the PRIMARY pass's set as well: neither `X/shared-ret` nor
+          // `X/shared-tail` ever ships where `X` was dropped. The follow and the sink each give the
+          // structurer a shape it can accept where the primary one declined — sound, but the same
+          // trade one level up again.
           for (const s of variantCands) {
             if (twin && droppedPrimary.has(s.suffix)) {
               continue;
             }
-            if (
-              STRUCTURING_AXES.some(
-                (ax) => ax.strip && s[ax.flag] && droppedPrimary.has(s.suffix.replace(ax.suffix, '')),
-              )
-            ) {
+            if (STRUCTURING_AXES.some((ax) => ax.strip && s[ax.flag] && dropped.has(s.suffix.replace(ax.suffix, '')))) {
               // A SKIPPED variant is recorded exactly like a dropped one, or the closure would not be
               // transitive: with plain X dropped and X/inplace skipped-but-unrecorded,
               // X/inplace/merge-names would find neither stripped key and run — shipping a
               // double-lever candidate where its ancestor failed the boundary contracts.
-              droppedPrimary.add(s.suffix);
+              dropped.add(s.suffix);
               continue;
             }
             // structure() reads `fn` and produces a fresh SFn (it does not mutate `fn`), so both branch
@@ -1800,7 +1828,7 @@ export function enumerateCandidates(
               }
               // Recorded for EVERY dropped variant: a candidate with more axes on looks its siblings
               // up by stripping one axis at a time, and the stripped key can itself carry the other.
-              droppedPrimary.add(s.suffix);
+              dropped.add(s.suffix);
               // an anchored variant that fails structuring or its contracts is a dropped lever, never
               // an aborted enumeration — same rule as respell below
               opts.onLeverError?.(name + vsuffix + s.suffix, firstLine(e));

--- a/packages/core/src/rank.ts
+++ b/packages/core/src/rank.ts
@@ -61,6 +61,7 @@ import { type Prototypes, prototypesFromSymbols } from './proto';
 import { inferGlobalArrays, orderLicensedGlobals, sameDerivedShape } from './raise/globalshape';
 import { runPreRecovery } from './raise/pre-recovery';
 import { recoverTypes } from './raise/recover';
+import { sinkStoreTails } from './raise/tailsink';
 import {
   BASEFOLD_ADMISSIONS,
   type BaseAdmission,
@@ -1710,13 +1711,28 @@ export function enumerateCandidates(
           continue;
         }
         // THE SHARED-TAIL TWIN (`/shared-tail`): the same raised fn, structured a second time with
-        // `followEarlyReturns` — safe because `structure()` never mutates `fn`. A twin, not the
-        // default: as a default it costs `synthetic:sw_fallguard:ido7.1` 13/19 → 19/23 and
-        // `synthetic:gcseflat:agbcc` 19/53 → 22/54. Enumerated only where it can differ: some
-        // divergent `if` shares a `ret`.
+        // `followEarlyReturns`, after `sinkStoreTails` has rewritten it in place — safe because
+        // `structure()` never mutates `fn`, so the first pass is done with it. A lift variant's twin
+        // rather than a structuring axis because the sink is an IR rewrite. Not the default: the
+        // same IR comes from both sources (raise/tailsink.ts), and the follow alone as a default
+        // costs `synthetic:sw_fallguard:ido7.1` 13/19 → 19/23 and `synthetic:gcseflat:agbcc`
+        // 19/53 → 22/54. Enumerated only where it can differ: the sink fired, or some divergent
+        // `if` shares a `ret`.
         for (const twin of [false, true]) {
-          if (twin && !hasDivergentSharedRet(fn)) {
-            break;
+          if (twin) {
+            let sunk: boolean;
+            try {
+              sunk = sinkStoreTails(fn);
+              if (sunk) {
+                verify(fn);
+              }
+            } catch (e) {
+              opts.onLeverError?.(name + lv.suffix + SHARED_TAIL_SUFFIX, firstLine(e));
+              break;
+            }
+            if (!sunk && !hasDivergentSharedRet(fn)) {
+              break;
+            }
           }
           const vsuffix = twin ? lv.suffix + SHARED_TAIL_SUFFIX : lv.suffix;
           // the per-variant axis gates, on THIS variant's lifted fn — see the table doc

--- a/packages/core/src/structure/structure.ts
+++ b/packages/core/src/structure/structure.ts
@@ -1552,6 +1552,10 @@ export interface StructureOptions {
   // join's feed a NAME to adopt, and materialization is keyed on the defining `Op` — a parameter
   // has none, so there is nothing to key.
   freshParamMerge?: boolean;
+  // Give a DIVERGENT `if` — one whose arms reach no common block before EXIT — the follow its
+  // non-returning paths share: `followOverReturns` below. Absent, such an `if` keeps its arms
+  // divergent and a region both of them reach is emitted in each.
+  followEarlyReturns?: boolean;
   // How an unresolvable VALUE degrades (a live `opaque`, an unlowered transient op, a dropped def):
   //   "strict"   (default) — the `"?"` sentinel, tripping assertResolved at the boundary (loud in
   //              the PROCESS);
@@ -1643,6 +1647,8 @@ export interface StructureHooks {
    *  which sense it actually emitted. The enumeration domain — a site only exists once structuring
    *  has decided both arms are real, so it cannot be computed ahead of the pass. */
   onBranchSenseSite?: (site: { block: number; ordinal: number; joined: boolean; negated: boolean }) => void;
+  /** Every divergent `if` `followEarlyReturns` gave a follow: the `if`'s block and the follow's. */
+  onEarlyReturnFollow?: (site: { block: number; follow: number }) => void;
 }
 
 /** A CANDIDATE SPELLING MUST NEVER UNLOCK A FUNCTION THE PRIMARY DECLINES. `varName` is not only
@@ -1671,6 +1677,7 @@ function assertPrimaryAccepts(fn: Fn, opts: StructureOptions, hooks: StructureHo
       homeMergeFeeds: false,
       anchorConstCopies: false,
       anchorLoopEntryConsts: false,
+      followEarlyReturns: false,
     },
     hooks,
   );
@@ -1685,6 +1692,52 @@ interface EarlyReturnArmDeps {
 
 function isRet(blk: Block): boolean {
   return blk.ops[blk.ops.length - 1]?.opcode === 'ret';
+}
+/** Is there an `if` whose arms reach no common block before EXIT but share a `ret` — the only shape
+ *  `followEarlyReturns` changes? The shared-tail twin's enumeration gate (rank.ts); a superset, since
+ *  it asks neither the loop nor the enclosing-region refusals. */
+export function hasDivergentSharedRet(fn: Fn): boolean {
+  const ipdom = postDominators(fn);
+  const retsFrom = (b: Block): Set<Block> => {
+    const out = new Set<Block>();
+    const seen = new Set<Block>();
+    const stack = [b];
+    while (stack.length) {
+      const x = stack.pop()!;
+      if (!seen.has(x)) {
+        seen.add(x);
+        if (isRet(x)) {
+          out.add(x);
+        }
+        stack.push(...successorsOf(x));
+      }
+    }
+    return out;
+  };
+  return fn.blocks.some((b) => {
+    const [s1, s2] = b.ops[b.ops.length - 1].opcode === 'cond_br' ? successorsOf(b) : [];
+    if (!s1 || !s2 || s1 === s2 || ipdom.get(b) !== null) {
+      return false;
+    }
+    const r2 = retsFrom(s2);
+    return [...retsFrom(s1)].some((r) => r2.has(r));
+  });
+}
+/** does a path from `from` reach `to` without passing through `avoid`? */
+function reachesAvoiding(from: Block, to: Block, avoid: Block): boolean {
+  const seen = new Set<Block>([avoid]);
+  const stack = successorsOf(from);
+  while (stack.length) {
+    const x = stack.pop()!;
+    if (x === to) {
+      return true;
+    }
+    if (!seen.has(x)) {
+      seen.add(x);
+      stack.push(...successorsOf(x));
+    }
+  }
+  return false;
 }
 // An early `return` out of the loop: forward-walking from `to` WITHOUT re-entering the loop `body`,
 // every path terminates in a `ret`. agbcc/gcc merge every `return` into ONE epilogue block and each
@@ -1789,6 +1842,7 @@ export function structure(fn: Fn, opts: StructureOptions = {}, hooks: StructureH
     unsignedCompareSpelling = false,
     coalesceMergeNames = false,
     freshParamMerge = false,
+    followEarlyReturns = false,
     onGap = 'strict',
     symbols: mapSymbols,
     inferredSymbols,
@@ -1837,7 +1891,8 @@ export function structure(fn: Fn, opts: StructureOptions = {}, hooks: StructureH
     homeLoopExprs ||
     homeDerivedReads ||
     homeMergeFeeds ||
-    anchorConstCopies
+    anchorConstCopies ||
+    followEarlyReturns
   ) {
     assertPrimaryAccepts(fn, opts, hooks);
   }
@@ -1867,6 +1922,59 @@ export function structure(fn: Fn, opts: StructureOptions = {}, hooks: StructureH
       },
     },
   );
+
+  // THE FOLLOW OF A DIVERGENT `if`, over the paths that do not return early. Post-dominance gives
+  // such an `if` no join — its arms reach two different `ret`s, and EXIT is the only block on every
+  // path — so each arm is structured to its end and a region both arms reach is emitted in both.
+  // When the compiler emitted that region ONCE, the source can have written it once, after the
+  // `if`, with every other path into a `ret` an early `return;` — `synthetic:gcseinner`, where
+  // agbcc keeps the `fnA` arm's own `ret` and stores the default once. An option, enumerated as
+  // rank.ts's `/shared-tail` twin: as a default it costs rows, measured there.
+  //
+  // WHICH REGION: the `ret`s reachable from BOTH successors. Every block that cannot reach one of
+  // them is an early-return region and is deleted; the follow is `b`'s post-dominator over what is
+  // left. Sound for the same reason an ordinary follow is: every kept path from `b` passes it, and a
+  // deleted block reaches no kept `ret` and so never the follow, so each arm structures up to the
+  // follow or into a `return`. And no deleted region is reachable from both arms — its `ret` would
+  // then be one of the shared ones — so the rule duplicates nothing across the arms.
+  //
+  // PER `if`, never function-wide: the deletion set is a function of that `if`'s own shared `ret`s
+  // (memoized on them), because a nested `if` shares a different set, or none.
+  //
+  // REFUSES (keeping the divergent arms) when no `ret` is reachable from both successors, when the
+  // kept graph gives `b` no post-dominator but EXIT, and when the enclosing region's `stop` is
+  // reachable from `b` without passing the follow — that path must reach `stop`, and structuring
+  // the arms towards a different follow would emit `stop`'s region inside an arm. The caller asks
+  // only outside a loop body, where `clampToLoop` owns the in-loop question.
+  const followsByShared = new Map<string, Map<Block, Block | null>>();
+  const followOverReturns = (b: Block, stop: Block | null): Block | null => {
+    const [s1, s2] = successorsOf(b);
+    if (s1 === undefined || s2 === undefined || s1 === s2) {
+      return null;
+    }
+    const retsFrom = (x: Block): Block[] => [x, ...reachFrom(x)].filter(isRet);
+    const fromS2 = new Set(retsFrom(s2));
+    const shared = retsFrom(s1).filter((r) => fromS2.has(r));
+    if (shared.length === 0) {
+      return null;
+    }
+    const key = shared
+      .map((r) => fn.blocks.indexOf(r))
+      .sort((x, y) => x - y)
+      .join(',');
+    let pd = followsByShared.get(key);
+    if (pd === undefined) {
+      const keep = new Set(fn.blocks.filter((x) => shared.some((r) => r === x || reachFrom(x).has(r))));
+      pd = postDominators(fn, keep);
+      followsByShared.set(key, pd);
+    }
+    const follow = pd.get(b) ?? null;
+    if (follow === null || (stop !== null && follow !== stop && reachesAvoiding(b, stop, follow))) {
+      return null;
+    }
+    hooks.onEarlyReturnFollow?.({ block: fn.blocks.indexOf(b), follow: fn.blocks.indexOf(follow) });
+    return follow;
+  };
 
   // SCALAR-vs-AGGREGATE globals: a `gaddr` symbol accessed EXCLUSIVELY at offset 0 is a scalar
   // global → the bare name `gSym` (byte-exact, matches the source). A symbol accessed at any
@@ -4723,7 +4831,8 @@ export function structure(fn: Fn, opts: StructureOptions = {}, hooks: StructureH
     }
 
     const cond = expr(term.operands[0]);
-    const ipd = ipdom.get(b) ?? null; // null ⇒ the arms diverge (both reach EXIT), no join
+    // null ⇒ the arms diverge (both reach EXIT) and no follow over early returns applies
+    const ipd = ipdom.get(b) ?? (followEarlyReturns && loopCtx === null ? followOverReturns(b, stop) : null);
     // Inside a loop body, a join OUTSIDE that body is not this `if`'s join: an arm that leaves the
     // loop `return`s and never comes back, so what is left reconverges at the loop's own
     // continuation. Post-dominance cannot see that — agbcc/gcc merge every `return` into one
@@ -5748,22 +5857,24 @@ function* inEdgeRecords(preds: Map<Block, Block[]>, b: Block): Generator<{ pred:
   }
 }
 
-// Immediate post-dominators. EXIT is represented as `null`; ret-blocks post-lead to it.
-function postDominators(fn: Fn): Map<Block, Block | null> {
-  const nodes: (Block | null)[] = [null, ...fn.blocks];
+// Immediate post-dominators. EXIT is represented as `null`; ret-blocks post-lead to it. Over the
+// subgraph `keep` induces when given, every member of which must still reach a `ret` inside it.
+function postDominators(fn: Fn, keep?: ReadonlySet<Block>): Map<Block, Block | null> {
+  const blocks = keep ? fn.blocks.filter((b) => keep.has(b)) : fn.blocks;
+  const nodes: (Block | null)[] = [null, ...blocks];
   const succ = (b: Block): (Block | null)[] => {
     const term = b.ops[b.ops.length - 1];
-    return term.opcode === 'ret' ? [null] : successorsOf(b);
+    return term.opcode === 'ret' ? [null] : successorsOf(b).filter((s) => keep === undefined || keep.has(s));
   };
   const pdom = new Map<Block | null, Set<Block | null>>();
   pdom.set(null, new Set([null]));
-  for (const b of fn.blocks) {
+  for (const b of blocks) {
     pdom.set(b, new Set(nodes));
   }
   let changed = true;
   while (changed) {
     changed = false;
-    for (const b of fn.blocks) {
+    for (const b of blocks) {
       const ss = succ(b);
       let inter: Set<Block | null> | null = null;
       for (const s of ss) {
@@ -5788,7 +5899,7 @@ function postDominators(fn: Fn): Map<Block, Block | null> {
   }
   // ipdom(b) = the strict post-dom c with (strictPostDoms(b) \ {c}) ⊆ pdom(c)
   const ipdom = new Map<Block, Block | null>();
-  for (const b of fn.blocks) {
+  for (const b of blocks) {
     const strict = [...pdom.get(b)!].filter((c) => c !== b);
     let chosen: Block | null = null;
     for (const c of strict) {

--- a/packages/core/src/structure/structure.ts
+++ b/packages/core/src/structure/structure.ts
@@ -1693,35 +1693,40 @@ interface EarlyReturnArmDeps {
 function isRet(blk: Block): boolean {
   return blk.ops[blk.ops.length - 1]?.opcode === 'ret';
 }
+/** The `ret`s reachable from BOTH successors of `b` — the region `followEarlyReturns` keeps. Empty
+ *  when there is none, and when `b` does not branch two ways. `reachFrom` is forward reachability,
+ *  the start block excluded. */
+function sharedRetsOf(b: Block, reachFrom: (x: Block) => ReadonlySet<Block>): Block[] {
+  const [s1, s2] = b.ops[b.ops.length - 1]?.opcode === 'cond_br' ? successorsOf(b) : [];
+  if (s1 === undefined || s2 === undefined || s1 === s2) {
+    return [];
+  }
+  const retsFrom = (x: Block): Block[] => [x, ...reachFrom(x)].filter(isRet);
+  const fromS2 = new Set(retsFrom(s2));
+  return retsFrom(s1).filter((r) => fromS2.has(r));
+}
 /** Is there an `if` whose arms reach no common block before EXIT but share a `ret` — the only shape
- *  `followEarlyReturns` changes? The shared-tail twin's enumeration gate (rank.ts); a superset, since
- *  it asks neither the loop nor the enclosing-region refusals. */
+ *  `followEarlyReturns` changes? The shared-tail twin's enumeration gate (rank.ts); a superset,
+ *  since it asks `sharedRetsOf` and none of the follow's three later refusals. */
 export function hasDivergentSharedRet(fn: Fn): boolean {
   const ipdom = postDominators(fn);
-  const retsFrom = (b: Block): Set<Block> => {
-    const out = new Set<Block>();
-    const seen = new Set<Block>();
-    const stack = [b];
-    while (stack.length) {
-      const x = stack.pop()!;
-      if (!seen.has(x)) {
-        seen.add(x);
-        if (isRet(x)) {
+  const reach = new Map<Block, Set<Block>>();
+  const reachFrom = (b: Block): Set<Block> => {
+    let out = reach.get(b);
+    if (out === undefined) {
+      out = new Set<Block>();
+      for (const stack = successorsOf(b); stack.length;) {
+        const x = stack.pop()!;
+        if (!out.has(x)) {
           out.add(x);
+          stack.push(...successorsOf(x));
         }
-        stack.push(...successorsOf(x));
       }
+      reach.set(b, out);
     }
     return out;
   };
-  return fn.blocks.some((b) => {
-    const [s1, s2] = b.ops[b.ops.length - 1].opcode === 'cond_br' ? successorsOf(b) : [];
-    if (!s1 || !s2 || s1 === s2 || ipdom.get(b) !== null) {
-      return false;
-    }
-    const r2 = retsFrom(s2);
-    return [...retsFrom(s1)].some((r) => r2.has(r));
-  });
+  return fn.blocks.some((b) => ipdom.get(b) === null && sharedRetsOf(b, reachFrom).length > 0);
 }
 /** does a path from `from` reach `to` without passing through `avoid`? */
 function reachesAvoiding(from: Block, to: Block, avoid: Block): boolean {
@@ -1945,16 +1950,10 @@ export function structure(fn: Fn, opts: StructureOptions = {}, hooks: StructureH
   // kept graph gives `b` no post-dominator but EXIT, and when the enclosing region's `stop` is
   // reachable from `b` without passing the follow — that path must reach `stop`, and structuring
   // the arms towards a different follow would emit `stop`'s region inside an arm. The caller asks
-  // only outside a loop body, where `clampToLoop` owns the in-loop question.
+  // only outside a loop body.
   const followsByShared = new Map<string, Map<Block, Block | null>>();
   const followOverReturns = (b: Block, stop: Block | null): Block | null => {
-    const [s1, s2] = successorsOf(b);
-    if (s1 === undefined || s2 === undefined || s1 === s2) {
-      return null;
-    }
-    const retsFrom = (x: Block): Block[] => [x, ...reachFrom(x)].filter(isRet);
-    const fromS2 = new Set(retsFrom(s2));
-    const shared = retsFrom(s1).filter((r) => fromS2.has(r));
+    const shared = sharedRetsOf(b, reachFrom);
     if (shared.length === 0) {
       return null;
     }
@@ -4831,7 +4830,10 @@ export function structure(fn: Fn, opts: StructureOptions = {}, hooks: StructureH
     }
 
     const cond = expr(term.operands[0]);
-    // null ⇒ the arms diverge (both reach EXIT) and no follow over early returns applies
+    // null ⇒ the arms diverge (both reach EXIT) and no follow over early returns applies. Asked
+    // outside loop bodies only: inside one, `clampToLoop` below owns the question. DEFENSIVE — no
+    // input it changes: ablated, the follow fires on no more of 40,000 generated functions (random
+    // structuring options, sunk and unsunk) and on no corpus row the twin reaches.
     const ipd = ipdom.get(b) ?? (followEarlyReturns && loopCtx === null ? followOverReturns(b, stop) : null);
     // Inside a loop body, a join OUTSIDE that body is not this `if`'s join: an arm that leaves the
     // loop `return`s and never comes back, so what is left reconverges at the loop's own

--- a/packages/core/src/structure/structure.ts
+++ b/packages/core/src/structure/structure.ts
@@ -4835,7 +4835,8 @@ export function structure(fn: Fn, opts: StructureOptions = {}, hooks: StructureH
     // null ⇒ the arms diverge (both reach EXIT) and no follow over early returns applies. Asked
     // outside loop bodies only: inside one, `clampToLoop` below owns the question. DEFENSIVE — no
     // input it changes: ablated, the follow fires on no more of 40,000 generated functions (random
-    // structuring options, sunk and unsunk) and on no corpus row the twins reach.
+    // structuring options, sunk and unsunk), and every row of both tiers enumerates a byte-identical
+    // label-and-source set (810 synthetic, 251 real, `ProcessInputAndUpdateEntities` excepted).
     const ipd = ipdom.get(b) ?? (followEarlyReturns && loopCtx === null ? followOverReturns(b, stop) : null);
     // Inside a loop body, a join OUTSIDE that body is not this `if`'s join: an arm that leaves the
     // loop `return`s and never comes back, so what is left reconverges at the loop's own

--- a/packages/core/src/structure/structure.ts
+++ b/packages/core/src/structure/structure.ts
@@ -1706,8 +1706,9 @@ function sharedRetsOf(b: Block, reachFrom: (x: Block) => ReadonlySet<Block>): Bl
   return retsFrom(s1).filter((r) => fromS2.has(r));
 }
 /** Is there an `if` whose arms reach no common block before EXIT but share a `ret` — the only shape
- *  `followEarlyReturns` changes? The shared-tail twin's enumeration gate (rank.ts); a superset,
- *  since it asks `sharedRetsOf` and none of the follow's three later refusals. */
+ *  `followEarlyReturns` changes? The enumeration gate of both shared-tail twins (rank.ts), asked of
+ *  the fn as raised and again of the sunk fn; a superset, since it asks `sharedRetsOf` and none of
+ *  the follow's three later refusals. */
 export function hasDivergentSharedRet(fn: Fn): boolean {
   const ipdom = postDominators(fn);
   const reach = new Map<Block, Set<Block>>();
@@ -1934,7 +1935,8 @@ export function structure(fn: Fn, opts: StructureOptions = {}, hooks: StructureH
   // When the compiler emitted that region ONCE, the source can have written it once, after the
   // `if`, with every other path into a `ret` an early `return;` — `synthetic:gcseinner`, where
   // agbcc keeps the `fnA` arm's own `ret` and stores the default once. An option, enumerated as
-  // rank.ts's `/shared-tail` twin: as a default it costs rows, measured there.
+  // rank.ts's `/shared-ret` twin, and as its `/shared-tail` twin after the store-tail sink: as a
+  // default it costs rows, measured there.
   //
   // WHICH REGION: the `ret`s reachable from BOTH successors. Every block that cannot reach one of
   // them is an early-return region and is deleted; the follow is `b`'s post-dominator over what is
@@ -4833,7 +4835,7 @@ export function structure(fn: Fn, opts: StructureOptions = {}, hooks: StructureH
     // null ⇒ the arms diverge (both reach EXIT) and no follow over early returns applies. Asked
     // outside loop bodies only: inside one, `clampToLoop` below owns the question. DEFENSIVE — no
     // input it changes: ablated, the follow fires on no more of 40,000 generated functions (random
-    // structuring options, sunk and unsunk) and on no corpus row the twin reaches.
+    // structuring options, sunk and unsunk) and on no corpus row the twins reach.
     const ipd = ipdom.get(b) ?? (followEarlyReturns && loopCtx === null ? followOverReturns(b, stop) : null);
     // Inside a loop body, a join OUTSIDE that body is not this `if`'s join: an arm that leaves the
     // loop `return`s and never comes back, so what is left reconverges at the loop's own

--- a/packages/core/test/gate-contract.test.ts
+++ b/packages/core/test/gate-contract.test.ts
@@ -48,7 +48,6 @@ import { NARROW_LOCAL_GATES } from '../src/raise/narrowlocal';
 import { PARAM_WIDTH_GATES } from '../src/raise/paramwidth';
 import { FALL_IN_GATES, SELECT_GATES } from '../src/raise/retsink';
 import { ARM_REREAD_GATES } from '../src/raise/shortcircuit';
-import { TAIL_SINK_GATES } from '../src/raise/tailsink';
 import { PREUPDATE_SINK_GATES } from '../src/structure/hazards';
 import { NAME_COALESCE_GATES } from '../src/structure/namecoalesce';
 import { CARRIER_NAME_GATES, ENCLOSING_CARRIER_GATES, FRESH_MERGE_GATES } from '../src/structure/structure';
@@ -81,7 +80,6 @@ const TABLES: Record<string, readonly Gate<never>[]> = {
   LATCH_GATES: LATCH_GATES as readonly Gate<never>[],
   FALL_IN_GATES: FALL_IN_GATES as readonly Gate<never>[],
   SELECT_GATES: SELECT_GATES as readonly Gate<never>[],
-  TAIL_SINK_GATES: TAIL_SINK_GATES as readonly Gate<never>[],
   ARM_REREAD_GATES: ARM_REREAD_GATES as readonly Gate<never>[],
   ADDRESS_GATES: ADDRESS_GATES as readonly Gate<never>[],
   SHAPE_GATES: SHAPE_GATES as readonly Gate<never>[],

--- a/packages/core/test/gate-contract.test.ts
+++ b/packages/core/test/gate-contract.test.ts
@@ -48,6 +48,7 @@ import { NARROW_LOCAL_GATES } from '../src/raise/narrowlocal';
 import { PARAM_WIDTH_GATES } from '../src/raise/paramwidth';
 import { FALL_IN_GATES, SELECT_GATES } from '../src/raise/retsink';
 import { ARM_REREAD_GATES } from '../src/raise/shortcircuit';
+import { TAIL_SINK_GATES } from '../src/raise/tailsink';
 import { PREUPDATE_SINK_GATES } from '../src/structure/hazards';
 import { NAME_COALESCE_GATES } from '../src/structure/namecoalesce';
 import { CARRIER_NAME_GATES, ENCLOSING_CARRIER_GATES, FRESH_MERGE_GATES } from '../src/structure/structure';
@@ -80,6 +81,7 @@ const TABLES: Record<string, readonly Gate<never>[]> = {
   LATCH_GATES: LATCH_GATES as readonly Gate<never>[],
   FALL_IN_GATES: FALL_IN_GATES as readonly Gate<never>[],
   SELECT_GATES: SELECT_GATES as readonly Gate<never>[],
+  TAIL_SINK_GATES: TAIL_SINK_GATES as readonly Gate<never>[],
   ARM_REREAD_GATES: ARM_REREAD_GATES as readonly Gate<never>[],
   ADDRESS_GATES: ADDRESS_GATES as readonly Gate<never>[],
   SHAPE_GATES: SHAPE_GATES as readonly Gate<never>[],

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -166,6 +166,12 @@ export interface Event {
   args: Val[];
 }
 
+/** Where a global `name` lives, for both interpreters: a store's address is an observable, so the
+ *  IR's `gaddr` and the tree's `&name` have to agree on it. Word-aligned and far apart, so no
+ *  constant offset a fixture uses carries one symbol onto another. */
+export const symAddr = (name: string): number =>
+  (([...name].reduce((h, ch) => (h * 31 + ch.charCodeAt(0)) & 0xfff, 7) + 1) * 0x10000) | 0;
+
 /** Every observable the emitted tree produces, in execution order. Conditions are evaluated for
  *  REAL — a naming defect that changes one changes the PATH, which is a difference worth catching
  *  (it changed a loop's trip count once). Parameters are seeded, or every value is UNDEF and the
@@ -215,10 +221,17 @@ export function traceOf(sfn: SFn, seed: number): Event[] {
         calls++;
         return args.some((a) => a === UNDEF) ? UNDEF : args.reduce((x: number, y) => x + (y as number), calls) | 0;
       }
-      case 'un':
-        return evalExpr(e.e) === UNDEF ? UNDEF : -(evalExpr(e.e) as number) | 0;
+      case 'un': {
+        const x = evalExpr(e.e);
+        if (x === UNDEF) {
+          return UNDEF;
+        }
+        return e.op === '!' ? (x === 0 ? 1 : 0) : e.op === '~' ? ~x : -x | 0;
+      }
       case 'cast':
         return evalExpr(e.e);
+      case 'addr':
+        return symAddr(e.name);
       default:
         throw new Error(`the generator does not emit ${e.k}`);
     }
@@ -242,6 +255,17 @@ export function traceOf(sfn: SFn, seed: number): Event[] {
         case 'exprstmt':
           evalExpr(s.value);
           break;
+        case 'store': {
+          // A store is observed as (address, value); only the `base[idx]` lvalue is modelled.
+          if (s.lval.k !== 'index') {
+            throw new Error(`unmodelled store lvalue ${s.lval.k}`);
+          }
+          const base = evalExpr(s.lval.base);
+          const idx = evalExpr(s.lval.idx);
+          const at = base === UNDEF || idx === UNDEF ? UNDEF : (base + idx * s.lval.width) | 0;
+          trace.push({ fn: 'store', args: [at, evalExpr(s.value)] });
+          break;
+        }
         case 'if': {
           const sig = truthy(s.cond) ? exec(s.then) : exec(s.else ?? []);
           if (sig !== 'none') return sig;
@@ -353,6 +377,12 @@ export function irTraceOf(fn: Fn, seed: number): Event[] {
           trace.push({ fn: op.attrs.target as string, args: o });
           calls++;
           env.set(r, o.reduce((x, y) => x + y, calls) | 0);
+          break;
+        case 'gaddr':
+          env.set(r, symAddr(op.attrs.sym as string));
+          break;
+        case 'store':
+          trace.push({ fn: 'store', args: [(o[0] + ((op.attrs.off as number | undefined) ?? 0)) | 0, o[1]] });
           break;
         case 'ret':
           trace.push({ fn: 'ret', args: o });

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -190,6 +190,17 @@ export function traceOf(sfn: SFn, seed: number): Event[] {
         return e.value;
       case 'bin': {
         const l = evalExpr(e.l);
+        if (e.op === '&&' || e.op === '||') {
+          // short-circuit: the right side runs only when the left does not decide it
+          if (l === UNDEF) {
+            return UNDEF;
+          }
+          if ((l !== 0) === (e.op === '||')) {
+            return e.op === '||' ? 1 : 0;
+          }
+          const rr = evalExpr(e.r);
+          return rr === UNDEF ? UNDEF : rr !== 0 ? 1 : 0;
+        }
         const r = evalExpr(e.r);
         if (l === UNDEF || r === UNDEF) return UNDEF;
         switch (e.op) {
@@ -372,6 +383,21 @@ export function irTraceOf(fn: Fn, seed: number): Event[] {
           break;
         case 'icmp_slt':
           env.set(r, o[0] < o[1] ? 1 : 0);
+          break;
+        // the comparisons a real Thumb lift of a fixture's `cmp` produces
+        case 'icmp_sge':
+          env.set(r, o[0] >= o[1] ? 1 : 0);
+          break;
+        case 'icmp_eq':
+          env.set(r, o[0] === o[1] ? 1 : 0);
+          break;
+        // raise's short-circuit recovery folds a condition tree into these; both operands are
+        // already computed values, so there is nothing to short-circuit
+        case 'logic_and':
+          env.set(r, o[0] !== 0 && o[1] !== 0 ? 1 : 0);
+          break;
+        case 'logic_or':
+          env.set(r, o[0] !== 0 || o[1] !== 0 ? 1 : 0);
           break;
         case 'call':
           trace.push({ fn: op.attrs.target as string, args: o });

--- a/packages/core/test/shared-tail-dropped.test.ts
+++ b/packages/core/test/shared-tail-dropped.test.ts
@@ -1,47 +1,94 @@
-// `X/shared-tail` NEVER SHIPS WHERE `X` WAS DROPPED — rank.ts's `/merge-names` closure, one level up.
+// A SHARED-TAIL TWIN NEVER SHIPS WHERE ITS PRIMARY WAS DROPPED — rank.ts's `/merge-names` closure,
+// one level up — AND ONE TWIN'S DROP NEVER COSTS THE OTHER.
 //
-// The twin structures the SUNK fn, which the structurer can accept where the unsunk one failed a
-// boundary contract. Both are sound, and that is why only the enumeration can refuse it: the
-// twin's axis point reads the unsunk pass's dropped set. `structureChecked` is mocked to fail
-// every unsunk `/defsite` point and to mark every twin one, because no committed disassembly makes
-// a contract fail on one lift and pass on its sunk twin — the closure is a property of the loop,
-// not of any row.
+// Each twin structures a fn the primary pass did not: `/shared-ret` the raised fn with the follow
+// on, `/shared-tail` the SUNK fn with it. The structurer can accept either where the primary failed
+// a boundary contract. Both are sound, and that is why only the enumeration can refuse it: each
+// twin's axis point reads the primary pass's dropped set. And each twin keeps its OWN drops apart,
+// so a follow the unsunk fn cannot carry does not take the sunk fn's candidate with it.
+// `structureChecked` is mocked to fail chosen `/defsite` points and to mark every other one, because
+// no committed disassembly makes a contract fail on one of these passes and pass on another — the
+// closure is a property of the loop, not of any row.
 import { expect, test, vi } from 'vitest';
 
+import { print } from '../src/ir/print';
 import { T } from '../src/ir/types';
 import { enumerateCandidates } from '../src/rank';
 import { ARMV4T_AGBCC } from '../src/target';
+
+/** Which passes the mock fails at every `/defsite` point. The primary pass is the one without the
+ *  follow; the `/shared-ret` pass is the one with the follow on a fn the primary pass also saw. */
+const fail = { primary: false, sharedRet: false };
+const primaryFns = new Set<string>();
 
 vi.mock('../src/pipeline', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/pipeline')>();
   return {
     ...actual,
     structureChecked: (...args: Parameters<typeof actual.structureChecked>) => {
-      const opts = args[1];
-      if (opts.anchorConstCopies && !opts.followEarlyReturns) {
+      const fn = args[0];
+      const opts = args[1] ?? {};
+      const text = print(fn);
+      if (!opts.followEarlyReturns) {
+        primaryFns.add(text);
+      }
+      const pass = !opts.followEarlyReturns ? 'primary' : primaryFns.has(text) ? 'sharedRet' : 'sharedTail';
+      if (
+        opts.anchorConstCopies &&
+        ((pass === 'primary' && fail.primary) || (pass === 'sharedRet' && fail.sharedRet))
+      ) {
         throw new Error('mocked contract failure');
       }
       const sfn = actual.structureChecked(...args);
-      // a distinct tree at every twin `/defsite` point, so the tree dedup cannot hide one
+      // a distinct tree at every `/defsite` point, so the tree dedup cannot hide one
       return opts.anchorConstCopies ? { ...sfn, locals: [...sfn.locals, { name: 'zzDefsite', type: T.s(32) }] } : sfn;
     },
   };
 });
 
+const P = { f: { params: 2, returnsVoid: true } };
 // `shared-tail.test.ts`'s cross-jumped tail, which only the sink turns into early returns.
 const THUMB =
   'f:\n\tpush\t{lr}\n\tldr\tr2, .L9\n\tcmp\tr0, #0\n\tblt\t.L3\n\tcmp\tr1, #0\n\tbge\t.L5\n' +
   '\tmov\tr3, #7\n\tb\t.L6\n.L3:\n\tstr\tr1, [r2, #8]\n.L5:\n\tmov\tr3, #9\n.L6:\n\tstr\tr3, [r2, #4]\n' +
   '\tpop\t{r0}\n\tbx\tr0\n.L10:\n\t.align\t2, 0\n.L9:\n\t.word\tgQ\n';
+// `shared-tail.test.ts`'s arm the compiler left returning, where only the follow runs.
+const THUMB_LEFT =
+  'f:\n\tpush\t{lr}\n\tldr\tr2, .L9\n\tcmp\tr0, #0\n\tblt\t.L3\n\tcmp\tr1, #0\n\tbge\t.L5\n' +
+  '\tmov\tr3, #7\n\tstr\tr3, [r2, #4]\n\tb\t.L6\n.L3:\n\tstr\tr1, [r2, #8]\n.L5:\n\tmov\tr3, #9\n' +
+  '\tstr\tr3, [r2, #4]\n.L6:\n\tpop\t{r0}\n\tbx\tr0\n.L10:\n\t.align\t2, 0\n.L9:\n\t.word\tgQ\n';
+// `shared-tail.test.ts`'s `THUMB_FLAT`, where both twins run.
+const THUMB_FLAT =
+  'f:\n\tpush\t{lr}\n\tldr\tr2, .L9\n\tcmp\tr0, #0\n\tblt\t.L3\n\tcmp\tr1, #0\n\tbge\t.L5\n' +
+  '\tcmp\tr0, #5\n\tbeq\t.L7\n\tmov\tr3, #7\n\tb\t.L6\n.L3:\n\tstr\tr1, [r2, #8]\n.L5:\n\tmov\tr3, #9\n' +
+  '.L6:\n\tstr\tr3, [r2, #4]\n\tpop\t{r0}\n\tbx\tr0\n.L7:\n\tmov\tr3, #8\n\tstr\tr3, [r2, #4]\n' +
+  '\tpop\t{r0}\n\tbx\tr0\n.L10:\n\t.align\t2, 0\n.L9:\n\t.word\tgQ\n';
 
-test('the twin skips every axis point its unsunk sibling dropped, and keeps the rest', () => {
+const run = (asm: string, failing: typeof fail) => {
+  Object.assign(fail, failing);
+  primaryFns.clear();
   const errors: string[] = [];
-  const cands = enumerateCandidates('f', THUMB, ARMV4T_AGBCC, {
-    prototypes: { f: { params: 2, returnsVoid: true } },
+  const cands = enumerateCandidates('f', asm, ARMV4T_AGBCC, {
+    prototypes: P,
     onLeverError: (label) => errors.push(label),
   });
-  expect(errors.some((l) => l.includes('/defsite') && !l.includes('/shared-tail'))).toBe(true);
-  const twin = cands.filter((c) => c.label.includes('/shared-tail'));
+  return { errors, cands };
+};
+
+test.each([
+  ['/shared-tail', THUMB],
+  ['/shared-ret', THUMB_LEFT],
+])('the %s twin skips every axis point its primary sibling dropped, and keeps the rest', (suffix, asm) => {
+  const { errors, cands } = run(asm, { primary: true, sharedRet: false });
+  expect(errors.some((l) => l.includes('/defsite') && !l.includes('/shared-'))).toBe(true);
+  const twin = cands.filter((c) => c.label.includes(suffix));
   expect(twin.length).toBeGreaterThan(0);
   expect(twin.filter((c) => c.label.includes('/defsite'))).toEqual([]);
+});
+
+test('a point the `/shared-ret` twin drops still ships in the `/shared-tail` twin', () => {
+  const { errors, cands } = run(THUMB_FLAT, { primary: false, sharedRet: true });
+  expect(errors.some((l) => l.includes('/shared-ret') && l.includes('/defsite'))).toBe(true);
+  expect(cands.filter((c) => c.label.includes('/shared-ret') && c.label.includes('/defsite'))).toEqual([]);
+  expect(cands.some((c) => c.label.includes('/shared-tail') && c.label.includes('/defsite'))).toBe(true);
 });

--- a/packages/core/test/shared-tail-dropped.test.ts
+++ b/packages/core/test/shared-tail-dropped.test.ts
@@ -1,0 +1,47 @@
+// `X/shared-tail` NEVER SHIPS WHERE `X` WAS DROPPED — rank.ts's `/merge-names` closure, one level up.
+//
+// The twin structures the SUNK fn, which the structurer can accept where the unsunk one failed a
+// boundary contract. Both are sound, and that is why only the enumeration can refuse it: the
+// twin's axis point reads the unsunk pass's dropped set. `structureChecked` is mocked to fail
+// every unsunk `/defsite` point and to mark every twin one, because no committed disassembly makes
+// a contract fail on one lift and pass on its sunk twin — the closure is a property of the loop,
+// not of any row.
+import { expect, test, vi } from 'vitest';
+
+import { T } from '../src/ir/types';
+import { enumerateCandidates } from '../src/rank';
+import { ARMV4T_AGBCC } from '../src/target';
+
+vi.mock('../src/pipeline', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/pipeline')>();
+  return {
+    ...actual,
+    structureChecked: (...args: Parameters<typeof actual.structureChecked>) => {
+      const opts = args[1];
+      if (opts.anchorConstCopies && !opts.followEarlyReturns) {
+        throw new Error('mocked contract failure');
+      }
+      const sfn = actual.structureChecked(...args);
+      // a distinct tree at every twin `/defsite` point, so the tree dedup cannot hide one
+      return opts.anchorConstCopies ? { ...sfn, locals: [...sfn.locals, { name: 'zzDefsite', type: T.s(32) }] } : sfn;
+    },
+  };
+});
+
+// `shared-tail.test.ts`'s cross-jumped tail, which only the sink turns into early returns.
+const THUMB =
+  'f:\n\tpush\t{lr}\n\tldr\tr2, .L9\n\tcmp\tr0, #0\n\tblt\t.L3\n\tcmp\tr1, #0\n\tbge\t.L5\n' +
+  '\tmov\tr3, #7\n\tb\t.L6\n.L3:\n\tstr\tr1, [r2, #8]\n.L5:\n\tmov\tr3, #9\n.L6:\n\tstr\tr3, [r2, #4]\n' +
+  '\tpop\t{r0}\n\tbx\tr0\n.L10:\n\t.align\t2, 0\n.L9:\n\t.word\tgQ\n';
+
+test('the twin skips every axis point its unsunk sibling dropped, and keeps the rest', () => {
+  const errors: string[] = [];
+  const cands = enumerateCandidates('f', THUMB, ARMV4T_AGBCC, {
+    prototypes: { f: { params: 2, returnsVoid: true } },
+    onLeverError: (label) => errors.push(label),
+  });
+  expect(errors.some((l) => l.includes('/defsite') && !l.includes('/shared-tail'))).toBe(true);
+  const twin = cands.filter((c) => c.label.includes('/shared-tail'));
+  expect(twin.length).toBeGreaterThan(0);
+  expect(twin.filter((c) => c.label.includes('/defsite'))).toEqual([]);
+});

--- a/packages/core/test/shared-tail-fuzz.test.ts
+++ b/packages/core/test/shared-tail-fuzz.test.ts
@@ -5,17 +5,19 @@
 // the follow turns fall-through into early `return;`s. That is the change that can be byte-closer
 // and semantically wrong at once, and no naming fuzz can see it — each compares one spelling with
 // another. So the oracle is the IR itself: the run of the lifted function (`irTraceOf`) against
-// the run of the IR after the sink, and against the run of each structured tree (`traceOf`).
+// the run of the IR after the sink, and against the run of each structured tree (`traceOf`), both
+// `structure()`'s and `structureChecked`'s after its committed L3 rewrites.
 //
 // The generator builds the family's shapes on purpose — a decision tree whose leaves branch into a
-// shared store tail, directly or through a pure forwarder or a join both sides may reach, or keep a
-// `ret` of their own — because a random CFG almost never shares a tail, and a fuzz that never
-// fires the path proves nothing. The firing counts are asserted, not just printed.
+// shared store tail, directly or through a chain of pure forwarders or a join both sides may
+// reach, or keep a `ret` of their own — because a random CFG almost never shares a tail, and a
+// fuzz that never fires the path proves nothing. The firing counts are asserted, not just printed.
 import { expect, test, vi } from 'vitest';
 
 import { type Block, type Fn, type Value, mkOp, mkValue } from '../src/ir/core';
 import { T } from '../src/ir/types';
 import { verify } from '../src/ir/verify';
+import { structureChecked } from '../src/pipeline';
 import { sinkStoreTails } from '../src/raise/tailsink';
 import { StructureError, structure } from '../src/structure/structure';
 import { BREATHE_EVERY, breathe, irTraceOf, mulberry32, traceOf } from './helpers';
@@ -49,19 +51,21 @@ function generateSharedTailFn(seed: number): Fn {
   const store = (b: Block, value: Value, off: number) =>
     b.ops.push(mkOp('store', { operands: [gq, value], attrs: { off, width: 4 } }));
 
-  // The shared store tail, an optional pure forwarder into it, and up to two joins either side of
-  // the top `if` may fall into.
+  // The shared store tail, a chain of up to two pure forwarders into it, and up to two joins either
+  // side of the top `if` may fall into.
   const tail = block(1);
   store(tail, tail.params[0], 4);
   if (rnd() < 0.3) {
     store(tail, pick(params), 8);
   }
   tail.ops.push(mkOp('ret'));
-  const fwd = rnd() < 0.4 ? block(1) : undefined;
-  if (fwd) {
-    br(fwd, tail, [fwd.params[0]]);
+  const entries = [tail];
+  for (let i = 0, n = rnd() < 0.4 ? (rnd() < 0.5 ? 1 : 2) : 0; i < n; i++) {
+    const f = block(1);
+    br(f, entries[entries.length - 1], [f.params[0]]);
+    entries.push(f);
   }
-  const into = (b: Block, value: Value) => br(b, fwd && rnd() < 0.5 ? fwd : tail, [value]);
+  const into = (b: Block, value: Value) => br(b, pick(entries), [value]);
   const joins: Block[] = [];
   for (let i = 0, n = Math.floor(rnd() * 3); i < n; i++) {
     const j = block();
@@ -178,6 +182,9 @@ test('the sink and the follow change no observable, on the shapes they were buil
         return 0;
       }
       RUNS.forEach((r, i) => expect(traceOf(tree, r), `seed ${seed}, run ${r}`).toEqual(want[i]));
+      // and after the committed L3 rewrites (tail-merge, dead stores, base locals) and contracts
+      const checked = structureChecked(fn, { returnsVoid: true, followEarlyReturns: true });
+      RUNS.forEach((r, i) => expect(traceOf(checked, r), `seed ${seed} checked, run ${r}`).toEqual(want[i]));
       return fired;
     };
     // The follow alone, on the lifted function.
@@ -191,7 +198,7 @@ test('the sink and the follow change no observable, on the shapes they were buil
       sunkAndFollowed += run(fn) > 0 ? 1 : 0;
     }
   }
-  // At authoring: sunk 1842, followed 9466, sunk+followed 1834, declined 0 — the floors below.
+  // At authoring: sunk 15866, followed 9391, sunk+followed 3662, declined 0 — the floors below.
   console.log(
     `[shared-tail-fuzz] seeds=${SEEDS} sunk=${sunk} followed=${followed} sunk+followed=${sunkAndFollowed} declined=${declined}`,
   );

--- a/packages/core/test/shared-tail-fuzz.test.ts
+++ b/packages/core/test/shared-tail-fuzz.test.ts
@@ -1,10 +1,11 @@
-// The irTraceOf differential behind the SHARED DEFAULT TAIL — structure()'s `followEarlyReturns`,
-// rank.ts's `/shared-tail` twin.
+// The irTraceOf differential behind the SHARED DEFAULT TAIL — `raise/tailsink.ts` and structure()'s
+// `followEarlyReturns`, the two terms of rank.ts's `/shared-tail` twin.
 //
-// The follow turns fall-through into early `return;`s, moving effects between control-flow paths.
-// That is the change that can be byte-closer and semantically wrong at once, and no naming fuzz
-// can see it — each compares one spelling with another. So the oracle is the IR itself: the run of
-// the lifted function (`irTraceOf`) against the run of each structured tree (`traceOf`).
+// Both move effects between control-flow paths: the sink copies a store tail into the arms, and
+// the follow turns fall-through into early `return;`s. That is the change that can be byte-closer
+// and semantically wrong at once, and no naming fuzz can see it — each compares one spelling with
+// another. So the oracle is the IR itself: the run of the lifted function (`irTraceOf`) against
+// the run of the IR after the sink, and against the run of each structured tree (`traceOf`).
 //
 // The generator builds the family's shapes on purpose — a decision tree whose leaves branch into a
 // shared store tail, directly or through a pure forwarder or a join both sides may reach, or keep a
@@ -15,6 +16,7 @@ import { expect, test, vi } from 'vitest';
 import { type Block, type Fn, type Value, mkOp, mkValue } from '../src/ir/core';
 import { T } from '../src/ir/types';
 import { verify } from '../src/ir/verify';
+import { sinkStoreTails } from '../src/raise/tailsink';
 import { StructureError, structure } from '../src/structure/structure';
 import { BREATHE_EVERY, breathe, irTraceOf, mulberry32, traceOf } from './helpers';
 
@@ -150,9 +152,11 @@ function generateSharedTailFn(seed: number): Fn {
  *  `< -2 / 0 / 2` tests take both sides. */
 const RUNS = [0, 9, 83, 511, 4095, 1234, 3001];
 
-test('the follow changes no observable, on the shapes it was built for', async () => {
+test('the sink and the follow change no observable, on the shapes they were built for', async () => {
   const SEEDS = 20000;
+  let sunk = 0;
   let followed = 0;
+  let sunkAndFollowed = 0;
   let declined = 0;
   for (let seed = 1; seed <= SEEDS; seed++) {
     if (seed % BREATHE_EVERY === 0) {
@@ -176,9 +180,22 @@ test('the follow changes no observable, on the shapes it was built for', async (
       RUNS.forEach((r, i) => expect(traceOf(tree, r), `seed ${seed}, run ${r}`).toEqual(want[i]));
       return fired;
     };
+    // The follow alone, on the lifted function.
     followed += run(lifted) > 0 ? 1 : 0;
+    // The sink, then the follow.
+    const fn = generateSharedTailFn(seed);
+    if (sinkStoreTails(fn)) {
+      sunk++;
+      verify(fn);
+      RUNS.forEach((r, i) => expect(irTraceOf(fn, r), `seed ${seed} sunk, run ${r}`).toEqual(want[i]));
+      sunkAndFollowed += run(fn) > 0 ? 1 : 0;
+    }
   }
-  // At authoring: followed 9466, declined 0 — the floor below.
-  console.log(`[shared-tail-fuzz] seeds=${SEEDS} followed=${followed} declined=${declined}`);
+  // At authoring: sunk 1842, followed 9466, sunk+followed 1834, declined 0 — the floors below.
+  console.log(
+    `[shared-tail-fuzz] seeds=${SEEDS} sunk=${sunk} followed=${followed} sunk+followed=${sunkAndFollowed} declined=${declined}`,
+  );
+  expect(sunk).toBeGreaterThan(1500);
   expect(followed).toBeGreaterThan(8000);
+  expect(sunkAndFollowed).toBeGreaterThan(1500);
 });

--- a/packages/core/test/shared-tail-fuzz.test.ts
+++ b/packages/core/test/shared-tail-fuzz.test.ts
@@ -12,14 +12,20 @@
 // shared store tail, directly or through a chain of pure forwarders or a join both sides may
 // reach, or keep a `ret` of their own — because a random CFG almost never shares a tail, and a
 // fuzz that never fires the path proves nothing. The firing counts are asserted, not just printed.
+//
+// A second arm runs the same functions through `raiseRecovered` first, because that is the fn
+// rank.ts hands the sink and raise reshapes it: a tail reached only through a forwarder reads the
+// forwarder's parameter. Hand-built IR never reaches that shape, and a sink that mishandled it threw
+// in `verify` on real Thumb while this first arm stayed green.
 import { expect, test, vi } from 'vitest';
 
 import { type Block, type Fn, type Value, mkOp, mkValue } from '../src/ir/core';
 import { T } from '../src/ir/types';
 import { verify } from '../src/ir/verify';
-import { structureChecked } from '../src/pipeline';
+import { raiseRecovered, structureChecked } from '../src/pipeline';
 import { sinkStoreTails } from '../src/raise/tailsink';
-import { StructureError, structure } from '../src/structure/structure';
+import { StructureError, hasDivergentSharedRet, structure } from '../src/structure/structure';
+import { ARMV4T_AGBCC } from '../src/target';
 import { BREATHE_EVERY, breathe, irTraceOf, mulberry32, traceOf } from './helpers';
 
 vi.setConfig({ testTimeout: 120_000 });
@@ -205,4 +211,79 @@ test('the sink and the follow change no observable, on the shapes they were buil
   expect(sunk).toBeGreaterThan(1500);
   expect(followed).toBeGreaterThan(8000);
   expect(sunkAndFollowed).toBeGreaterThan(1500);
+});
+
+/** A store tail — stores, then a void `ret` — that reads a block parameter of some OTHER non-entry
+ *  block: the shape only raise produces, by stripping the parameter of a tail whose one predecessor
+ *  is a forwarder, so that the tail reads the forwarder's. */
+const readsForeignParam = (fn: Fn): boolean =>
+  fn.blocks.some(
+    (b) =>
+      b.ops.length >= 2 &&
+      b.ops[b.ops.length - 1].opcode === 'ret' &&
+      b.ops.slice(0, -1).every((o) => o.opcode === 'store') &&
+      b.ops.some((o) => o.operands.some((v) => fn.blocks.some((x, i) => i > 0 && x !== b && x.params.includes(v)))),
+  );
+
+test('the same, on the fn the raise spine hands rank.ts', async () => {
+  // rank.ts sinks the RAISED fn, and raise reshapes what the generator built: a tail whose one
+  // predecessor is a forwarder loses its parameter and reads the forwarder's. Hand-built IR never
+  // reaches that, so this arm runs the generator's functions through `raiseRecovered` first, and
+  // takes the raised fn's own run as the oracle. The follow is asked where rank.ts asks it.
+  const SEEDS = 6000;
+  let foreign = 0;
+  let sunk = 0;
+  let foreignSunk = 0;
+  let followed = 0;
+  let sunkAndFollowed = 0;
+  let declined = 0;
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    if (seed % BREATHE_EVERY === 0) {
+      await breathe();
+    }
+    const fn = generateSharedTailFn(seed);
+    raiseRecovered(fn, ARMV4T_AGBCC, {}, { params: 3, returnsVoid: true }, { shortCircuit: { foldTreeOwned: false } });
+    const want = RUNS.map((r) => irTraceOf(fn, r));
+    const run = (label: string): number => {
+      let fired = 0;
+      let tree;
+      try {
+        tree = structure(fn, { returnsVoid: true, followEarlyReturns: true }, { onEarlyReturnFollow: () => fired++ });
+      } catch (e) {
+        if (!(e instanceof StructureError)) {
+          throw e;
+        }
+        declined++;
+        return 0;
+      }
+      RUNS.forEach((r, i) => expect(traceOf(tree, r), `seed ${seed} ${label}, run ${r}`).toEqual(want[i]));
+      const checked = structureChecked(fn, { returnsVoid: true, followEarlyReturns: true });
+      RUNS.forEach((r, i) => expect(traceOf(checked, r), `seed ${seed} ${label} checked, run ${r}`).toEqual(want[i]));
+      return fired;
+    };
+    if (hasDivergentSharedRet(fn)) {
+      followed += run('raised') > 0 ? 1 : 0;
+    }
+    const isForeign = readsForeignParam(fn);
+    foreign += isForeign ? 1 : 0;
+    if (sinkStoreTails(fn)) {
+      sunk++;
+      foreignSunk += isForeign ? 1 : 0;
+      verify(fn);
+      RUNS.forEach((r, i) => expect(irTraceOf(fn, r), `seed ${seed} raised+sunk, run ${r}`).toEqual(want[i]));
+      if (hasDivergentSharedRet(fn)) {
+        sunkAndFollowed += run('raised+sunk') > 0 ? 1 : 0;
+      }
+    }
+  }
+  // At authoring: 318 foreign-parameter tails, all sunk; sunk 4779, followed 2780, sunk+followed 1100,
+  // declined 0 — the floors below. With the copy substituting the tail's own parameters alone, seed
+  // 1 already throws in `verify`.
+  console.log(
+    `[shared-tail-fuzz raised] seeds=${SEEDS} foreignParamTail=${foreign} sunk=${sunk} sunkForeign=${foreignSunk} followed=${followed} sunk+followed=${sunkAndFollowed} declined=${declined}`,
+  );
+  expect(foreignSunk).toBeGreaterThan(150);
+  expect(sunk).toBeGreaterThan(2000);
+  expect(followed).toBeGreaterThan(1200);
+  expect(sunkAndFollowed).toBeGreaterThan(500);
 });

--- a/packages/core/test/shared-tail-fuzz.test.ts
+++ b/packages/core/test/shared-tail-fuzz.test.ts
@@ -15,8 +15,9 @@
 //
 // A second arm runs the same functions through `raiseRecovered` first, because that is the fn
 // rank.ts hands the sink and raise reshapes it: a tail reached only through a forwarder reads the
-// forwarder's parameter. Hand-built IR never reaches that shape, and a sink that mishandled it threw
-// in `verify` on real Thumb while this first arm stayed green.
+// forwarder's parameter. Hand-built IR never reaches that shape, and a sink that substitutes the
+// tail's own parameters alone throws in `verify` on a real Thumb lift while this first arm stays
+// green.
 import { expect, test, vi } from 'vitest';
 
 import { type Block, type Fn, type Value, mkOp, mkValue } from '../src/ir/core';
@@ -204,7 +205,9 @@ test('the sink and the follow change no observable, on the shapes they were buil
       sunkAndFollowed += run(fn) > 0 ? 1 : 0;
     }
   }
-  // At authoring: sunk 15866, followed 9391, sunk+followed 3662, declined 0 — the floors below.
+  // The sweep is not vacuous. At 20000 seeds it sinks 15866 functions, follows 9391 and does both
+  // on 3662, declining none; the floors sit well under all three, so a generator tweak cannot turn
+  // this green by quietly generating nothing the transform touches.
   console.log(
     `[shared-tail-fuzz] seeds=${SEEDS} sunk=${sunk} followed=${followed} sunk+followed=${sunkAndFollowed} declined=${declined}`,
   );
@@ -276,9 +279,10 @@ test('the same, on the fn the raise spine hands rank.ts', async () => {
       }
     }
   }
-  // At authoring: 318 foreign-parameter tails, all sunk; sunk 4779, followed 2780, sunk+followed 1100,
-  // declined 0 — the floors below. With the copy substituting the tail's own parameters alone, seed
-  // 1 already throws in `verify`.
+  // The shape this arm exists for really occurs: 318 of the raised functions carry a foreign-
+  // parameter tail and all 318 are sunk (sunk 4779, followed 2780, both 1100, declined 0), which is
+  // what the first floor holds. With the copy substituting the tail's own parameters alone, seed 1
+  // already throws in `verify`.
   console.log(
     `[shared-tail-fuzz raised] seeds=${SEEDS} foreignParamTail=${foreign} sunk=${sunk} sunkForeign=${foreignSunk} followed=${followed} sunk+followed=${sunkAndFollowed} declined=${declined}`,
   );

--- a/packages/core/test/shared-tail-fuzz.test.ts
+++ b/packages/core/test/shared-tail-fuzz.test.ts
@@ -1,0 +1,184 @@
+// The irTraceOf differential behind the SHARED DEFAULT TAIL — structure()'s `followEarlyReturns`,
+// rank.ts's `/shared-tail` twin.
+//
+// The follow turns fall-through into early `return;`s, moving effects between control-flow paths.
+// That is the change that can be byte-closer and semantically wrong at once, and no naming fuzz
+// can see it — each compares one spelling with another. So the oracle is the IR itself: the run of
+// the lifted function (`irTraceOf`) against the run of each structured tree (`traceOf`).
+//
+// The generator builds the family's shapes on purpose — a decision tree whose leaves branch into a
+// shared store tail, directly or through a pure forwarder or a join both sides may reach, or keep a
+// `ret` of their own — because a random CFG almost never shares a tail, and a fuzz that never
+// fires the path proves nothing. The firing counts are asserted, not just printed.
+import { expect, test, vi } from 'vitest';
+
+import { type Block, type Fn, type Value, mkOp, mkValue } from '../src/ir/core';
+import { T } from '../src/ir/types';
+import { verify } from '../src/ir/verify';
+import { StructureError, structure } from '../src/structure/structure';
+import { BREATHE_EVERY, breathe, irTraceOf, mulberry32, traceOf } from './helpers';
+
+vi.setConfig({ testTimeout: 120_000 });
+
+const s32 = T.s(32);
+
+/** A function of the shared-tail family, seeded. Every value is defined in the block that uses it
+ *  or in the entry, so definitions dominate uses by construction. */
+function generateSharedTailFn(seed: number): Fn {
+  const rnd = mulberry32(seed);
+  const pick = <X>(xs: readonly X[]): X => xs[Math.floor(rnd() * xs.length)];
+  const params = [mkValue(s32), mkValue(s32), mkValue(s32)];
+  const blocks: Block[] = [{ params, ops: [] }];
+  const block = (arity = 0): Block => {
+    const b: Block = { params: Array.from({ length: arity }, () => mkValue(s32)), ops: [] };
+    blocks.push(b);
+    return b;
+  };
+  const konst = (b: Block, value: number): Value => {
+    const r = mkValue(s32);
+    b.ops.push(mkOp('const', { results: [r], attrs: { value } }));
+    return r;
+  };
+  const call = (b: Block, arg: Value) =>
+    b.ops.push(mkOp('call', { operands: [arg], results: [mkValue(s32)], attrs: { target: pick(['f0', 'f1']) } }));
+  const br = (b: Block, to: Block, args: Value[]) => b.ops.push(mkOp('br', { successors: [{ block: to, args }] }));
+  const gq = mkValue(T.ptr(s32));
+  blocks[0].ops.push(mkOp('gaddr', { results: [gq], attrs: { sym: 'gQ' } }));
+  const store = (b: Block, value: Value, off: number) =>
+    b.ops.push(mkOp('store', { operands: [gq, value], attrs: { off, width: 4 } }));
+
+  // The shared store tail, an optional pure forwarder into it, and up to two joins either side of
+  // the top `if` may fall into.
+  const tail = block(1);
+  store(tail, tail.params[0], 4);
+  if (rnd() < 0.3) {
+    store(tail, pick(params), 8);
+  }
+  tail.ops.push(mkOp('ret'));
+  const fwd = rnd() < 0.4 ? block(1) : undefined;
+  if (fwd) {
+    br(fwd, tail, [fwd.params[0]]);
+  }
+  const into = (b: Block, value: Value) => br(b, fwd && rnd() < 0.5 ? fwd : tail, [value]);
+  const joins: Block[] = [];
+  for (let i = 0, n = Math.floor(rnd() * 3); i < n; i++) {
+    const j = block();
+    if (rnd() < 0.4) {
+      call(j, pick(params));
+    }
+    if (rnd() < 0.8) {
+      into(j, konst(j, pick([1, 2, 3])));
+    } else {
+      store(j, konst(j, pick([1, 2, 3])), 4);
+      j.ops.push(mkOp('ret'));
+    }
+    joins.push(j);
+  }
+  const leaf = (b: Block) => {
+    const r = rnd();
+    if (joins.length > 0 && r < 0.4) {
+      br(b, pick(joins), []);
+    } else if (r < 0.75) {
+      into(b, konst(b, pick([1, 2, 3])));
+    } else if (r < 0.9) {
+      store(b, konst(b, pick([1, 2, 3])), 4); // an arm the compiler left returning
+      b.ops.push(mkOp('ret'));
+    } else {
+      b.ops.push(mkOp('ret'));
+    }
+  };
+  const grow = (b: Block, depth: number) => {
+    if (rnd() < 0.3) {
+      call(b, pick(params));
+    }
+    if (depth < 3 && (depth === 0 || rnd() < 0.55)) {
+      const c = mkValue(T.u(32));
+      b.ops.push(mkOp('icmp_slt', { operands: [pick(params), konst(b, pick([-2, 0, 2]))], results: [c] }));
+      const [t, e] = [block(), block()];
+      // now and then one side reaches the tail by the conditional edge itself
+      const direct = rnd() < 0.08;
+      b.ops.push(
+        mkOp('cond_br', {
+          operands: [c],
+          successors: [direct ? { block: tail, args: [konst(b, 5)] } : { block: t, args: [] }, { block: e, args: [] }],
+        }),
+      );
+      if (!direct) {
+        grow(t, depth + 1);
+      }
+      grow(e, depth + 1);
+    } else if (rnd() < 0.15) {
+      // a counted loop before the leaf — `gcsetail`'s own, which the rules must not need
+      const head = block(1);
+      const exit = block();
+      br(b, head, [konst(b, 0)]);
+      call(head, head.params[0]);
+      const next = mkValue(s32);
+      head.ops.push(mkOp('add', { operands: [head.params[0], konst(head, 1)], results: [next] }));
+      const c = mkValue(T.u(32));
+      head.ops.push(mkOp('icmp_slt', { operands: [next, konst(head, 3)], results: [c] }));
+      head.ops.push(
+        mkOp('cond_br', {
+          operands: [c],
+          successors: [
+            { block: head, args: [next] },
+            { block: exit, args: [] },
+          ],
+        }),
+      );
+      leaf(exit);
+    } else {
+      leaf(b);
+    }
+  };
+  grow(blocks[0], 0);
+  // Drop what no path reaches (an unused tail, forwarder or join, and a `grow` block cut by a
+  // direct edge).
+  const reach = new Set<Block>();
+  const stack = [blocks[0]];
+  while (stack.length) {
+    const b = stack.pop()!;
+    if (!reach.has(b)) {
+      reach.add(b);
+      stack.push(...b.ops[b.ops.length - 1].successors.map((s) => s.block));
+    }
+  }
+  return { name: `st${seed}`, blocks: blocks.filter((b) => reach.has(b)), writeOrder: undefined, slotHomes: undefined };
+}
+
+/** Parameter seeds for the two interpreters: each spreads the three parameters over -5..5, so the
+ *  `< -2 / 0 / 2` tests take both sides. */
+const RUNS = [0, 9, 83, 511, 4095, 1234, 3001];
+
+test('the follow changes no observable, on the shapes it was built for', async () => {
+  const SEEDS = 20000;
+  let followed = 0;
+  let declined = 0;
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    if (seed % BREATHE_EVERY === 0) {
+      await breathe();
+    }
+    const lifted = generateSharedTailFn(seed);
+    verify(lifted);
+    const want = RUNS.map((r) => irTraceOf(lifted, r));
+    const run = (fn: Fn): number => {
+      let fired = 0;
+      let tree;
+      try {
+        tree = structure(fn, { returnsVoid: true, followEarlyReturns: true }, { onEarlyReturnFollow: () => fired++ });
+      } catch (e) {
+        if (!(e instanceof StructureError)) {
+          throw e;
+        }
+        declined++;
+        return 0;
+      }
+      RUNS.forEach((r, i) => expect(traceOf(tree, r), `seed ${seed}, run ${r}`).toEqual(want[i]));
+      return fired;
+    };
+    followed += run(lifted) > 0 ? 1 : 0;
+  }
+  // At authoring: followed 9466, declined 0 — the floor below.
+  console.log(`[shared-tail-fuzz] seeds=${SEEDS} followed=${followed} declined=${declined}`);
+  expect(followed).toBeGreaterThan(8000);
+});

--- a/packages/core/test/shared-tail.test.ts
+++ b/packages/core/test/shared-tail.test.ts
@@ -376,7 +376,8 @@ const THUMB_LEFT_PARAM =
 
 test('where the sink deletes the follow, rank.ts still enumerates the follow alone', () => {
   // A FAN-level assertion, because the fuzz compares semantics only and cannot see a lost
-  // candidate: with the follow tried only behind the sink, this fan had 0 spellings of the store once.
+  // candidate: a twin that tried the follow only behind the sink emits 0 spellings of the store
+  // once on this shape.
   const errors: string[] = [];
   const cands = enumerateCandidates('f', THUMB_LEFT_PARAM, ARMV4T_AGBCC, {
     prototypes: P,
@@ -418,8 +419,8 @@ const THUMB_PAD =
 
 test('a tail that reads a forwarder parameter is copied with the value each path carried', () => {
   // On a REAL lift and raise, which is the only way to reach this shape: hand-built IR keeps the
-  // tail's own parameter. A copy that substituted the tail's parameters alone read the forwarder's,
-  // which the sweep then deleted — `verify` threw, and the whole `/shared-tail` twin went with it.
+  // tail's own parameter. A copy that substitutes the tail's parameters alone reads the forwarder's,
+  // which the sweep then deletes: `verify` throws, and the whole `/shared-tail` twin goes with it.
   const fn = frontendFor(ARMV4T_AGBCC).lift('f', THUMB_PAD, ARMV4T_AGBCC, P);
   raiseRecovered(fn, ARMV4T_AGBCC, {}, P.f, { shortCircuit: { foldTreeOwned: false } });
   const tail = fn.blocks.find((b) => b.ops.length === 2 && b.ops[0].opcode === 'store' && b.ops[1].opcode === 'ret');

--- a/packages/core/test/shared-tail.test.ts
+++ b/packages/core/test/shared-tail.test.ts
@@ -1,5 +1,6 @@
 // THE SHARED DEFAULT TAIL — `structure()`'s `followEarlyReturns` and `raise/tailsink.ts`, which
-// rank.ts enumerates together as the `/shared-tail` twin.
+// rank.ts enumerates as two twins: `/shared-ret` (the follow alone) and `/shared-tail` (the follow
+// after the sink).
 //
 // The source shape is one tail written ONCE, after an `if`, with every other path into a `ret`
 // an early `return;`. agbcc reaches it two ways, and each fixture below is one of them:
@@ -7,14 +8,18 @@
 //     the follow alone recovers it;
 //   - the arms cross-jumped into one `store; ret` (`synthetic:gcsetail`): the tail has to be copied
 //     back into the paths that branch to it before the follow can see them as early returns.
-// Each of the follow's three refusals is produced by a fixture of its own.
+// A third shape is why the two are separate twins: a store tail that is ITSELF the follow, which the
+// sink deletes (`synthetic:gcsejoin`). Each of the follow's three refusals is produced by a fixture
+// of its own.
 import { expect, test } from 'vitest';
 
 import { cBackend } from '../src/backend/c';
+import { frontendFor } from '../src/frontend/registry';
 import type { Fn } from '../src/ir/core';
 import { parse } from '../src/ir/parse';
 import { print } from '../src/ir/print';
 import { verify } from '../src/ir/verify';
+import { raiseRecovered } from '../src/pipeline';
 import { sinkStoreTails } from '../src/raise/tailsink';
 import { enumerateCandidates } from '../src/rank';
 import { hasDivergentSharedRet, structure } from '../src/structure/structure';
@@ -238,9 +243,12 @@ test('the two terms are one capability: sunk without the follow, the tail is wri
   expect(count(emit(fn, true), '[1] = 9;')).toBe(1);
 });
 
-test('a tail sunk where no path is reached from both sides leaves no shared `ret`, so no twin', () => {
+test('with no follow before the sink or after it, neither twin has anything to spell', () => {
   // `gcsedup`'s shape: both sources hang off the inner `if`, and the outer one's other side
-  // returns on its own. Each copy is reached from one side, and rank.ts's gate sees no follow.
+  // returns on its own. No `ret` is reached from both sides of the outer `if`, before the sink or
+  // after it — each copy is reached from one side — so rank.ts's gates see no follow for either
+  // twin. (Where the fn AS RAISED has one, the `/shared-ret` twin runs whatever the sink leaves:
+  // the next test.)
   const one = parse(
     CROSS_JUMPED.replace('  %5: s32 = call %0 {target="work"}\n  br ^bb4()', '  br ^bb6()').replace(
       '^bb5(%9: s32):',
@@ -248,9 +256,32 @@ test('a tail sunk where no path is reached from both sides leaves no shared `ret
     ),
   );
   verify(one);
+  expect(hasDivergentSharedRet(one)).toBe(false);
   expect(sinkStoreTails(one)).toBe(true);
   verify(one);
   expect(hasDivergentSharedRet(one)).toBe(false);
+});
+
+/** `LEFT_RETURNING` with the both-sides tail storing a PARAMETER: `^bb4` is now a store tail, and it
+ *  is already `^bb0`'s follow. */
+const LEFT_RETURNING_PARAM = LEFT_RETURNING.replace(
+  '^bb4():\n  %8: s32 = const {value=9}\n  store %2, %8 {off=4, width=4}',
+  '^bb4():\n  store %2, %1 {off=4, width=4}',
+);
+
+test('a store tail that is already the follow is deleted by the sink, so the follow is tried unsunk', () => {
+  // `gcsejoin`'s shape. The tail is the one `ret` both sides of `^bb0` reach, so the follow spells
+  // it once, after the `if`. The sink copies it into `^bb1`, its one `br` source, and keeps it for
+  // `^bb2`'s conditional edge: each is then reached from one side, and the follow is gone. That is
+  // why rank.ts tries the follow on the fn as raised, not only behind the sink.
+  const fn = parse(LEFT_RETURNING_PARAM);
+  verify(fn);
+  expect(hasDivergentSharedRet(fn)).toBe(true);
+  expect(count(emit(fn, true), '[1] = a1;')).toBe(1);
+  expect(sinkStoreTails(fn)).toBe(true);
+  verify(fn);
+  expect(hasDivergentSharedRet(fn)).toBe(false);
+  expect(count(emit(fn, true), '[1] = a1;')).toBe(2);
 });
 
 test('a conditional edge into the tail keeps it; every `br` source still gets its copy', () => {
@@ -312,10 +343,11 @@ const THUMB_LEFT =
   '\tmov\tr3, #7\n\tstr\tr3, [r2, #4]\n\tb\t.L6\n.L3:\n\tstr\tr1, [r2, #8]\n.L5:\n\tmov\tr3, #9\n' +
   '\tstr\tr3, [r2, #4]\n.L6:\n\tpop\t{r0}\n\tbx\tr0\n.L10:\n\t.align\t2, 0\n.L9:\n\t.word\tgQ\n';
 
-test('rank.ts enumerates `/shared-tail` where an arm the compiler left returning shares the rest', () => {
+test('rank.ts enumerates `/shared-ret` where an arm the compiler left returning shares the rest', () => {
   const cands = enumerateCandidates('f', THUMB_LEFT, ARMV4T_AGBCC, { prototypes: P });
-  const twin = cands.filter((c) => c.label.includes('/shared-tail'));
+  const twin = cands.filter((c) => c.label.includes('/shared-ret'));
   expect(twin.length).toBeGreaterThan(0);
+  expect(cands.filter((c) => c.label.includes('/shared-tail'))).toEqual([]); // nothing to sink
   expect(twin.every((c) => count(c.source, ' = 9;') === 1 && /= 7;\s+return;/.test(c.source))).toBe(true);
   expect(cands.some((c) => c.label === 'unsigned' && count(c.source, ' = 9;') === 2)).toBe(true);
 });
@@ -333,4 +365,76 @@ test('rank.ts enumerates `/shared-tail` on a cross-jumped tail, beside the unsun
   expect(twin.every((c) => count(c.source, ' = 9;') === 1 && /= 7;\s+return;/.test(c.source))).toBe(true);
   expect(cands.some((c) => c.label === 'unsigned' && c.source.includes('[1] = v0;'))).toBe(true);
   expect(cands.some((c) => c.label === 'unsigned/unmerge')).toBe(true);
+});
+
+// `THUMB_LEFT` with the both-sides tail storing the parameter `r1`: a store tail that is already the
+// follow, which the sink deletes (`gcsejoin`'s shape, the unit test above on a real lift).
+const THUMB_LEFT_PARAM =
+  'f:\n\tpush\t{lr}\n\tldr\tr2, .L9\n\tcmp\tr0, #0\n\tblt\t.L3\n\tcmp\tr1, #0\n\tbge\t.L5\n' +
+  '\tmov\tr3, #7\n\tstr\tr3, [r2, #4]\n\tb\t.L6\n.L3:\n\tstr\tr1, [r2, #8]\n.L5:\n' +
+  '\tstr\tr1, [r2, #4]\n.L6:\n\tpop\t{r0}\n\tbx\tr0\n.L10:\n\t.align\t2, 0\n.L9:\n\t.word\tgQ\n';
+
+test('where the sink deletes the follow, rank.ts still enumerates the follow alone', () => {
+  // A FAN-level assertion, because the fuzz compares semantics only and cannot see a lost
+  // candidate: with the follow tried only behind the sink, this fan had 0 spellings of the store once.
+  const errors: string[] = [];
+  const cands = enumerateCandidates('f', THUMB_LEFT_PARAM, ARMV4T_AGBCC, {
+    prototypes: P,
+    onLeverError: (l, e) => errors.push(`${l}: ${e}`),
+  });
+  const once = cands.filter((c) => count(c.source, '[1] = a1;') === 1);
+  expect(once.length).toBeGreaterThan(0);
+  expect(once.every((c) => c.label.includes('/shared-ret') && /= 7;\s+return;/.test(c.source))).toBe(true);
+  expect(cands.filter((c) => c.label.includes('/shared-tail'))).toEqual([]);
+  expect(errors).toEqual([]);
+});
+
+// `THUMB` with a third arm, `.L7`, that keeps its own `ret`: the tail `.L6` is the follow before the
+// sink, and its copy in the join `.L5` is the follow after it (`gcseflat`'s shape), so both twins run.
+const THUMB_FLAT =
+  'f:\n\tpush\t{lr}\n\tldr\tr2, .L9\n\tcmp\tr0, #0\n\tblt\t.L3\n\tcmp\tr1, #0\n\tbge\t.L5\n' +
+  '\tcmp\tr0, #5\n\tbeq\t.L7\n\tmov\tr3, #7\n\tb\t.L6\n.L3:\n\tstr\tr1, [r2, #8]\n.L5:\n\tmov\tr3, #9\n' +
+  '.L6:\n\tstr\tr3, [r2, #4]\n\tpop\t{r0}\n\tbx\tr0\n.L7:\n\tmov\tr3, #8\n\tstr\tr3, [r2, #4]\n' +
+  '\tpop\t{r0}\n\tbx\tr0\n.L10:\n\t.align\t2, 0\n.L9:\n\t.word\tgQ\n';
+
+test('where the fn as raised and the sunk fn both have a follow, both twins are enumerated', () => {
+  const cands = enumerateCandidates('f', THUMB_FLAT, ARMV4T_AGBCC, { prototypes: P });
+  const ret = cands.filter((c) => c.label.includes('/shared-ret'));
+  const tail = cands.filter((c) => c.label.includes('/shared-tail'));
+  expect(ret.length).toBeGreaterThan(0);
+  expect(tail.length).toBeGreaterThan(0);
+  // the follow alone keeps the merged store; after the sink, the arm `= 7` returns on its own
+  expect(ret.every((c) => /= 8;\s+return;/.test(c.source))).toBe(true);
+  expect(tail.every((c) => count(c.source, ' = 9;') === 1 && /= 7;\s+return;/.test(c.source))).toBe(true);
+});
+
+// A JUMP PAD in front of the tail: `.L4: b .L6` is the only way into the store, so after raise's
+// `simplifyTrivialPhis` the tail reads the FORWARDER's parameter directly, not one of its own.
+const THUMB_PAD =
+  'f:\n\tpush\t{lr}\n\tldr\tr2, .L9\n\tcmp\tr0, #0\n\tblt\t.L3\n\tcmp\tr1, #0\n\tbge\t.L5\n' +
+  '\tcmp\tr0, #5\n\tbeq\t.L7\n\tmov\tr3, #7\n\tb\t.L4\n.L3:\n\tstr\tr1, [r2, #8]\n.L5:\n\tmov\tr3, #9\n' +
+  '.L4:\n\tb\t.L6\n.L7:\n\tmov\tr3, #8\n\tstr\tr3, [r2, #4]\n\tpop\t{r0}\n\tbx\tr0\n' +
+  '.L10:\n\t.align\t2, 0\n.L9:\n\t.word\tgQ\n.L6:\n\tstr\tr3, [r2, #4]\n\tpop\t{r0}\n\tbx\tr0\n';
+
+test('a tail that reads a forwarder parameter is copied with the value each path carried', () => {
+  // On a REAL lift and raise, which is the only way to reach this shape: hand-built IR keeps the
+  // tail's own parameter. A copy that substituted the tail's parameters alone read the forwarder's,
+  // which the sweep then deleted — `verify` threw, and the whole `/shared-tail` twin went with it.
+  const fn = frontendFor(ARMV4T_AGBCC).lift('f', THUMB_PAD, ARMV4T_AGBCC, P);
+  raiseRecovered(fn, ARMV4T_AGBCC, {}, P.f, { shortCircuit: { foldTreeOwned: false } });
+  const tail = fn.blocks.find((b) => b.ops.length === 2 && b.ops[0].opcode === 'store' && b.ops[1].opcode === 'ret');
+  const pad = fn.blocks.find((b) => b.ops.length === 1 && b.ops[0].successors[0]?.block === tail);
+  expect(pad?.params).toContain(tail?.ops[0].operands[1]); // the shape: the tail reads the pad's param
+  const want = [0, 9, 83, 511].map((r) => irTraceOf(fn, r));
+  expect(sinkStoreTails(fn)).toBe(true);
+  verify(fn);
+  expect(fn.blocks).not.toContain(pad);
+  expect([0, 9, 83, 511].map((r) => irTraceOf(fn, r))).toEqual(want);
+  const errors: string[] = [];
+  const cands = enumerateCandidates('f', THUMB_PAD, ARMV4T_AGBCC, {
+    prototypes: P,
+    onLeverError: (l, e) => errors.push(`${l}: ${e}`),
+  });
+  expect(errors).toEqual([]);
+  expect(cands.some((c) => c.label.includes('/shared-tail') && count(c.source, ' = 9;') === 1)).toBe(true);
 });

--- a/packages/core/test/shared-tail.test.ts
+++ b/packages/core/test/shared-tail.test.ts
@@ -1,0 +1,128 @@
+// THE SHARED DEFAULT TAIL — `structure()`'s `followEarlyReturns`, which rank.ts enumerates as
+// the `/shared-tail` twin.
+//
+// The source shape is one tail written ONCE, after an `if`, with every other path into a `ret`
+// an early `return;`. Here the compiler LEFT an arm returning on its own and emitted the rest once
+// (`synthetic:gcseinner`), which the follow alone recovers. Every refusal has a positive control
+// one fact away from it.
+import { expect, test } from 'vitest';
+
+import { cBackend } from '../src/backend/c';
+import type { Fn } from '../src/ir/core';
+import { parse } from '../src/ir/parse';
+import { verify } from '../src/ir/verify';
+import { enumerateCandidates } from '../src/rank';
+import { hasDivergentSharedRet, structure } from '../src/structure/structure';
+import { ARMV4T_AGBCC } from '../src/target';
+import { count } from './helpers';
+
+const emit = (fn: Fn, followEarlyReturns: boolean) =>
+  cBackend.emit(structure(fn, { returnsVoid: true, followEarlyReturns }));
+
+/** `gcseinner`'s shape: the arm `^bb3` keeps its OWN `ret`, and `^bb4` — reached from both sides —
+ *  is the tail the source wrote once. */
+const LEFT_RETURNING = `fn g {
+^bb0(%0: s32, %1: s32):
+  %2: s32* = gaddr {sym="gQ"}
+  %3: s32 = const {value=0}
+  %4: u32 = icmp_slt %0, %3
+  cond_br %4, ^bb1(), ^bb2()
+^bb1():
+  %5: s32 = call %0 {target="work"}
+  br ^bb4()
+^bb2():
+  %6: u32 = icmp_slt %1, %3
+  cond_br %6, ^bb3(), ^bb4()
+^bb3():
+  %7: s32 = const {value=7}
+  store %2, %7 {off=4, width=4}
+  ret
+^bb4():
+  %8: s32 = const {value=9}
+  store %2, %8 {off=4, width=4}
+  ret
+}
+`;
+
+test('a region both arms of a divergent `if` reach is its follow, and the other `ret` an early return', () => {
+  const fn = parse(LEFT_RETURNING);
+  verify(fn);
+  expect(hasDivergentSharedRet(fn)).toBe(true);
+  // Off, the arms diverge and the shared store is written in each; on, once, after the `if`.
+  expect(count(emit(fn, false), '[1] = 9;')).toBe(2);
+  const on = emit(fn, true);
+  expect(count(on, '[1] = 9;')).toBe(1);
+  expect(on).toMatch(/\[1\] = 7;\s+return;\s+}\s+} else {\s+work\(a0\);\s+}\s+\(\(s32 \*\)&gQ\)\[1\] = 9;/);
+});
+
+test('an `if` whose returning arms share nothing keeps them divergent', () => {
+  // `^bb3` and `^bb4` are each reached from ONE side, so no region is the follow.
+  const fn = parse(LEFT_RETURNING.replace('cond_br %6, ^bb3(), ^bb4()', 'br ^bb3()'));
+  verify(fn);
+  expect(hasDivergentSharedRet(fn)).toBe(false);
+  expect(emit(fn, true)).toBe(emit(fn, false));
+});
+
+test("the enclosing region's follow is never emitted inside an arm", () => {
+  // Inside the else side, `^bb2`'s arms share `^bb6` — but `^bb5` also reaches `^bb7`, the OUTER
+  // `if`'s follow, without passing `^bb6`. Taking `^bb6` as `^bb2`'s follow would structure that
+  // path into `^bb7` inside the arm; the refusal keeps `^bb7` once, after the outer `if`.
+  const fn = parse(`fn h {
+^bb0(%0: s32, %1: s32, %2: s32):
+  %3: s32* = gaddr {sym="gQ"}
+  %4: s32 = const {value=0}
+  %5: u32 = icmp_slt %0, %4
+  cond_br %5, ^bb1(), ^bb2()
+^bb1():
+  %6: s32 = call %0 {target="work"}
+  br ^bb7()
+^bb2():
+  %7: u32 = icmp_slt %1, %4
+  cond_br %7, ^bb3(), ^bb4()
+^bb3():
+  %8: s32 = const {value=3}
+  br ^bb6(%8)
+^bb4():
+  %9: u32 = icmp_slt %2, %4
+  cond_br %9, ^bb5(), ^bb7()
+^bb5():
+  %10: s32 = const {value=4}
+  br ^bb6(%10)
+^bb6(%11: s32):
+  store %3, %11 {off=8, width=4}
+  ret
+^bb7():
+  %12: s32 = const {value=9}
+  store %3, %12 {off=4, width=4}
+  ret
+}
+`);
+  verify(fn);
+  const follows: number[] = [];
+  const on = cBackend.emit(
+    structure(
+      fn,
+      { returnsVoid: true, followEarlyReturns: true },
+      { onEarlyReturnFollow: (s) => follows.push(s.block) },
+    ),
+  );
+  expect(follows).toEqual([0]);
+  expect(count(on, '[1] = 9;')).toBe(1);
+});
+
+// The rank.ts half, on hand-lifted Thumb bodies: `/shared-tail` is a DISTINCT source beside the
+// spellings it does not replace, which the fan keeps — the same IR can come from the duplicated
+// source (`gcsepre`/`gcsepredup` lift byte-identical), so only the differ decides.
+const P = { f: { params: 2, returnsVoid: true } };
+const THUMB_LEFT =
+  'f:\n\tpush\t{lr}\n\tldr\tr2, .L9\n\tcmp\tr0, #0\n\tblt\t.L3\n\tcmp\tr1, #0\n\tbge\t.L5\n' +
+  '\tmov\tr3, #7\n\tstr\tr3, [r2, #4]\n\tb\t.L6\n.L3:\n\tstr\tr1, [r2, #8]\n.L5:\n\tmov\tr3, #9\n' +
+  '\tstr\tr3, [r2, #4]\n.L6:\n\tpop\t{r0}\n\tbx\tr0\n.L10:\n\t.align\t2, 0\n.L9:\n\t.word\tgQ\n';
+
+test('rank.ts enumerates `/shared-tail` where an arm the compiler left returning shares the rest', () => {
+  const cands = enumerateCandidates('f', THUMB_LEFT, ARMV4T_AGBCC, { prototypes: P });
+  const twin = cands.filter((c) => c.label.includes('/shared-tail'));
+  expect(twin.length).toBeGreaterThan(0);
+  expect(twin.every((c) => count(c.source, ' = 9;') === 1 && /= 7;\s+return;/.test(c.source))).toBe(true);
+  expect(cands.some((c) => c.label === 'unsigned' && count(c.source, ' = 9;') === 2)).toBe(true);
+});

--- a/packages/core/test/shared-tail.test.ts
+++ b/packages/core/test/shared-tail.test.ts
@@ -7,7 +7,7 @@
 //     the follow alone recovers it;
 //   - the arms cross-jumped into one `store; ret` (`synthetic:gcsetail`): the tail has to be copied
 //     back into the paths that branch to it before the follow can see them as early returns.
-// Every refusal has a positive control one fact away from it.
+// Each of the follow's three refusals is produced by a fixture of its own.
 import { expect, test } from 'vitest';
 
 import { cBackend } from '../src/backend/c';
@@ -19,7 +19,7 @@ import { sinkStoreTails } from '../src/raise/tailsink';
 import { enumerateCandidates } from '../src/rank';
 import { hasDivergentSharedRet, structure } from '../src/structure/structure';
 import { ARMV4T_AGBCC } from '../src/target';
-import { count, irTraceOf } from './helpers';
+import { count, irTraceOf, traceOf } from './helpers';
 
 const emit = (fn: Fn, followEarlyReturns: boolean) =>
   cBackend.emit(structure(fn, { returnsVoid: true, followEarlyReturns }));
@@ -139,6 +139,82 @@ test("the enclosing region's follow is never emitted inside an arm", () => {
   );
   expect(follows).toEqual([0]);
   expect(count(on, '[1] = 9;')).toBe(1);
+});
+
+test('each divergent `if` gets the follow of its OWN shared `ret`s', () => {
+  // `^bb0`'s arms share `^bb7` and `^bb8`, so its follow is `^bb4`; `^bb4`'s share only `^bb8`, so
+  // its follow is `^bb8` — two deletion sets, where one function-wide set answers only the first.
+  const fn = parse(`fn k {
+^bb0(%0: s32, %1: s32, %2: s32, %3: s32):
+  %4: s32* = gaddr {sym="gQ"}
+  %5: s32 = const {value=0}
+  %6: u32 = icmp_slt %0, %5
+  cond_br %6, ^bb1(), ^bb2()
+^bb1():
+  %7: u32 = icmp_slt %1, %5
+  cond_br %7, ^bb3(), ^bb4()
+^bb2():
+  %8: s32 = call %0 {target="work"}
+  br ^bb4()
+^bb3():
+  %9: s32 = const {value=1}
+  store %4, %9 {off=4, width=4}
+  ret
+^bb4():
+  %10: u32 = icmp_slt %2, %5
+  cond_br %10, ^bb5(), ^bb6()
+^bb5():
+  %11: u32 = icmp_slt %3, %5
+  cond_br %11, ^bb7(), ^bb8()
+^bb6():
+  %12: s32 = call %2 {target="work"}
+  br ^bb8()
+^bb7():
+  %13: s32 = const {value=2}
+  store %4, %13 {off=4, width=4}
+  ret
+^bb8():
+  %14: s32 = const {value=3}
+  store %4, %14 {off=4, width=4}
+  ret
+}
+`);
+  verify(fn);
+  const follows: [number, number][] = [];
+  const tree = structure(
+    fn,
+    { returnsVoid: true, followEarlyReturns: true },
+    { onEarlyReturnFollow: (s) => follows.push([s.block, s.follow]) },
+  );
+  expect(follows).toEqual([
+    [0, 4],
+    [4, 8],
+  ]);
+  expect(count(cBackend.emit(tree), '[1] = 3;')).toBe(1);
+  expect([0, 9, 83, 511].map((r) => traceOf(tree, r))).toEqual([0, 9, 83, 511].map((r) => irTraceOf(fn, r)));
+});
+
+test('arms that share two `ret`s the kept graph cannot order have no follow', () => {
+  // Both sides of `^bb0` reach both `^bb5` and `^bb6`, so both are kept and only EXIT
+  // post-dominates `^bb0`: its arms stay divergent.
+  const fn = parse(
+    LEFT_RETURNING.replace(
+      '  %5: s32 = call %0 {target="work"}\n  br ^bb4()',
+      '  %5: u32 = icmp_slt %1, %0\n  cond_br %5, ^bb3(), ^bb4()',
+    ),
+  );
+  verify(fn);
+  expect(hasDivergentSharedRet(fn)).toBe(true);
+  const follows: number[] = [];
+  const on = cBackend.emit(
+    structure(
+      fn,
+      { returnsVoid: true, followEarlyReturns: true },
+      { onEarlyReturnFollow: (s) => follows.push(s.block) },
+    ),
+  );
+  expect(follows).toEqual([]);
+  expect(on).toBe(emit(fn, false));
 });
 
 test('a cross-jumped store tail is copied into every path that branches to it, and the follow keeps one', () => {

--- a/packages/core/test/shared-tail.test.ts
+++ b/packages/core/test/shared-tail.test.ts
@@ -1,16 +1,22 @@
-// THE SHARED DEFAULT TAIL — `structure()`'s `followEarlyReturns`, which rank.ts enumerates as
-// the `/shared-tail` twin.
+// THE SHARED DEFAULT TAIL — `structure()`'s `followEarlyReturns` and `raise/tailsink.ts`, which
+// rank.ts enumerates together as the `/shared-tail` twin.
 //
 // The source shape is one tail written ONCE, after an `if`, with every other path into a `ret`
-// an early `return;`. Here the compiler LEFT an arm returning on its own and emitted the rest once
-// (`synthetic:gcseinner`), which the follow alone recovers. Every refusal has a positive control
-// one fact away from it.
+// an early `return;`. agbcc reaches it two ways, and each fixture below is one of them:
+//   - the compiler LEFT an arm returning on its own and shared the rest (`synthetic:gcseinner`):
+//     the follow alone recovers it;
+//   - the arms cross-jumped into one `store; ret` (`synthetic:gcsetail`): the tail has to be sunk
+//     back into the arms before the follow can see them as early returns.
+// Every refusal has a positive control one fact away from it.
 import { expect, test } from 'vitest';
 
 import { cBackend } from '../src/backend/c';
 import type { Fn } from '../src/ir/core';
 import { parse } from '../src/ir/parse';
+import { print } from '../src/ir/print';
 import { verify } from '../src/ir/verify';
+import { tallying } from '../src/l3/gates';
+import { TAIL_SINK_GATES, sinkStoreTails } from '../src/raise/tailsink';
 import { enumerateCandidates } from '../src/rank';
 import { hasDivergentSharedRet, structure } from '../src/structure/structure';
 import { ARMV4T_AGBCC } from '../src/target';
@@ -18,6 +24,32 @@ import { count } from './helpers';
 
 const emit = (fn: Fn, followEarlyReturns: boolean) =>
   cBackend.emit(structure(fn, { returnsVoid: true, followEarlyReturns }));
+
+/** `gcsetail` without its loop: `^bb4` is the path both sides of `^bb0` fall into, `^bb3` an arm
+ *  reached from the else side only, and both branch into the one store tail `^bb5`. */
+const CROSS_JUMPED = `fn f {
+^bb0(%0: s32, %1: s32):
+  %2: s32* = gaddr {sym="gQ"}
+  %3: s32 = const {value=0}
+  %4: u32 = icmp_slt %0, %3
+  cond_br %4, ^bb1(), ^bb2()
+^bb1():
+  %5: s32 = call %0 {target="work"}
+  br ^bb4()
+^bb2():
+  %6: u32 = icmp_slt %1, %3
+  cond_br %6, ^bb3(), ^bb4()
+^bb3():
+  %7: s32 = const {value=7}
+  br ^bb5(%7)
+^bb4():
+  %8: s32 = const {value=9}
+  br ^bb5(%8)
+^bb5(%9: s32):
+  store %2, %9 {off=4, width=4}
+  ret
+}
+`;
 
 /** `gcseinner`'s shape: the arm `^bb3` keeps its OWN `ret`, and `^bb4` — reached from both sides —
  *  is the tail the source wrote once. */
@@ -110,6 +142,72 @@ test("the enclosing region's follow is never emitted inside an arm", () => {
   expect(count(on, '[1] = 9;')).toBe(1);
 });
 
+test('a cross-jumped store tail is sunk into the one-sided arm and kept for the path both sides reach', () => {
+  const fn = parse(CROSS_JUMPED);
+  verify(fn);
+  expect(sinkStoreTails(fn)).toBe(true);
+  verify(fn);
+  const ir = print(fn);
+  expect(ir).toContain('%7: s32 = const {value=7}\n  store %2, %7 {off=4, width=4}\n  ret');
+  expect(ir).toContain('store %2, %8 {off=4, width=4}\n  ret');
+  expect(count(emit(fn, true), '[1] = 9;')).toBe(1);
+});
+
+test('the two terms are one capability: sunk without the follow, the tail is written on every path', () => {
+  const fn = parse(CROSS_JUMPED);
+  expect(count(emit(fn, true), '[1] = v')).toBe(1); // unsunk: one merged store, whatever the option
+  sinkStoreTails(fn);
+  expect(count(emit(fn, false), '[1] = 9;')).toBe(2);
+  expect(count(emit(fn, true), '[1] = 9;')).toBe(1);
+});
+
+test('a tail whose arms are each reached from ONE side has no kept path and is not sunk', () => {
+  // `gcsedup`'s shape: both sources hang off the inner `if`, so neither is what both sides of the
+  // tail's dominator fall into.
+  const fn = parse(CROSS_JUMPED.replace('cond_br %4, ^bb1(), ^bb2()', 'cond_br %4, ^bb2(), ^bb2()'));
+  const t1 = tallying(TAIL_SINK_GATES);
+  expect(sinkStoreTails(fn, t1.gates)).toBe(false);
+  expect(t1.refusals().map(([id]) => id)).toEqual(['dominator-is-not-a-branch']);
+  const one = parse(
+    CROSS_JUMPED.replace('  %5: s32 = call %0 {target="work"}\n  br ^bb4()', '  br ^bb6()').replace(
+      '^bb5(%9: s32):',
+      '^bb6():\n  ret\n^bb5(%9: s32):',
+    ),
+  );
+  verify(one);
+  const t2 = tallying(TAIL_SINK_GATES);
+  expect(sinkStoreTails(one, t2.gates)).toBe(false);
+  expect(t2.refusals().map(([id]) => id)).toEqual(['no-single-path-from-both-sides']);
+});
+
+test('an arm that reaches the tail by a conditional branch refuses; the kept path may', () => {
+  const armCond = parse(
+    CROSS_JUMPED.replace('cond_br %6, ^bb3(), ^bb4()', 'cond_br %6, ^bb5(%3), ^bb4()').replace(
+      '^bb3():\n  %7: s32 = const {value=7}\n  br ^bb5(%7)\n',
+      '',
+    ),
+  );
+  verify(armCond);
+  const t = tallying(TAIL_SINK_GATES);
+  expect(sinkStoreTails(armCond, t.gates)).toBe(false);
+  expect(t.refusals().map(([id]) => id)).toEqual(['conditional-arm']);
+});
+
+test('an arm that branches into the tail through a pure forwarder gets its copy too', () => {
+  // `gcsefwd`'s shape: `^bb6` forwards to the tail, and the one-sided arm `^bb3` reaches it only
+  // through the forwarder, which the both-sides path `^bb4` also uses.
+  const fn = parse(
+    CROSS_JUMPED.replace('  br ^bb5(%7)', '  br ^bb6(%7)')
+      .replace('  br ^bb5(%8)', '  br ^bb6(%8)')
+      .replace('^bb5(%9: s32):', '^bb6(%10: s32):\n  br ^bb5(%10)\n^bb5(%9: s32):'),
+  );
+  verify(fn);
+  expect(sinkStoreTails(fn)).toBe(true);
+  verify(fn);
+  expect(print(fn)).toContain('%7: s32 = const {value=7}\n  store %2, %7 {off=4, width=4}\n  ret');
+  expect(count(emit(fn, true), '[1] = 9;')).toBe(1);
+});
+
 // The rank.ts half, on hand-lifted Thumb bodies: `/shared-tail` is a DISTINCT source beside the
 // spellings it does not replace, which the fan keeps — the same IR can come from the duplicated
 // source (`gcsepre`/`gcsepredup` lift byte-identical), so only the differ decides.
@@ -125,4 +223,19 @@ test('rank.ts enumerates `/shared-tail` where an arm the compiler left returning
   expect(twin.length).toBeGreaterThan(0);
   expect(twin.every((c) => count(c.source, ' = 9;') === 1 && /= 7;\s+return;/.test(c.source))).toBe(true);
   expect(cands.some((c) => c.label === 'unsigned' && count(c.source, ' = 9;') === 2)).toBe(true);
+});
+
+// The cross-jumped tail, which only the sink turns into early returns.
+const THUMB =
+  'f:\n\tpush\t{lr}\n\tldr\tr2, .L9\n\tcmp\tr0, #0\n\tblt\t.L3\n\tcmp\tr1, #0\n\tbge\t.L5\n' +
+  '\tmov\tr3, #7\n\tb\t.L6\n.L3:\n\tstr\tr1, [r2, #8]\n.L5:\n\tmov\tr3, #9\n.L6:\n\tstr\tr3, [r2, #4]\n' +
+  '\tpop\t{r0}\n\tbx\tr0\n.L10:\n\t.align\t2, 0\n.L9:\n\t.word\tgQ\n';
+
+test('rank.ts enumerates `/shared-tail` on a cross-jumped tail, beside the unsunk spellings', () => {
+  const cands = enumerateCandidates('f', THUMB, ARMV4T_AGBCC, { prototypes: P });
+  const twin = cands.filter((c) => c.label.includes('/shared-tail'));
+  expect(twin.length).toBeGreaterThan(0);
+  expect(twin.every((c) => count(c.source, ' = 9;') === 1 && /= 7;\s+return;/.test(c.source))).toBe(true);
+  expect(cands.some((c) => c.label === 'unsigned' && c.source.includes('[1] = v0;'))).toBe(true);
+  expect(cands.some((c) => c.label === 'unsigned/unmerge')).toBe(true);
 });

--- a/packages/core/test/shared-tail.test.ts
+++ b/packages/core/test/shared-tail.test.ts
@@ -5,8 +5,8 @@
 // an early `return;`. agbcc reaches it two ways, and each fixture below is one of them:
 //   - the compiler LEFT an arm returning on its own and shared the rest (`synthetic:gcseinner`):
 //     the follow alone recovers it;
-//   - the arms cross-jumped into one `store; ret` (`synthetic:gcsetail`): the tail has to be sunk
-//     back into the arms before the follow can see them as early returns.
+//   - the arms cross-jumped into one `store; ret` (`synthetic:gcsetail`): the tail has to be copied
+//     back into the paths that branch to it before the follow can see them as early returns.
 // Every refusal has a positive control one fact away from it.
 import { expect, test } from 'vitest';
 
@@ -15,12 +15,11 @@ import type { Fn } from '../src/ir/core';
 import { parse } from '../src/ir/parse';
 import { print } from '../src/ir/print';
 import { verify } from '../src/ir/verify';
-import { tallying } from '../src/l3/gates';
-import { TAIL_SINK_GATES, sinkStoreTails } from '../src/raise/tailsink';
+import { sinkStoreTails } from '../src/raise/tailsink';
 import { enumerateCandidates } from '../src/rank';
 import { hasDivergentSharedRet, structure } from '../src/structure/structure';
 import { ARMV4T_AGBCC } from '../src/target';
-import { count } from './helpers';
+import { count, irTraceOf } from './helpers';
 
 const emit = (fn: Fn, followEarlyReturns: boolean) =>
   cBackend.emit(structure(fn, { returnsVoid: true, followEarlyReturns }));
@@ -142,14 +141,16 @@ test("the enclosing region's follow is never emitted inside an arm", () => {
   expect(count(on, '[1] = 9;')).toBe(1);
 });
 
-test('a cross-jumped store tail is sunk into the one-sided arm and kept for the path both sides reach', () => {
+test('a cross-jumped store tail is copied into every path that branches to it, and the follow keeps one', () => {
   const fn = parse(CROSS_JUMPED);
   verify(fn);
   expect(sinkStoreTails(fn)).toBe(true);
   verify(fn);
   const ir = print(fn);
   expect(ir).toContain('%7: s32 = const {value=7}\n  store %2, %7 {off=4, width=4}\n  ret');
-  expect(ir).toContain('store %2, %8 {off=4, width=4}\n  ret');
+  expect(ir).toContain('%8: s32 = const {value=9}\n  store %2, %8 {off=4, width=4}\n  ret');
+  expect(ir).not.toContain('^bb5');
+  // `^bb4`'s copy is the `ret` both sides of `^bb0` reach, so the follow spells it once.
   expect(count(emit(fn, true), '[1] = 9;')).toBe(1);
 });
 
@@ -161,13 +162,9 @@ test('the two terms are one capability: sunk without the follow, the tail is wri
   expect(count(emit(fn, true), '[1] = 9;')).toBe(1);
 });
 
-test('a tail whose arms are each reached from ONE side has no kept path and is not sunk', () => {
-  // `gcsedup`'s shape: both sources hang off the inner `if`, so neither is what both sides of the
-  // tail's dominator fall into.
-  const fn = parse(CROSS_JUMPED.replace('cond_br %4, ^bb1(), ^bb2()', 'cond_br %4, ^bb2(), ^bb2()'));
-  const t1 = tallying(TAIL_SINK_GATES);
-  expect(sinkStoreTails(fn, t1.gates)).toBe(false);
-  expect(t1.refusals().map(([id]) => id)).toEqual(['dominator-is-not-a-branch']);
+test('a tail sunk where no path is reached from both sides leaves no shared `ret`, so no twin', () => {
+  // `gcsedup`'s shape: both sources hang off the inner `if`, and the outer one's other side
+  // returns on its own. Each copy is reached from one side, and rank.ts's gate sees no follow.
   const one = parse(
     CROSS_JUMPED.replace('  %5: s32 = call %0 {target="work"}\n  br ^bb4()', '  br ^bb6()').replace(
       '^bb5(%9: s32):',
@@ -175,12 +172,14 @@ test('a tail whose arms are each reached from ONE side has no kept path and is n
     ),
   );
   verify(one);
-  const t2 = tallying(TAIL_SINK_GATES);
-  expect(sinkStoreTails(one, t2.gates)).toBe(false);
-  expect(t2.refusals().map(([id]) => id)).toEqual(['no-single-path-from-both-sides']);
+  expect(sinkStoreTails(one)).toBe(true);
+  verify(one);
+  expect(hasDivergentSharedRet(one)).toBe(false);
 });
 
-test('an arm that reaches the tail by a conditional branch refuses; the kept path may', () => {
+test('a conditional edge into the tail keeps it; every `br` source still gets its copy', () => {
+  // `^bb2` reaches the tail by its own `cond_br`. Splicing a copy over that terminator would drop
+  // its other successor — the one wrong program this rewrite can make — so the tail stays for it.
   const armCond = parse(
     CROSS_JUMPED.replace('cond_br %6, ^bb3(), ^bb4()', 'cond_br %6, ^bb5(%3), ^bb4()').replace(
       '^bb3():\n  %7: s32 = const {value=7}\n  br ^bb5(%7)\n',
@@ -188,9 +187,13 @@ test('an arm that reaches the tail by a conditional branch refuses; the kept pat
     ),
   );
   verify(armCond);
-  const t = tallying(TAIL_SINK_GATES);
-  expect(sinkStoreTails(armCond, t.gates)).toBe(false);
-  expect(t.refusals().map(([id]) => id)).toEqual(['conditional-arm']);
+  const want = [0, 9, 83, 511].map((r) => irTraceOf(armCond, r));
+  expect(sinkStoreTails(armCond)).toBe(true);
+  verify(armCond);
+  const ir = print(armCond);
+  expect(ir).toContain('cond_br %6, ^bb4(), ^bb3()'); // the tail, now `^bb4`, kept for the edge
+  expect(ir).toContain('^bb3():\n  %7: s32 = const {value=9}\n  store %2, %7 {off=4, width=4}\n  ret');
+  expect([0, 9, 83, 511].map((r) => irTraceOf(armCond, r))).toEqual(want);
 });
 
 test('an arm that branches into the tail through a pure forwarder gets its copy too', () => {
@@ -206,6 +209,22 @@ test('an arm that branches into the tail through a pure forwarder gets its copy 
   verify(fn);
   expect(print(fn)).toContain('%7: s32 = const {value=7}\n  store %2, %7 {off=4, width=4}\n  ret');
   expect(count(emit(fn, true), '[1] = 9;')).toBe(1);
+});
+
+test('a CHAIN of forwarders is seen through, and every link it orphans is dropped', () => {
+  // `^bb3` reaches the tail through `^bb7` then `^bb6`, and `^bb4` through `^bb6` alone. Once both
+  // sources hold their copy, `^bb7` has no predecessor and `^bb6`'s only one is `^bb7`.
+  const fn = parse(
+    CROSS_JUMPED.replace('  br ^bb5(%7)', '  br ^bb7(%7)')
+      .replace('  br ^bb5(%8)', '  br ^bb6(%8)')
+      .replace('^bb5(%9: s32):', '^bb7(%11: s32):\n  br ^bb6(%11)\n^bb6(%10: s32):\n  br ^bb5(%10)\n^bb5(%9: s32):'),
+  );
+  verify(fn);
+  const want = [0, 9, 83, 511].map((r) => irTraceOf(fn, r));
+  expect(sinkStoreTails(fn)).toBe(true);
+  verify(fn);
+  expect(fn.blocks).toHaveLength(5);
+  expect([0, 9, 83, 511].map((r) => irTraceOf(fn, r))).toEqual(want);
 });
 
 // The rank.ts half, on hand-lifted Thumb bodies: `/shared-tail` is a DISTINCT source beside the


### PR DESCRIPTION
agbcc's `gcse.c` PRE finds a trailing store's base partially redundant, inserts it at the end of both
join predecessors, and the arms then cross-jump into ONE `store; ret`. The C behind that spells the
tail once, after the `if`, and ends every other path with an early `return;`. asmlift could not spell
that shape at all: over `kleod:CountCollectedGems:agbcc` every one of the 5952 candidates it
enumerated kept the tail where the object put it (NO REACH), and the row's last `diff:18/344` was
exactly that one gap — #189 showed the residual closes to byte-exact with only that edit.

This branch builds it as two ranked lift variants:

- **the follow** (`structure()`'s `followEarlyReturns`, label `/shared-ret`) — a divergent `if` with
  no post-dominator but EXIT gets, as its follow, the post-dominator over the blocks that reach a
  `ret` reachable from BOTH successors; every other returning region becomes an early `return;`.
  Decided per `if`, not per function.
- **the sink** (`raise/tailsink.ts`, label `/shared-tail`) — a `store+; ret` tail is copied into every
  path that `br`s to it, pure forwarders seen through, and the follow then picks which copy stays
  shared. Tail duplication, so sound by construction; a conditional edge cannot carry a copy, so the
  tail stays for the sources that reach it that way.

Neither can be a default: `synthetic:gcsepre` and `synthetic:gcsepredup` compile to different objects
(an r4/r5 swap) and lift to byte-identical IR, so no IR rule tells the shared spelling from the
duplicated one. The differ referees. There is no loop gate — "a loop before the join" is a sample,
not a law (ten pairs: neither necessary nor sufficient).

## Rows, baseline → final

Baseline: `pnpm bench baseline <sym>` at `910fd416` (committed artifact of 2026-09-11T17:03:16Z,
every row answering CURRENT). Final: the full `pnpm bench run` at `b2a677a`, merged and diffed
against `origin/main`. Every score is `N/maxScore`.

| row | before | after |
|---|---|---|
| `kleod:CountCollectedGems:agbcc` | diff 18/344 | **MATCH 0/344** |
| `synthetic:gcsetail:agbcc` | 15/44 | **MATCH 0/39** |
| `synthetic:gcsepre:agbcc` | 5/45 | **MATCH 0/45** |
| `synthetic:gcsearms:agbcc` | 18/63 | **MATCH 0/59** |
| `synthetic:gcseinner:agbcc` | 21/55 | **MATCH 0/50** |
| `synthetic:gcseflat:agbcc` | 19/53 | **MATCH 0/49** |
| `synthetic:gcsefwd:agbcc` | 30/96 | **MATCH 0/85** |
| `synthetic:gcsearms6:agbcc` | 29/89 | **MATCH 0/84** |
| `synthetic:gcsejoin:agbcc` (row added by this branch) | 7/37 | **MATCH 0/35** |

CountCollectedGems' winner is
`unsigned/connective/shared-tail/defsite/loop-entry/flip-join/reread-globals/derived-home/merge-home/uns-cmp/offmember`
— `/site-sense`, `/unmerge` and `/livebase` LEFT the label and `/offmember` ENTERED, exactly as #189
predicted from its graft. The ranked run outside the harness, at the branch's final source commit:

    pnpm bench fan kleod:CountCollectedGems:agbcc --force
    asmlift: [ranked] 9192 candidate(s) scored, 0 dropped, 0 withheld, 0 synthesized,
      best unsigned/connective/shared-tail/…/offmember: 0/344 (match) [asmlift source b2a677a]

## The route chosen, and the price of the one rejected

#189 handed over two routes at different levels. **Route A (the IR-level lift variant) shipped.**
Route B — an L3 re-spelling beside `/unmerge`: hoist one leaf statement S out of the `if` and end
every other leaf with `return;` — was prototyped, enumerated and rejected on three measurements:

- **Its stated reach is false.** #189's "tree edits of candidates the fan already emits reach EVERY
  inhabitant (`gcseflat` 0/49, `gcsearms6` 0/84)" does not hold. On those two rows the default is ONE
  merge temp read at TWO join sites, `/unmerge`'s totality refuses, and no tree the fan emits has the
  duplicated leaves to hoist from; those two numbers were hand grafts that ALSO un-merged that temp.
  Prototyped, Route B leaves `gcseflat` at 19/53 and `gcsearms6` at 23/87.
- **It is 1.8× the price.** Enumerated with the harness's own `enumerateRanked`: Route B costs
  **+5760** candidates on CountCollectedGems (k = 2 — `UpdateWorldMapNodeAnim` ×7 and
  `GameplayMainLoop` ×2 both end ≥2 leaves), Route A **+3240**. #189's inferred bounds had the
  ordering the other way round (B ≤ +2880 against A ≤ +1800).
- **Nothing at L3 decides S.** On `gcsearms`, `fnA` ends 3 leaves and `fnB` 2 and both appear in both
  arms; the tree has lost that the `fnB` copies were one IR block. In the IR it is decided — the
  source reached from both successors of the sources' nearest common dominator — which is what the
  follow computes. Route A's edits substitute edge arguments before any merge temp exists, which is
  why they reach `gcseflat`/`gcsearms6` where B cannot.

Price as shipped, enumerated over both tiers: synthetic 7330 → 7782 (+452 over 810 rows), real
+5078 concentrated on 7 rows (CountCollectedGems 5952 → 9192, CheckWorldCompletion 840 → 2520,
ProcessHBlankWait 140 → 210, DoForcedMovement 32 → 96, IsStringLengthAtLeast 16 → 28, EwramMalloc
8 → 16, VerifyFlashSector_Core 8 → 12). `ProcessInputAndUpdateEntities`, the real tier's wall clock,
is not among them. Every row not listed emits a byte-identical candidate set, so it cannot move.

## One commit per term

- `e00dcccf` **feat(structure)** — the follow over early returns, as a twin with no sink.
  `gcseinner` 21/55 → MATCH; inert on tail/pre/arms/flat/fwd and on CountCollectedGems. A term of a
  conjunction that moves one row alone, shipped in the same PR as its partner on purpose.
- `2e95160c` **feat(raise)** — the store-tail sink. CountCollectedGems 18/344 → MATCH.
- `9459d9cd` **refactor(raise)** — the sink copies into every `br` source and lets the follow pick the
  kept one; `conditional-arm` becomes the rewrite's precondition instead of an ablatable gate;
  `TAIL_SINK_GATES` deleted; the price gate moves to rank.ts. Byte-identical on 252/252 real rows and
  807/809 synthetic.
- `e7ffc98c` **refactor(structure)** — one `sharedRetsOf` serving the follow and its gate, a per-site
  two-`if` test, and the loop refusal written in the repo's defensive form with its ablation numbers.
- `cca5c486` **fix(rank)** — never ship `X/shared-tail` where the unsunk `X` was dropped.
- `51a29dda` **fix(raise)** — resolve a sunk tail's reads through the FORWARDERS it was reached by. A
  jump pad (`.L4: b .L6`) in front of the store made `verify` throw and the whole twin vanish through
  `onLeverError`, a channel `bench run` never prints: 106 throws → 0 over 4000 generated functions,
  43 of which gain a sunk twin the throw was suppressing.
- `76e3b26a` **fix(rank)** — enumerate the follow ALONE, not only behind the sink. Bundled into one
  bit, the sink deleted the follow it exists to feed; `gcsejoin`, the row added here, is ordinary
  loop-free C of that shape and was 7/37 both before the branch and under the bundled twin.
- `b2a677a6` **docs** — the family's commentary rewritten as what this round measured.
- `458de4d1` **bench** — the regenerated artifact, last commit on the branch.

## Gates

- `pnpm bench run` (all tiers, at `b2a677a`): ✓ synthetic 810 results in 344.4 s, ✓ real 252 in
  2099.9 s. `pnpm bench:merge` → 1062 results.
- `pnpm bench regression --base origin/main`: **0 lost, 0 missing, 9 gained, 0 other flips**
  (1061 committed rows).
- `pnpm bench diff --base origin/main`: 86 field changes, 1 added, 0 removed. **Totals: asmlift
  620/1061 → 630/1062; m2c 416 either way.**
- `npx vitest run` (the whole config, apps included): **226 files, 4111 tests passed**.
- `pnpm test:matching` (in no PR gate — it is the gate that caught #188's first cut losing five
  byte-exact matches): **42 files, 394 tests passed**.
- `pnpm exec vitest run apps/benchmark/test`: 37 files, 1022 tests passed.
- `pnpm typecheck` 0 errors · `pnpm lint` 0 errors, 126 warnings (the count at `origin/main`; the
  changed files add none) · prettier clean · `scripts/check-artifact-provenance.sh` OK.

## The oracle, and how often it fired

This round moves stores between control-flow paths and turns fall-through into early returns —
exactly the change that can be byte-closer and semantically wrong, which is how #185's rule promoted
a pre-existing wrong candidate to winner while the score read it as progress. So the transform ships
with an **`irTraceOf` differential** (`packages/core/test/shared-tail-fuzz.test.ts`): it runs the IR
itself and compares its observable trace with `traceOf` of the structured tree, the one oracle a
naming fuzz cannot replace. `helpers.ts`' `traceOf`/`irTraceOf` learned `gaddr`/`store`/`addr`,
`icmp_*`, `logic_and`/`logic_or` and short-circuit `&&`/`||`, so a store's address and value are
observables on both sides.

Firing counts, from the gate run's own stdout — a fuzz that never fires the path proves nothing:

    [shared-tail-fuzz] seeds=20000 sunk=15866 followed=9391 sunk+followed=3662 declined=0
    [shared-tail-fuzz raised] seeds=6000 foreignParamTail=318 sunk=4779 sunkForeign=318
                              followed=2780 sunk+followed=1100 declined=0

The second arm runs 6000 generated functions through the real `raiseRecovered` spine before the sink
and traces every tree against the RAISED fn's own run, through both `structure` and
`structureChecked`. Teeth, measured: the pre-`51a29dda` substitution throws at seed 1; giving every
copy the kept path's values fails both arms. Floors are asserted so a generator tweak cannot turn it
green by quietly generating nothing the transform touches.

## Moved-row inventory (`bench diff`, 17 rows)

Flipped to MATCH (9): the eight above plus `pokeemerald:IsStringLengthAtLeast:agbcc` 8/22 → **0/19**
(`signed/shared-ret/initfirst` — its shared `return 0;` after the loop guard), which the build's
scoped runs found and the attribution did not name.

Moved on score without flipping (2): `kleod:CheckWorldCompletion:agbcc` 45/191 → 44/191;
`synthetic:findfirst:agbcc` 12/25 → 10/25.

Relabelled, still MATCH, published source one line shorter (5): `synthetic:sw_fallguard:agbcc`,
`synthetic:findfirst:mwcc_242_81`, `synthetic:breakloop:gcc2.7.2kmc`,
`pokeemerald:DoForcedMovement:agbcc`, `sa3:VerifyFlashSector_Core:agbcc` — each `X` → `X/shared-ret`,
a shared `return` after the `if` instead of an `else { return …; }`, byte-exact either way and won on
readability. Added (1): `synthetic:gcsejoin:agbcc`.

**No row moved that the branch's scoped runs had not already predicted**, and no control moved on any
toolchain: `gcsedup`, `gcsepredup`, `gcseinnerdup` (the three #189 added), `armexpr`, `maskchain`,
`mergeu16`, `mergenarrow`, `mergeldcast`, `mergepool`, `armcb`, `armcb2`, `ladder4`, `ladidx1`,
`ladidx2`, and the `retsink.ts` surface #188 protected (`clamp0`, `bittest`, `absdiff`, `maxi`,
`mini`, the `ifand`/`ifor` family, the `sw_fall` family) are all MATCH, on every toolchain the spec
targets. `gcsepredup` is the sharpest control: it carries 20 `/shared-tail` candidates and still wins
on the un-sunk spelling.

## Three comment claims REFUTED by measurement, not by reading

1. #189's Route-B recommendation, above. It is the claim that recommended the route not taken.
2. rank.ts's own "one function carries two sunk tails": instrumenting the two counters,
   **three** functions carry two of something — `maskchain` (2 follow sites), `gcsearms6` (2 sunk
   tails) and `pokeemerald:SetMauvilleOldManLanguage:agbcc` (2 sunk tails). The third was invisible
   to every census the round ran, because the price gate then refuses and its fan is unchanged. It
   moves nothing, but any future per-site vs per-function claim about this family must count it.
3. rank.ts's "204 synthetic candidates on 8 rows (… and four ladders)": the 204 and the 8 re-ablate
   exactly, but the four ladders are `ladder4`, `ladder5`, `ladidx2` and `revlad5s` — none of the
   ladder controls the block above it names. Now listed by name.

## Findings declined across the two adversarial waves

Both waves' blockers were confirmed and fixed (the ledgers are in the commit bodies). Declined:

- **A-F3 (second half), "table the follow's refusals"** — the spec asks for a table of refusals you
  had to instrument or suspect never fire; none of the follow's three was instrumented to attribute a
  row, and each is now produced by its own fixture (the missing "no follow but EXIT" one was added).
  A census would also need a caller seam the twin loop does not have.
- **A-F5a, "cite `gcseinner`/`gcseinnerdup` as the compiled pair the IR cannot decide"** — REFUTED by
  measurement: their recover-stage IR differs (58 lines against 60). `gcsepre`/`gcsepredup` is that
  pair; the measured default losses stay as the evidence.
- **A-F7 (part), pin the ranked re-spellings** — `/offmember` and `/livebase` are pre-existing levers
  this branch does not change.
- **A-F8.1 (part), share the splice between `tailsink` and `retsink`** — they splice different bodies
  (`ret v` against stores) under different populations, ~6 lines in common. A pointer from
  `retsink`'s `m.ops.length !== 1` skip was added instead.
- A per-tail "never sink a tail that is already a follow" refusal was built and measured as the
  alternative to the enumeration split, and it costs `gcseflat` 0/49 → 19/53 and `gcsearms6` 0/84 →
  23/87: those two need a tail that is BOTH a follow and a cross-jump target. No predicate on this IR
  picks, which is why the split is an enumeration split and not a gate.
- One surviving mutation, reported rather than fixed: running the sink pass when `sunk === false`
  changes no candidate — the tree dedup absorbs it, so it costs structure calls only.

## What this round did NOT do

- No forwarder-threading step (#189's part (iii)): the sink's source walk sees through
  `^f(v): br ^t(v)` by construction, and `gcsefwd` and CountCollectedGems MATCH without it.
- `gcsejoindup`, the duplicated twin of the new row, was built, measured and NOT added: it lifts with
  no shared `ret` at all and 0 twin candidates either way, so it gates nothing.
- The four CountCollectedGems-like low-pressure variants #189 flagged as probable general-follow
  inhabitants were not hand-marked and get no row.
- The ten rows are measured on agbcc only, as #189 left them; the structuring change itself is not
  toolchain-specific, and the relabels above land on mwcc and gcc2.7.2kmc rows too.
- Two harness defects #189 found stay open and unfixed: `bench repro --run` truncating stderr at
  ~64 KiB on fans over ~550 candidates, and `apps/benchmark/test/preflight.test.ts` reading the live
  lock register (it fails while any bench is running on the machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5bxiJ5KCo7S7padFmjsAx
