### PR TITLE
Register the unmatchable source quirks, and make a stop-here verdict link its evidence

### DIFF
--- a/.claude/commands/attribute-function.md
+++ b/.claude/commands/attribute-function.md
@@ -152,6 +152,10 @@ near-identical code diffs as ~100% different. Instead:
   capability gaps, some will belong to other, known machinery (dispatch shape of a recovered
   `switch`, signedness of locals, operand order). Separate them explicitly — a finding attributed
   to the wrong machinery produces a row that gates nothing.
+- Check the row against [`docs/unmatchable-quirks.md`](../../docs/unmatchable-quirks.md) before
+  filing a gap for it. A residual already cleared there is not a capability gap and must not become
+  a row; a residual you believe that register gets WRONG is worth more than any attribution, because
+  its entries close rows and each is falsified by one honest spelling reaching the target bytes.
 
 ## Phase 3 — Verify every hypothesis against the compiler itself
 

--- a/.claude/commands/dogfood-klonoa.md
+++ b/.claude/commands/dogfood-klonoa.md
@@ -351,7 +351,9 @@ Then update the memory files under
    152→34 improvement that did not exist.
 6. **asmlift stays pinned for the duration.** Log its defects; fix them after the round.
 7. **Never declare a function irreducibly unmatchable from hand experiments.** Name the blocking
-   hypothesis and leave it open.
+   hypothesis and leave it open. The bar that would close it, and the rows that have cleared it, is
+   [`docs/unmatchable-quirks.md`](../../docs/unmatchable-quirks.md) — two compiler sweeps — and its
+   entries are benchmark rows, so a checkout function cannot enter it at all.
 8. **A placeholder name beats a guess**, and an unverified runtime claim beats nothing only if it is
    labelled as unverified.
 9. **Never use an `asm("")` barrier, and never count a function that carries one as matched.** A

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -437,7 +437,10 @@ launch anything long. What this command leans on:
    for harness reasons.
 4. **Stop rule.** If the capability is bigger than this session, or the row turns out unmatchable:
    keep and ship the commits that genuinely reduced the diff, and report what is blocked and what
-   the next step would be. Do not force an ad-hoc hack to close the last few bytes.
+   the next step would be. Do not force an ad-hoc hack to close the last few bytes. "Unmatchable"
+   here means it cleared the bar in
+   [`docs/unmatchable-quirks.md`](../../docs/unmatchable-quirks.md) — two compiler sweeps — and
+   never "I ran out of session": that case is blocked, which is a different report.
 5. **Everything in [`docs/measurement-discipline.md`](../../docs/measurement-discipline.md)** —
    numbers come from commands; a compiler claim is verified by compiling; a refusing site is named
    by instrumenting or ablating it; NO REACH ≠ LOSES ≠ DOES NOT COMPOSE; the denominator moves;

--- a/.claude/commands/match-function.md
+++ b/.claude/commands/match-function.md
@@ -100,9 +100,13 @@ them are not "add a feature":
   candidate-generation change, and levers regress other rows far more often than they help; it
   needs a gate (see Hard Rules).
 - **Unmatchable source quirk** — the original C used a construct no honest recovery would produce
-  (register-allocation intermediates, a hand-written temporary, an unusual build flag). Real
-  precedent in this repo: `StrCpy`. Say so, prove it, and stop — do not invent machinery to imitate
-  a quirk.
+  (register-allocation intermediates, a hand-written temporary, an unusual build flag, a redundant
+  expression the compiler then eliminates). Say so, prove it, and stop — do not invent machinery to
+  imitate a quirk. The bar for "prove it" and the rows that have cleared it are
+  [`docs/unmatchable-quirks.md`](../../docs/unmatchable-quirks.md): two compiler sweeps, not an
+  argument about plausibility, because the verdict closes a row to every later round. An entry there
+  is falsified by one honest spelling reaching the target bytes — so read the row's entry and try to
+  break it rather than citing it.
 - **Harness / fidelity problem** — the row is built with a toolchain or flags the real project did
   not use (the `old_agbcc` class of bug). Then the fix is in the manifest/toolchain, not the
   decompiler, and it may *remove* the row rather than match it.

--- a/apps/benchmark/src/report/repro.ts
+++ b/apps/benchmark/src/report/repro.ts
@@ -119,8 +119,8 @@ export async function repro(
     `repro: ${row.id} — ${tool} ${published.outcome} ${published.score ?? '-'}/${published.maxScore ?? '-'} as published`,
   );
   log(`repro: wrote ${path}`);
-  // asmlift only: the symbol map is asmlift's input (`symbolMap` is documented "asmlift only" in
-  // the schema), and m2c's channel is the --context header the script embeds verbatim.
+  // asmlift only: `symbolMap` is an asmlift-only field of the schema, and m2c's channel is the
+  // `--context` header its own script writes.
   if (tool === 'asmlift' && row.tier === 'real' && row.asmlift.symbolMap) {
     // A row measured WITH a map and reproduced without one answers a different question, and
     // `bench target` only warns — it exits 0 and the run continues.
@@ -146,10 +146,8 @@ export async function repro(
 
   // M2C HAS NO SCORING STEP. `m2cScript` ends at `python3 m2c.py … in.s`: it prints C to stdout, and
   // `code === 0` means python ran. So there is no `[ranked]` line to look for on ANY m2c run,
-  // success included, and nothing was scored that "byte-exact" could describe. Reporting it through
-  // the asmlift path below said three contradictory things at once on a completely successful run —
-  // asmlift's published score, "the run printed no [ranked] line — read out.err" (0 bytes), and
-  // "script exit 0 (byte-exact)". On a row a verdict has closed, "byte-exact" is the worst of them.
+  // success included, and nothing was scored that "byte-exact" could describe — which is what the
+  // asmlift path below would report of a completely successful one. Hence its own exit path.
   if (tool === 'm2c') {
     if (broken) {
       err(`repro: ${broken}`);
@@ -173,10 +171,9 @@ export async function repro(
   if (ranked.length === 0) {
     err(`repro: the run printed no [ranked] line — read ${join(dir, 'out.err')}`);
   }
-  // A SETUP failure must change the VERDICT LINE, not merely add one above it. The first version of
-  // this check printed its diagnosis and then fell into the line below, which says the script
-  // behaved as designed and the row simply does not match — and `repro()` returns `code`, so exit 1
-  // with no asmlift binary was byte-for-byte indistinguishable from exit 1 for a faithfully
+  // A SETUP failure must change the VERDICT LINE, not merely add one above it: the line below says
+  // the script behaved as designed and the row simply does not match, and `repro()` returns `code`,
+  // so exit 1 with no asmlift binary would be indistinguishable from exit 1 for a faithfully
   // reproduced nonmatch. Exit 2 is "this command could not answer", the code an unknown `--tool`
   // already returns.
   if (broken) {
@@ -193,11 +190,10 @@ export async function repro(
 /** The failures of the MACHINE rather than of the row, named from the script's stderr. Returns the
  *  recovery, or undefined when nothing here explains it.
  *
- *  NOT "the one cause that is not the row" — the first version of this check said so in a comment
- *  and the second cause was the very first one a reviewer hit, in a fresh worktree wired the
- *  documented way. Detecting these by regexing the stderr of a run that should not have started is
- *  the inverse of `run/preflight.ts`'s contract; that module is the right home once `repro --run`
- *  has a preflight, and this is a pure function so the move is a call-site change. */
+ *  Not a closed list: a cause missing from it reads as the row not matching, so add one whenever a
+ *  wiring failure is seen wearing that disguise. Regexing the stderr of a run that should never have
+ *  started is the inverse of `run/preflight.ts`'s contract, which is where this belongs once
+ *  `repro --run` has a preflight; keeping it pure makes that move a call-site change. */
 export function setupRefusal(errText: string): string | undefined {
   if (
     /\.bin\/asmlift: (?:No such file or directory|command not found)|cannot execute: required file not found/.test(

--- a/apps/benchmark/src/report/repro.ts
+++ b/apps/benchmark/src/report/repro.ts
@@ -144,6 +144,18 @@ export async function repro(
   }
   if (ranked.length === 0) {
     err(`repro: the run printed no [ranked] line — read ${join(dir, 'out.err')}`);
+    // THE ONE CAUSE THAT IS NOT THE ROW. `@asmlift/cli`'s build output is gitignored, so in a
+    // fresh worktree the first `pnpm install` cannot create the bin link and `--run` dies on a bare
+    // ENOENT that says nothing about what to do. `repro-scripts.ts` writes the recovery into the
+    // generated script as a comment, three lines above the invocation — where nobody reading this
+    // error is looking. Say it where the failure is.
+    if (/\.bin\/asmlift: No such file or directory|cannot execute: required file not found/.test(errText)) {
+      err(
+        "repro: that is the checkout's asmlift bin missing, not the row. The CLI's build output is " +
+          'gitignored, so a fresh worktree has no bin link: run `pnpm --filter @asmlift/cli build` ' +
+          'and then `pnpm install` again, and re-run this.',
+      );
+    }
   }
   // exit 0 only on byte-exact (`--score-against`), so a non-matching row's script exits 1 by
   // design. That is the row reproducing, not the script breaking — pass it through and say so.

--- a/apps/benchmark/src/report/repro.ts
+++ b/apps/benchmark/src/report/repro.ts
@@ -111,11 +111,17 @@ export async function repro(
   const path = join(dir, `repro-${tool}.sh`);
   writeFileSync(path, script);
 
+  // THE TOOL'S OWN published figure. Printing `row.asmlift` under `--tool m2c` states a number this
+  // script cannot produce, next to a script that produces a different one: on `kleod:StrCpy:agbcc`
+  // asmlift is 5/8 and m2c is 6/7, and the reader compares the C in out.c against the wrong one.
+  const published = tool === 'm2c' ? row.m2c : row.asmlift;
   log(
-    `repro: ${row.id} — ${row.asmlift.outcome} ${row.asmlift.score ?? '-'}/${row.asmlift.maxScore ?? '-'} as published`,
+    `repro: ${row.id} — ${tool} ${published.outcome} ${published.score ?? '-'}/${published.maxScore ?? '-'} as published`,
   );
   log(`repro: wrote ${path}`);
-  if (row.tier === 'real' && row.asmlift.symbolMap) {
+  // asmlift only: the symbol map is asmlift's input (`symbolMap` is documented "asmlift only" in
+  // the schema), and m2c's channel is the --context header the script embeds verbatim.
+  if (tool === 'asmlift' && row.tier === 'real' && row.asmlift.symbolMap) {
     // A row measured WITH a map and reproduced without one answers a different question, and
     // `bench target` only warns — it exits 0 and the run continues.
     log(
@@ -136,6 +142,28 @@ export async function repro(
   for (const line of errText.split('\n').filter((l) => l.startsWith('WARN'))) {
     err(`repro: ${line}`);
   }
+  const broken = setupRefusal(errText);
+
+  // M2C HAS NO SCORING STEP. `m2cScript` ends at `python3 m2c.py … in.s`: it prints C to stdout, and
+  // `code === 0` means python ran. So there is no `[ranked]` line to look for on ANY m2c run,
+  // success included, and nothing was scored that "byte-exact" could describe. Reporting it through
+  // the asmlift path below said three contradictory things at once on a completely successful run —
+  // asmlift's published score, "the run printed no [ranked] line — read out.err" (0 bytes), and
+  // "script exit 0 (byte-exact)". On a row a verdict has closed, "byte-exact" is the worst of them.
+  if (tool === 'm2c') {
+    if (broken) {
+      err(`repro: ${broken}`);
+      return 2;
+    }
+    log(
+      code === 0
+        ? `repro: script exit 0 — m2c ran; its C is in ${join(dir, 'out.c')}. This script does not ` +
+            'score it: compare it against the row yourself (`pnpm bench baseline` has the published figure).'
+        : `repro: script exit ${code} — m2c did not run to completion; read ${join(dir, 'out.err')}`,
+    );
+    return code;
+  }
+
   // `[ranked]`, not the `[score]` table: it carries `best …` and the `[asmlift source <sha>]`
   // stamp, and it is one line whether the fan was 1 or 100,000.
   const ranked = errText.split('\n').filter((l) => l.includes('[ranked]') || l.includes('[declined]'));
@@ -144,23 +172,53 @@ export async function repro(
   }
   if (ranked.length === 0) {
     err(`repro: the run printed no [ranked] line — read ${join(dir, 'out.err')}`);
-    // THE ONE CAUSE THAT IS NOT THE ROW. `@asmlift/cli`'s build output is gitignored, so in a
-    // fresh worktree the first `pnpm install` cannot create the bin link and `--run` dies on a bare
-    // ENOENT that says nothing about what to do. `repro-scripts.ts` writes the recovery into the
-    // generated script as a comment, three lines above the invocation — where nobody reading this
-    // error is looking. Say it where the failure is.
-    if (/\.bin\/asmlift: No such file or directory|cannot execute: required file not found/.test(errText)) {
-      err(
-        "repro: that is the checkout's asmlift bin missing, not the row. The CLI's build output is " +
-          'gitignored, so a fresh worktree has no bin link: run `pnpm --filter @asmlift/cli build` ' +
-          'and then `pnpm install` again, and re-run this.',
-      );
-    }
+  }
+  // A SETUP failure must change the VERDICT LINE, not merely add one above it. The first version of
+  // this check printed its diagnosis and then fell into the line below, which says the script
+  // behaved as designed and the row simply does not match — and `repro()` returns `code`, so exit 1
+  // with no asmlift binary was byte-for-byte indistinguishable from exit 1 for a faithfully
+  // reproduced nonmatch. Exit 2 is "this command could not answer", the code an unknown `--tool`
+  // already returns.
+  if (broken) {
+    err(`repro: ${broken}`);
+    log(`repro: script exit ${code} — the CHECKOUT is not set up; this says NOTHING about the row`);
+    return 2;
   }
   // exit 0 only on byte-exact (`--score-against`), so a non-matching row's script exits 1 by
   // design. That is the row reproducing, not the script breaking — pass it through and say so.
   log(`repro: script exit ${code}${code === 0 ? ' (byte-exact)' : ' — a non-matching row exits nonzero by design'}`);
   return code;
+}
+
+/** The failures of the MACHINE rather than of the row, named from the script's stderr. Returns the
+ *  recovery, or undefined when nothing here explains it.
+ *
+ *  NOT "the one cause that is not the row" — the first version of this check said so in a comment
+ *  and the second cause was the very first one a reviewer hit, in a fresh worktree wired the
+ *  documented way. Detecting these by regexing the stderr of a run that should not have started is
+ *  the inverse of `run/preflight.ts`'s contract; that module is the right home once `repro --run`
+ *  has a preflight, and this is a pure function so the move is a call-site change. */
+export function setupRefusal(errText: string): string | undefined {
+  if (
+    /\.bin\/asmlift: (?:No such file or directory|command not found)|cannot execute: required file not found/.test(
+      errText,
+    )
+  ) {
+    return (
+      "the checkout's asmlift bin is missing, not the row. The CLI's build output is gitignored, so " +
+      'a fresh worktree has no bin link: run `pnpm --filter @asmlift/cli build` and then ' +
+      '`pnpm install` again, and re-run this.'
+    );
+  }
+  const toolchain = errText.match(/cannot run '([^']+)' \([^)]*\) — not installed/);
+  if (toolchain) {
+    return (
+      `the pinned toolchain at ${toolchain[1]} is not installed on this machine, not the row. ` +
+      'Point the ASMLIFT_* env var for it at your copy (`source .envrc.local`), or install it, and ' +
+      're-run this.'
+    );
+  }
+  return undefined;
 }
 
 /** Run the script in its own directory, capturing both streams to files. Buffered rather than

--- a/apps/benchmark/test/command-files.test.ts
+++ b/apps/benchmark/test/command-files.test.ts
@@ -242,6 +242,51 @@ describe('a verdict that ENDS a round is linked to its evidence', () => {
   });
 });
 
+describe('the unmatchable register is falsified by the artifact', () => {
+  // The register says of itself that "an entry here closes a row to future rounds and that is
+  // exactly the kind of claim that rots unwatched", and it shipped with no gate — while the cost
+  // table 170 lines above has one. A verdict does not rot on a CLOCK the way a cost figure does; it
+  // rots the instant somebody matches the row. `results.json` knows, and `citations.test.ts` already
+  // holds the ids in this page to rows that exist, so the only thing missing is the one assertion
+  // the entry's own falsification condition names.
+  const REGISTER = join(DOCS_DIR, 'unmatchable-quirks.md');
+  const ROW_ID = /^\|\s*`([\w.-]+:[\w.-]+:[\w.-]+)`\s*\|/;
+
+  const registerRows = () =>
+    readFileSync(REGISTER, 'utf8')
+      .split('\n')
+      .map((l) => l.match(ROW_ID)?.[1])
+      .filter((id): id is string => Boolean(id));
+
+  it('every row it closes is still a nonmatch in results.json', () => {
+    const ids = registerRows();
+    expect(
+      ids.length,
+      `no row parsed out of ${REGISTER}'s table — either the register is empty (delete this gate) or ` +
+        'its table shape moved and this check went blind',
+    ).toBeGreaterThan(0);
+
+    const artifact = JSON.parse(readFileSync(ARTIFACT, 'utf8')).results as {
+      id: string;
+      asmlift?: { outcome?: string };
+    }[];
+    const falsified: string[] = [];
+    for (const id of ids) {
+      const row = artifact.find((r) => r.id === id);
+      expect(row, `${REGISTER} closes ${id}, which is not a row in the committed results.json`).toBeDefined();
+      if (row?.asmlift?.outcome === 'match') {
+        falsified.push(id);
+      }
+    }
+    expect(
+      falsified,
+      `the register calls these rows unmatchable and the artifact says asmlift matched them. An entry ` +
+        `is falsified by one honest spelling reaching the target bytes, and a published match IS one: ` +
+        `delete the entry, do not annotate it. ${falsified.join(', ')}`,
+    ).toEqual([]);
+  });
+});
+
 describe('every link in a command file resolves', () => {
   // Both spellings: `](../../docs/x.md)` relative to the file, and `](docs/x.md)` relative to the
   // repo root. Matching only the leading-`.` form leaves a repo-root link that 404s invisible, and

--- a/apps/benchmark/test/command-files.test.ts
+++ b/apps/benchmark/test/command-files.test.ts
@@ -48,9 +48,12 @@
 //      weakest thing that closes it, and the two checks around it do the rest: `citations.test.ts`
 //      holds the linked page's rows to still existing, the link check below refuses a 404.
 //      The FIRST version of this gate examined 0 of 175 blocks, because it keyed on a word its own
-//      branch had deleted two commits earlier — green with the evidence link removed. Hence the
-//      `examined > 0` assertion and the fixture beside it: a gate whose examined-block count is zero
-//      is not a weak gate, it is no gate, and nothing else in this file would have said so.
+//      branch had deleted two commits earlier — green with the evidence link removed. The SECOND
+//      examined 2, and one of them was `## Hard rules` — an 18-line block holding the word
+//      `unmatchable` and an unrelated `docs/` link — so the `examined > 0` tripwire added for the
+//      first defeat was held up by a decoy and the gate was green with its subject deleted again.
+//      Hence the pinned inhabitant SET below rather than a count: this gate has twice been a
+//      comment with a test runner attached, and nothing else in this file would have said so.
 //
 // WHAT IT STILL CANNOT DECIDE, so that nobody reads more into a green run than is there:
 //   - It cannot check that an instruction is TRUE. Only a command run can.
@@ -161,64 +164,117 @@ describe('the two round prompts do not duplicate an instruction', () => {
 });
 
 describe('a verdict that ENDS a round is linked to its evidence', () => {
-  // WHY THIS SHAPE, and not the obvious one. The first version of this gate keyed on the word
-  // `precedent` — a word the SAME BRANCH's earlier commit had already deleted from the bullet the
-  // gate was written to protect. Replayed over `.claude/commands/*.md` it examined 0 of 175 blocks,
-  // so `unbacked` was `[]` unconditionally: it stayed green with the evidence link DELETED, which
-  // is the single regression it exists to prevent. Three things follow, all encoded below:
-  //   - key on the RULE (a verdict that tells the agent to stop) rather than on one sentence's
-  //     wording;
-  //   - assert the scan EXAMINED something, so that re-wording the outcome list reddens this file
-  //     instead of silently disarming it (#186: a stamp needs a test where it is produced);
-  //   - require a MARKDOWN link, because the sibling "every link in a command file resolves" suite
-  //     below only inspects `](…)` — a bare `docs/foo.md` in running text is an unchecked promise,
-  //     and the first version accepted one.
+  // WHY THIS SHAPE, and not either of the two obvious ones. This gate has now been disarmed twice
+  // by its own corpus, and both defeats are encoded below.
   //
-  // Blocks are blank-line separated, so a bullet LIST is one block: a link anywhere in the list
-  // that carries the verdict satisfies it. That is deliberate — the unit an agent reads is the
-  // outcome list, not the line.
+  //   DEFEAT 1 — the wrong KEY. The first version keyed on the word `precedent`, which the SAME
+  //   BRANCH's earlier commit had already deleted from the bullet the gate protects. It examined 0
+  //   of 175 blocks, so `unbacked` was `[]` unconditionally: green with the evidence link DELETED.
+  //   Fix: key on the RULE (a verdict that tells the agent to stop), require a MARKDOWN link
+  //   (the sibling link-resolution suite below only inspects `](…)`, so a bare `docs/foo.md` in
+  //   running text is an unchecked promise), and assert the scan examined something.
+  //
+  //   DEFEAT 2 — the wrong UNIT, which then propped up the count from defeat 1. Blocks were
+  //   blank-line delimited, so `## Hard rules`' five numbered items were ONE block: it carries the
+  //   word `unmatchable` (rule 4) and a `docs/measurement-discipline.md` link (rule 5), which has
+  //   nothing to do with any verdict. That decoy satisfied `examined > 0` on its own, so rewording
+  //   the Phase-1 outcome bullet and deleting its link — the exact regression — was green again.
+  //   Three independent existentials over an 18-line paragraph is not a rule about a verdict.
+  //
+  // Hence: the unit is the BULLET (a top-level `-`/`N.` item plus its continuation lines), the link
+  // must be in the bullet that carries the verdict, and the assertion on the corpus is the pinned
+  // INHABITANT SET below rather than a count. A count can be held up by anything; a named set
+  // cannot. `registerBacked` is a third, non-redundant check: re-pointing every verdict at some
+  // other `docs/` page keeps the set intact and the unbacked list empty while leaving the register
+  // itself unreferenced (#186: a stamp needs a test where it is produced).
   const STOPS = /\bstops?\b/i;
   const VERDICT = /\bunmatchable\b|\bquirks?\b/i;
   const DOC_LINK = /\]\([^)\s]*docs\/[\w.-]+\.md[^)\s]*\)/;
+  const REGISTER_LINK = /\]\([^)\s]*docs\/unmatchable-quirks\.md[^)\s]*\)/;
+  const BULLET = /^(?:[-*+]|\d+\.)\s/;
 
-  /** Blank-line-delimited blocks of `lines` that pronounce a row unmatchable AND tell the agent to
-   *  stop. Returns how many such blocks were examined as well as which lack an evidence link: a
-   *  gate over an empty set is a comment with a test runner attached. */
-  const scanStops = (lines: string[], file = '<fixture>') => {
-    const unbacked: string[] = [];
-    let examined = 0;
+  /** Every verdict bullet that must carry an evidence link today, `file: label`. A verdict that is
+   *  reworded away drops out of this set and reddens the file; a NEW one has to be added here on
+   *  purpose, which is where an author is asked whether it is backed. Labels are the bullet's bold
+   *  lead, not line numbers — those rot on the next edit above them. */
+  const PINNED = ['match-function.md: Unmatchable source quirk', 'match-function.md: Stop rule.'];
+
+  /** The units a verdict can live in: a top-level bullet or numbered rule with its continuation
+   *  lines, and (for text that is not a list) a blank-line-delimited paragraph. */
+  const verdictUnits = (lines: string[]) => {
+    const units: { line: number; body: string[] }[] = [];
+    const pushBlock = (block: string[], base: number) => {
+      let s = 0;
+      for (let i = 0; i <= block.length; i++) {
+        if (i < block.length && !(i > s && BULLET.test(block[i]))) {
+          continue;
+        }
+        if (i > s) {
+          units.push({ line: base + s + 1, body: block.slice(s, i) });
+        }
+        s = i;
+      }
+    };
     let start = 0;
     for (let i = 0; i <= lines.length; i++) {
       if (i < lines.length && lines[i].trim() !== '') {
         continue;
       }
-      const block = lines.slice(start, i);
-      const text = block.join(' ');
-      if (block.length > 0 && VERDICT.test(text) && STOPS.test(text)) {
-        examined++;
-        if (!DOC_LINK.test(text)) {
-          unbacked.push(`${file}:${start + 1}: ${block[0].trim().slice(0, 70)}`);
-        }
+      if (i > start) {
+        pushBlock(lines.slice(start, i), start);
       }
       start = i + 1;
     }
-    return { examined, unbacked };
+    return units;
+  };
+
+  /** Units of `lines` that pronounce a row unmatchable AND tell the agent to stop. Returns WHICH
+   *  were examined, not just how many — a gate over an empty set is a comment with a test runner
+   *  attached, and a gate over an unnamed set is one a decoy can keep alive. */
+  const scanStops = (lines: string[], file = '<fixture>') => {
+    const unbacked: string[] = [];
+    const examined: { file: string; label: string; line: number }[] = [];
+    let registerBacked = 0;
+    for (const unit of verdictUnits(lines)) {
+      const text = unit.body.join(' ');
+      if (!VERDICT.test(text) || !STOPS.test(text)) {
+        continue;
+      }
+      const label = (unit.body[0].match(/\*\*(.+?)\*\*/)?.[1] ?? unit.body[0].trim().slice(0, 60)).trim();
+      examined.push({ file, label, line: unit.line });
+      if (REGISTER_LINK.test(text)) {
+        registerBacked++;
+      }
+      if (!DOC_LINK.test(text)) {
+        unbacked.push(`${file}:${unit.line}: ${unit.body[0].trim().slice(0, 70)}`);
+      }
+    }
+    return { examined, unbacked, registerBacked };
   };
 
   it('every unmatchable verdict in a command file links a docs/ page', () => {
-    let examined = 0;
+    const examined: { file: string; label: string; line: number }[] = [];
     const unbacked: string[] = [];
+    let registerBacked = 0;
     for (const f of commandFiles()) {
       const found = scanStops(read(f), f);
-      examined += found.examined;
+      examined.push(...found.examined);
       unbacked.push(...found.unbacked);
+      registerBacked += found.registerBacked;
     }
     expect(unbacked, `a verdict that stops the round, with no evidence link: ${unbacked.join(' | ')}`).toEqual([]);
     expect(
-      examined,
-      'this gate examined no block at all, so it passes whatever the command files say. The wording ' +
-        'it keys on has moved: re-point it at the outcome bullet that tells an agent a row is ' +
-        'unmatchable and to stop.',
+      examined.map((e) => `${e.file}: ${e.label}`).sort(),
+      'the set of verdict bullets this gate protects has changed. MISSING entry: a bullet that told ' +
+        'an agent a row is unmatchable and to stop no longer reads that way — if that was deliberate, ' +
+        'delete it from PINNED; if not, this is the regression the gate exists to catch. EXTRA entry: ' +
+        'a new verdict that ends a round — add it to PINNED once it links its evidence.',
+    ).toEqual([...PINNED].sort());
+    expect(
+      registerBacked,
+      'no verdict bullet links docs/unmatchable-quirks.md any more. Every one of them is backed by ' +
+        'SOME docs page, so the check above is green — but the register that holds the cleared rows ' +
+        'is now unreachable from the prompts, which is how it stops being read.',
     ).toBeGreaterThan(0);
   });
 
@@ -228,17 +284,41 @@ describe('a verdict that ENDS a round is linked to its evidence', () => {
       '  produce. Say so, prove it, and stop.',
     ];
     const unlinked = scanStops(bullet);
-    expect(unlinked.examined).toBe(1);
+    expect(unlinked.examined.map((e) => e.label)).toEqual(['Unmatchable source quirk']);
     expect(unlinked.unbacked).toHaveLength(1);
     expect(unlinked.unbacked[0]).toContain('<fixture>:1: - **Unmatchable source quirk**');
     const backed = [
       bullet[0],
       `${bullet[1]} The bar is [\`docs/unmatchable-quirks.md\`](../../docs/unmatchable-quirks.md).`,
     ];
-    expect(scanStops(backed)).toEqual({ examined: 1, unbacked: [] });
+    expect(scanStops(backed).unbacked).toEqual([]);
+    expect(scanStops(backed).registerBacked).toBe(1);
     // A bare path in prose is NOT a link: nothing downstream checks it resolves.
     const prose = [bullet[0], `${bullet[1]} The bar is docs/unmatchable-quirks.md.`];
     expect(scanStops(prose).unbacked).toHaveLength(1);
+    // Some other docs page is a link but not the register: backed, not register-backed.
+    const elsewhere = [bullet[0], `${bullet[1]} The bar is [\`docs/bench-cost.md\`](../../docs/bench-cost.md).`];
+    expect(scanStops(elsewhere).unbacked).toEqual([]);
+    expect(scanStops(elsewhere).registerBacked).toBe(0);
+  });
+
+  it('does not let a neighbouring rule back a verdict — the defeat-2 shape', () => {
+    // `## Hard rules` verbatim in shape: one blank-line block, five numbered items, the verdict in
+    // item 2 and an unrelated docs link in item 3. Under the old block unit this scanned as ONE
+    // backed block — examined 1, unbacked 0, and the count kept the whole gate alive.
+    const rules = [
+      '1. **Never trade a loud failure for a silent wrong answer.** Every new transform must state',
+      '   the condition under which it refuses.',
+      '2. **Stop rule.** If the capability is bigger than this session, or the row turns out',
+      '   unmatchable: keep and ship the commits that genuinely reduced the diff.',
+      '3. **Everything in [`docs/measurement-discipline.md`](../../docs/measurement-discipline.md)**',
+      '   — numbers come from commands; a measured null ships.',
+    ];
+    const scanned = scanStops(rules, 'hard-rules');
+    expect(scanned.examined.map((e) => e.label)).toEqual(['Stop rule.']);
+    expect(scanned.unbacked).toHaveLength(1);
+    expect(scanned.unbacked[0]).toContain('hard-rules:3:');
+    expect(scanned.registerBacked).toBe(0);
   });
 });
 

--- a/apps/benchmark/test/command-files.test.ts
+++ b/apps/benchmark/test/command-files.test.ts
@@ -331,12 +331,27 @@ describe('the unmatchable register is falsified by the artifact', () => {
   // the entry's own falsification condition names.
   const REGISTER = join(DOCS_DIR, 'unmatchable-quirks.md');
   const ROW_ID = /^\|\s*`([\w.-]+:[\w.-]+:[\w.-]+)`\s*\|/;
+  const SECTION = '## The register';
 
-  const registerRows = () =>
-    readFileSync(REGISTER, 'utf8')
-      .split('\n')
+  /** ONLY the rows under `## The register`. The page carries a SECOND table — the near-misses that
+   *  the inhabitant count explicitly says are NOT closed — and scanning the whole file would read
+   *  one of those as a closed row the moment its cell is reformatted into a bare row id. Under the
+   *  register's own semantics ("an entry here closes a row to future rounds") that silently closes a
+   *  row nobody voted to close, and the reader of this gate's green run would never learn it. */
+  const registerRows = () => {
+    const lines = readFileSync(REGISTER, 'utf8').split('\n');
+    const from = lines.indexOf(SECTION);
+    expect(
+      from,
+      `${REGISTER} has no '${SECTION}' heading — the table this gate reads has been renamed or ` +
+        'moved, and scanning the rest of the page would treat the near-miss table as closed rows',
+    ).toBeGreaterThanOrEqual(0);
+    const to = lines.findIndex((l, i) => i > from && l.startsWith('## '));
+    return lines
+      .slice(from + 1, to === -1 ? lines.length : to)
       .map((l) => l.match(ROW_ID)?.[1])
       .filter((id): id is string => Boolean(id));
+  };
 
   it('every row it closes is still a nonmatch in results.json', () => {
     const ids = registerRows();
@@ -353,6 +368,12 @@ describe('the unmatchable register is falsified by the artifact', () => {
     const falsified: string[] = [];
     for (const id of ids) {
       const row = artifact.find((r) => r.id === id);
+      // `citations.test.ts` also resolves this id, and this assertion is KEPT anyway rather than
+      // deferred to it: an id that stops resolving leaves `row?.asmlift?.outcome` undefined, which
+      // is not `'match'`, so without this line the check below passes over an empty set and this
+      // gate is vacuous — the §10 defect, in the gate written for §10. The duplication is with a
+      // suite whose coverage of this page is conditional (`docs` being in its `SCANNED` list) and
+      // whose failure message is about citations, not about a closed row.
       expect(row, `${REGISTER} closes ${id}, which is not a row in the committed results.json`).toBeDefined();
       if (row?.asmlift?.outcome === 'match') {
         falsified.push(id);

--- a/apps/benchmark/test/command-files.test.ts
+++ b/apps/benchmark/test/command-files.test.ts
@@ -39,6 +39,14 @@
 //      `results/results.json` in prose, and `CountCollectedGems`'s fan is hand-typed in several
 //      files while being one integer in that same committed JSON. §3 is checked against the
 //      artifact rather than read; nothing before checked it at all.
+//  10. A STOP-HERE PRECEDENT WITH NO EVIDENCE BEHIND IT. A precedent that asks for MORE work is
+//      self-correcting — the round measures, and a wrong precedent costs time. One that tells the
+//      agent to STOP is not: acting on it means not measuring, so the claim is never re-tested and
+//      its reason is never checked. The unmatchable-quirk bullet named a row and linked nothing;
+//      the round sent to re-test it found the classification right and the stated reason too weak
+//      to decide the case, and re-derived the verdict from the compiler. A `docs/` link is the
+//      weakest thing that closes it, and the two checks around it do the rest: `citations.test.ts`
+//      holds the linked page's rows to still existing, the link check below refuses a 404.
 //
 // WHAT IT STILL CANNOT DECIDE, so that nobody reads more into a green run than is there:
 //   - It cannot check that an instruction is TRUE. Only a command run can.
@@ -145,6 +153,35 @@ describe('the two round prompts do not duplicate an instruction', () => {
         expect(text, `${f} does not link ${doc} — the laws and the costs are shared by every round`).toContain(doc);
       }
     }
+  });
+});
+
+describe('a precedent that ENDS a round is linked to its evidence', () => {
+  // Blocks are blank-line separated, so a bullet LIST is one block: a link anywhere in the list
+  // that carries the stop satisfies it. That is deliberate — the unit an agent reads is the
+  // outcome list, not the line.
+  const STOPS = /\bstop\b/;
+  const PRECEDENT = /\bprecedent\b/i;
+  const DOC_LINK = /docs\/[\w.-]+\.md/;
+
+  it('every stop-here precedent in a command file links a docs/ page', () => {
+    const unbacked: string[] = [];
+    for (const f of commandFiles()) {
+      const lines = read(f);
+      let start = 0;
+      for (let i = 0; i <= lines.length; i++) {
+        if (i < lines.length && lines[i].trim() !== '') {
+          continue;
+        }
+        const block = lines.slice(start, i);
+        const text = block.join(' ');
+        if (PRECEDENT.test(text) && STOPS.test(text) && !DOC_LINK.test(text)) {
+          unbacked.push(`${f}:${start + 1}: ${block[0].trim().slice(0, 70)}`);
+        }
+        start = i + 1;
+      }
+    }
+    expect(unbacked, `stop-here precedent with no evidence link: ${unbacked.join(' | ')}`).toEqual([]);
   });
 });
 

--- a/apps/benchmark/test/command-files.test.ts
+++ b/apps/benchmark/test/command-files.test.ts
@@ -39,14 +39,18 @@
 //      `results/results.json` in prose, and `CountCollectedGems`'s fan is hand-typed in several
 //      files while being one integer in that same committed JSON. §3 is checked against the
 //      artifact rather than read; nothing before checked it at all.
-//  10. A STOP-HERE PRECEDENT WITH NO EVIDENCE BEHIND IT. A precedent that asks for MORE work is
-//      self-correcting — the round measures, and a wrong precedent costs time. One that tells the
+//  10. A VERDICT THAT CLOSES A ROW, WITH NO EVIDENCE BEHIND IT. A precedent that asks for MORE work
+//      is self-correcting — the round measures, and a wrong precedent costs time. One that tells the
 //      agent to STOP is not: acting on it means not measuring, so the claim is never re-tested and
 //      its reason is never checked. The unmatchable-quirk bullet named a row and linked nothing;
 //      the round sent to re-test it found the classification right and the stated reason too weak
 //      to decide the case, and re-derived the verdict from the compiler. A `docs/` link is the
 //      weakest thing that closes it, and the two checks around it do the rest: `citations.test.ts`
 //      holds the linked page's rows to still existing, the link check below refuses a 404.
+//      The FIRST version of this gate examined 0 of 175 blocks, because it keyed on a word its own
+//      branch had deleted two commits earlier — green with the evidence link removed. Hence the
+//      `examined > 0` assertion and the fixture beside it: a gate whose examined-block count is zero
+//      is not a weak gate, it is no gate, and nothing else in this file would have said so.
 //
 // WHAT IT STILL CANNOT DECIDE, so that nobody reads more into a green run than is there:
 //   - It cannot check that an instruction is TRUE. Only a command run can.
@@ -156,32 +160,85 @@ describe('the two round prompts do not duplicate an instruction', () => {
   });
 });
 
-describe('a precedent that ENDS a round is linked to its evidence', () => {
+describe('a verdict that ENDS a round is linked to its evidence', () => {
+  // WHY THIS SHAPE, and not the obvious one. The first version of this gate keyed on the word
+  // `precedent` — a word the SAME BRANCH's earlier commit had already deleted from the bullet the
+  // gate was written to protect. Replayed over `.claude/commands/*.md` it examined 0 of 175 blocks,
+  // so `unbacked` was `[]` unconditionally: it stayed green with the evidence link DELETED, which
+  // is the single regression it exists to prevent. Three things follow, all encoded below:
+  //   - key on the RULE (a verdict that tells the agent to stop) rather than on one sentence's
+  //     wording;
+  //   - assert the scan EXAMINED something, so that re-wording the outcome list reddens this file
+  //     instead of silently disarming it (#186: a stamp needs a test where it is produced);
+  //   - require a MARKDOWN link, because the sibling "every link in a command file resolves" suite
+  //     below only inspects `](…)` — a bare `docs/foo.md` in running text is an unchecked promise,
+  //     and the first version accepted one.
+  //
   // Blocks are blank-line separated, so a bullet LIST is one block: a link anywhere in the list
-  // that carries the stop satisfies it. That is deliberate — the unit an agent reads is the
+  // that carries the verdict satisfies it. That is deliberate — the unit an agent reads is the
   // outcome list, not the line.
-  const STOPS = /\bstop\b/;
-  const PRECEDENT = /\bprecedent\b/i;
-  const DOC_LINK = /docs\/[\w.-]+\.md/;
+  const STOPS = /\bstops?\b/i;
+  const VERDICT = /\bunmatchable\b|\bquirks?\b/i;
+  const DOC_LINK = /\]\([^)\s]*docs\/[\w.-]+\.md[^)\s]*\)/;
 
-  it('every stop-here precedent in a command file links a docs/ page', () => {
+  /** Blank-line-delimited blocks of `lines` that pronounce a row unmatchable AND tell the agent to
+   *  stop. Returns how many such blocks were examined as well as which lack an evidence link: a
+   *  gate over an empty set is a comment with a test runner attached. */
+  const scanStops = (lines: string[], file = '<fixture>') => {
+    const unbacked: string[] = [];
+    let examined = 0;
+    let start = 0;
+    for (let i = 0; i <= lines.length; i++) {
+      if (i < lines.length && lines[i].trim() !== '') {
+        continue;
+      }
+      const block = lines.slice(start, i);
+      const text = block.join(' ');
+      if (block.length > 0 && VERDICT.test(text) && STOPS.test(text)) {
+        examined++;
+        if (!DOC_LINK.test(text)) {
+          unbacked.push(`${file}:${start + 1}: ${block[0].trim().slice(0, 70)}`);
+        }
+      }
+      start = i + 1;
+    }
+    return { examined, unbacked };
+  };
+
+  it('every unmatchable verdict in a command file links a docs/ page', () => {
+    let examined = 0;
     const unbacked: string[] = [];
     for (const f of commandFiles()) {
-      const lines = read(f);
-      let start = 0;
-      for (let i = 0; i <= lines.length; i++) {
-        if (i < lines.length && lines[i].trim() !== '') {
-          continue;
-        }
-        const block = lines.slice(start, i);
-        const text = block.join(' ');
-        if (PRECEDENT.test(text) && STOPS.test(text) && !DOC_LINK.test(text)) {
-          unbacked.push(`${f}:${start + 1}: ${block[0].trim().slice(0, 70)}`);
-        }
-        start = i + 1;
-      }
+      const found = scanStops(read(f), f);
+      examined += found.examined;
+      unbacked.push(...found.unbacked);
     }
-    expect(unbacked, `stop-here precedent with no evidence link: ${unbacked.join(' | ')}`).toEqual([]);
+    expect(unbacked, `a verdict that stops the round, with no evidence link: ${unbacked.join(' | ')}`).toEqual([]);
+    expect(
+      examined,
+      'this gate examined no block at all, so it passes whatever the command files say. The wording ' +
+        'it keys on has moved: re-point it at the outcome bullet that tells an agent a row is ' +
+        'unmatchable and to stop.',
+    ).toBeGreaterThan(0);
+  });
+
+  it('fires on a verdict whose evidence link is missing, and only then', () => {
+    const bullet = [
+      '- **Unmatchable source quirk** — the original C used a construct no honest recovery would',
+      '  produce. Say so, prove it, and stop.',
+    ];
+    const unlinked = scanStops(bullet);
+    expect(unlinked.examined).toBe(1);
+    expect(unlinked.unbacked).toHaveLength(1);
+    expect(unlinked.unbacked[0]).toContain('<fixture>:1: - **Unmatchable source quirk**');
+    const backed = [
+      bullet[0],
+      `${bullet[1]} The bar is [\`docs/unmatchable-quirks.md\`](../../docs/unmatchable-quirks.md).`,
+    ];
+    expect(scanStops(backed)).toEqual({ examined: 1, unbacked: [] });
+    // A bare path in prose is NOT a link: nothing downstream checks it resolves.
+    const prose = [bullet[0], `${bullet[1]} The bar is docs/unmatchable-quirks.md.`];
+    expect(scanStops(prose).unbacked).toHaveLength(1);
   });
 });
 

--- a/apps/benchmark/test/command-files.test.ts
+++ b/apps/benchmark/test/command-files.test.ts
@@ -40,20 +40,12 @@
 //      files while being one integer in that same committed JSON. §3 is checked against the
 //      artifact rather than read; nothing before checked it at all.
 //  10. A VERDICT THAT CLOSES A ROW, WITH NO EVIDENCE BEHIND IT. A precedent that asks for MORE work
-//      is self-correcting — the round measures, and a wrong precedent costs time. One that tells the
-//      agent to STOP is not: acting on it means not measuring, so the claim is never re-tested and
-//      its reason is never checked. The unmatchable-quirk bullet named a row and linked nothing;
-//      the round sent to re-test it found the classification right and the stated reason too weak
-//      to decide the case, and re-derived the verdict from the compiler. A `docs/` link is the
-//      weakest thing that closes it, and the two checks around it do the rest: `citations.test.ts`
-//      holds the linked page's rows to still existing, the link check below refuses a 404.
-//      The FIRST version of this gate examined 0 of 175 blocks, because it keyed on a word its own
-//      branch had deleted two commits earlier — green with the evidence link removed. The SECOND
-//      examined 2, and one of them was `## Hard rules` — an 18-line block holding the word
-//      `unmatchable` and an unrelated `docs/` link — so the `examined > 0` tripwire added for the
-//      first defeat was held up by a decoy and the gate was green with its subject deleted again.
-//      Hence the pinned inhabitant SET below rather than a count: this gate has twice been a
-//      comment with a test runner attached, and nothing else in this file would have said so.
+//      is self-correcting — the round measures, and a wrong one costs time. One that tells the agent
+//      to STOP is not: acting on it means not measuring, so the claim is never re-tested. A `docs/`
+//      link is the weakest thing that closes that, and the two checks around it do the rest:
+//      `citations.test.ts` holds the linked page's rows to still existing, the link check below
+//      refuses a 404. What the gate protects is pinned as a named SET of verdict bullets, because a
+//      count of them is satisfied by any block that happens to carry the words.
 //
 // WHAT IT STILL CANNOT DECIDE, so that nobody reads more into a green run than is there:
 //   - It cannot check that an instruction is TRUE. Only a command run can.
@@ -164,29 +156,26 @@ describe('the two round prompts do not duplicate an instruction', () => {
 });
 
 describe('a verdict that ENDS a round is linked to its evidence', () => {
-  // WHY THIS SHAPE, and not either of the two obvious ones. This gate has now been disarmed twice
-  // by its own corpus, and both defeats are encoded below.
+  // WHY THIS SHAPE. Three choices carry the gate, and each is what keeps it from passing over a
+  // corpus it is not really reading:
   //
-  //   DEFEAT 1 — the wrong KEY. The first version keyed on the word `precedent`, which the SAME
-  //   BRANCH's earlier commit had already deleted from the bullet the gate protects. It examined 0
-  //   of 175 blocks, so `unbacked` was `[]` unconditionally: green with the evidence link DELETED.
-  //   Fix: key on the RULE (a verdict that tells the agent to stop), require a MARKDOWN link
-  //   (the sibling link-resolution suite below only inspects `](…)`, so a bare `docs/foo.md` in
-  //   running text is an unchecked promise), and assert the scan examined something.
+  //   The KEY is the RULE — a verdict that tells the agent to stop — not any one word a prompt
+  //   happens to spell it with today, which an edit to the protected bullet also deletes.
   //
-  //   DEFEAT 2 — the wrong UNIT, which then propped up the count from defeat 1. Blocks were
-  //   blank-line delimited, so `## Hard rules`' five numbered items were ONE block: it carries the
-  //   word `unmatchable` (rule 4) and a `docs/measurement-discipline.md` link (rule 5), which has
-  //   nothing to do with any verdict. That decoy satisfied `examined > 0` on its own, so rewording
-  //   the Phase-1 outcome bullet and deleting its link — the exact regression — was green again.
-  //   Three independent existentials over an 18-line paragraph is not a rule about a verdict.
+  //   The UNIT is the BULLET: a top-level `-`/`N.` item plus its continuation lines. A blank-line
+  //   block is too coarse — `## Hard rules`' five numbered items are one block, and its rule 4
+  //   carries `unmatchable` while its rule 5 links `docs/measurement-discipline.md`, so an
+  //   unrelated neighbour would back a verdict that links nothing. Three independent existentials
+  //   over an 18-line paragraph is not a rule about a verdict.
   //
-  // Hence: the unit is the BULLET (a top-level `-`/`N.` item plus its continuation lines), the link
-  // must be in the bullet that carries the verdict, and the assertion on the corpus is the pinned
-  // INHABITANT SET below rather than a count. A count can be held up by anything; a named set
-  // cannot. `registerBacked` is a third, non-redundant check: re-pointing every verdict at some
-  // other `docs/` page keeps the set intact and the unbacked list empty while leaving the register
-  // itself unreferenced (#186: a stamp needs a test where it is produced).
+  //   The ASSERTION is the pinned inhabitant SET below, not a count: a count is satisfied by any
+  //   block carrying the words, a named set only by the bullets the gate exists for.
+  //
+  // The link must be a MARKDOWN link, because the sibling link-resolution suite below only inspects
+  // `](…)` — a bare `docs/foo.md` in running text is an unchecked promise. `registerBacked` is a
+  // third, non-redundant check: re-pointing every verdict at some other `docs/` page keeps the set
+  // intact and the unbacked list empty while leaving the register itself unreferenced (#186: a
+  // stamp needs a test where it is produced).
   const STOPS = /\bstops?\b/i;
   const VERDICT = /\bunmatchable\b|\bquirks?\b/i;
   const DOC_LINK = /\]\([^)\s]*docs\/[\w.-]+\.md[^)\s]*\)/;
@@ -302,10 +291,10 @@ describe('a verdict that ENDS a round is linked to its evidence', () => {
     expect(scanStops(elsewhere).registerBacked).toBe(0);
   });
 
-  it('does not let a neighbouring rule back a verdict — the defeat-2 shape', () => {
+  it('does not let a neighbouring rule back a verdict', () => {
     // `## Hard rules` verbatim in shape: one blank-line block, five numbered items, the verdict in
-    // item 2 and an unrelated docs link in item 3. Under the old block unit this scanned as ONE
-    // backed block — examined 1, unbacked 0, and the count kept the whole gate alive.
+    // item 2 and an unrelated docs link in item 3. Scanned by blank-line block this is ONE backed
+    // block — examined 1, unbacked 0 — which is the shape the bullet unit exists to split.
     const rules = [
       '1. **Never trade a loud failure for a silent wrong answer.** Every new transform must state',
       '   the condition under which it refuses.',
@@ -324,11 +313,10 @@ describe('a verdict that ENDS a round is linked to its evidence', () => {
 
 describe('the unmatchable register is falsified by the artifact', () => {
   // The register says of itself that "an entry here closes a row to future rounds and that is
-  // exactly the kind of claim that rots unwatched", and it shipped with no gate — while the cost
-  // table 170 lines above has one. A verdict does not rot on a CLOCK the way a cost figure does; it
-  // rots the instant somebody matches the row. `results.json` knows, and `citations.test.ts` already
-  // holds the ids in this page to rows that exist, so the only thing missing is the one assertion
-  // the entry's own falsification condition names.
+  // exactly the kind of claim that rots unwatched". It does not rot on a CLOCK the way the cost
+  // figures gated below do; it rots the instant somebody matches the row. `results.json` knows, and
+  // `citations.test.ts` already holds the ids in this page to rows that exist, so what is left is
+  // the one assertion the entry's own falsification condition names.
   const REGISTER = join(DOCS_DIR, 'unmatchable-quirks.md');
   const ROW_ID = /^\|\s*`([\w.-]+:[\w.-]+:[\w.-]+)`\s*\|/;
   const SECTION = '## The register';
@@ -371,9 +359,9 @@ describe('the unmatchable register is falsified by the artifact', () => {
       // `citations.test.ts` also resolves this id, and this assertion is KEPT anyway rather than
       // deferred to it: an id that stops resolving leaves `row?.asmlift?.outcome` undefined, which
       // is not `'match'`, so without this line the check below passes over an empty set and this
-      // gate is vacuous — the §10 defect, in the gate written for §10. The duplication is with a
-      // suite whose coverage of this page is conditional (`docs` being in its `SCANNED` list) and
-      // whose failure message is about citations, not about a closed row.
+      // gate is vacuous. The duplication is with a suite whose coverage of this page is conditional
+      // (`docs` being in its `SCANNED` list) and whose failure message is about citations, not
+      // about a closed row.
       expect(row, `${REGISTER} closes ${id}, which is not a row in the committed results.json`).toBeDefined();
       if (row?.asmlift?.outcome === 'match') {
         falsified.push(id);

--- a/apps/benchmark/test/repro.test.ts
+++ b/apps/benchmark/test/repro.test.ts
@@ -132,10 +132,9 @@ describe('bench repro — the script it hands over', () => {
 });
 
 describe('bench repro — a broken MACHINE is not a non-matching row', () => {
-  // The one fragile part of the diagnosis is a regex over a shell error string, and it was pinned
-  // by nothing: the round that added it wrote 139 test lines about the command FILES and none about
-  // this. Its comment also called the bin link "the one cause that is not the row", and the second
-  // cause was the first thing a reviewer hit in a fresh worktree wired the documented way.
+  // The fragile part of the diagnosis is a regex over a shell error string — three spellings for
+  // one missing binary, and a message format for the toolchain. A cause it stops recognising goes
+  // back to reading as a row that simply does not match, which is silent.
   test('names the missing CLI bin, whichever way the shell spells it', () => {
     for (const line of [
       'bash: /wt/node_modules/.bin/asmlift: No such file or directory',

--- a/apps/benchmark/test/repro.test.ts
+++ b/apps/benchmark/test/repro.test.ts
@@ -14,7 +14,7 @@ import { join, relative } from 'node:path';
 import { afterAll, describe, expect, test } from 'vitest';
 
 import { REPO_ROOT } from '../src/config';
-import { repro, reproDirFor } from '../src/report/repro';
+import { repro, reproDirFor, setupRefusal } from '../src/report/repro';
 import { LOCAL_SCRATCH_DIR } from '../src/run/preflight';
 
 const results = (JSON.parse(readFileSync(join(import.meta.dirname, '../results/results.json'), 'utf8')) as BenchOutput)
@@ -99,6 +99,17 @@ describe('bench repro — the script it hands over', () => {
     expect(existsSync(join(dir, 'repro-asmlift.sh'))).toBe(false);
   });
 
+  test("--tool m2c states M2C's published figure, not asmlift's", async () => {
+    // These differ on this row — asmlift 5/8, m2c 6/7 — so printing the asmlift one beside the
+    // m2c script hands the reader the wrong thing to compare out.c against.
+    const r = await run(id, { out: scratch(), tool: 'm2c' });
+    expect(fn.m2c.score).not.toBe(fn.asmlift.score);
+    expect(r.out).toContain(`m2c ${fn.m2c.outcome} ${fn.m2c.score}/${fn.m2c.maxScore} as published`);
+    expect(r.out).not.toContain(`${fn.asmlift.score}/${fn.asmlift.maxScore}`);
+    // and no symbol-map line: the map is asmlift's input, m2c's channel is the --context header
+    expect(r.out).not.toContain('symbol map from');
+  });
+
   test('the default out dir is one a bench run will not refuse the round for', () => {
     // The script's step 1 is `bench target … --out "$PWD"`, so run at the repo root it leaves
     // decomp.yaml/ctx.i/in.asm/proto.json untracked there — which `run/preflight.ts` refuses a
@@ -117,5 +128,38 @@ describe('bench repro — the script it hands over', () => {
     // an id is harness-generated, but this composes a filesystem path out of one, so a separator
     // or a traversal in it must land in the name and not in the path
     expect(relative(join(REPO_ROOT, '.local', 'repro'), reproDirFor('a/../b:c:d'))).toBe('a_.._b_c_d');
+  });
+});
+
+describe('bench repro — a broken MACHINE is not a non-matching row', () => {
+  // The one fragile part of the diagnosis is a regex over a shell error string, and it was pinned
+  // by nothing: the round that added it wrote 139 test lines about the command FILES and none about
+  // this. Its comment also called the bin link "the one cause that is not the row", and the second
+  // cause was the first thing a reviewer hit in a fresh worktree wired the documented way.
+  test('names the missing CLI bin, whichever way the shell spells it', () => {
+    for (const line of [
+      'bash: /wt/node_modules/.bin/asmlift: No such file or directory',
+      'bash: /wt/node_modules/.bin/asmlift: command not found',
+      '/wt/repro.sh: line 40: /wt/node_modules/.bin/asmlift: cannot execute: required file not found',
+    ]) {
+      expect(setupRefusal(line), line).toMatch(/asmlift bin is missing/);
+    }
+  });
+
+  test('names an uninstalled pinned toolchain, and names WHICH', () => {
+    const msg = setupRefusal(
+      "Error: cannot run '/private/tmp/transmuter/compilers/agbcc/agbcc' (ENOENT) — not installed, or its pinned-toolchain path is wrong",
+    );
+    expect(msg).toMatch(/not installed on this machine, not the row/);
+    expect(msg).toContain('/private/tmp/transmuter/compilers/agbcc/agbcc');
+  });
+
+  test('says nothing about a run that merely did not match', () => {
+    expect(setupRefusal('')).toBeUndefined();
+    expect(setupRefusal('[ranked] 1 candidate(s) scored, 0 dropped, best unsigned: 5/8')).toBeUndefined();
+    // the words are there but the shape is not: a comment quoting the recovery is not the failure
+    expect(
+      setupRefusal('# run `pnpm --filter @asmlift/cli build` if node_modules/.bin/asmlift is absent'),
+    ).toBeUndefined();
   });
 });

--- a/docs/unmatchable-quirks.md
+++ b/docs/unmatchable-quirks.md
@@ -1,0 +1,176 @@
+# The unmatchable-quirk register
+
+A row is **unmatchable by source quirk** when the original C contains a construct that (a) changes
+the bytes the compiler emits and (b) leaves no evidence of itself in those bytes. Then no recovery
+from the object can produce it, because the object does not know it happened, and a decompiler that
+emitted it anyway would be guessing at the source rather than reading the machine.
+
+`/match-function`'s Phase 1 lists that as one of its four outcomes and tells the agent to **stop**.
+This file is what "stop" is allowed to rest on. A verdict here is not an opinion about how likely a
+spelling is; it is two measurements, and both are compiler runs:
+
+- **NECESSARY** — a sweep of honest spellings, none of which reaches the target bytes.
+- **INVISIBLE** — the construct's own effect is absent from the target instruction stream, so the
+  lift has nothing to recover it from.
+
+A verdict without both halves is a hypothesis. The entry says the date it was taken and the asmlift
+commit it was taken at, because an entry here closes a row to future rounds and that is exactly the
+kind of claim that rots unwatched.
+
+**How an entry is falsified:** find one honest spelling that reaches the target bytes. The recipe
+below is the one to run, and a falsified entry is deleted, not annotated.
+
+## The register
+
+| row                  | verdict taken | asmlift | the quirk                                        |
+| -------------------- | ------------- | ------- | ------------------------------------------------ |
+| `kleod:StrCpy:agbcc` | 2026-09-12    | 2a626ac | a redundant re-read the compiler then eliminates |
+
+## The recipe
+
+Both halves are "compile a C file the way the row's harness compiles a candidate, and compare the
+function's bytes with the target's". One command hands you the target and the exact compile line:
+
+```sh
+pnpm bench target <row-id> --out <dir>      # writes target.o, decomp.yaml, ctx.i
+```
+
+`decomp.yaml`'s `tools.asmlift.compiler` is the compile command, with `{{inputPath}}` the candidate
+`.c` and `{{outputPath}}` the `.o`; `ctx.i` is the prelude it is prepended to. Run it over each
+spelling and compare the function's own bytes — not the whole object, whose inter-function pad
+differs between the harness's assembly path and a hand one (`c046` against `0000` on this row):
+
+```sh
+arm-none-eabi-objcopy -O binary --only-section=.text <o> - | xxd -p
+```
+
+The spelling asmlift actually publishes comes from `pnpm bench fan <row-id> --show best`, so the
+first thing to try is always **that source plus the candidate construct**: if the row is a quirk
+row, the delta is usually one line.
+
+## `kleod:StrCpy:agbcc`
+
+Taken 2026-09-12 at asmlift `2a626ac`. Every number below is from that day.
+
+### The row
+
+```
+pnpm bench baseline StrCpy
+kleod:StrCpy:agbcc  asmlift=nonmatch 5/8  m2c=nonmatch 6/7  fan=1 rank=3.6s
+```
+
+The fan is **1**: asmlift considers exactly one spelling for this function, so there is no ranking
+question here, only a generation one. All three vehicles agreed on the day (`docs/ranked-repro.md`'s
+table is still the one that measures): `pnpm bench fan kleod:StrCpy:agbcc` and
+`pnpm bench repro kleod:StrCpy:agbcc --run` both `unsigned: 5/8`, the project-checkout command
+`unsigned: 6/9`.
+
+The target is seven Thumb instructions, `0a78 0270 0130 0131 002a f9d1 7047`:
+
+```
+ldrb r2, [r1]    strb r2, [r0]    adds r0, #1    adds r1, #1    cmp r2, #0    bne .-10    bx lr
+```
+
+The published source is `void StrCpy(u8 *dst, u8 *src)` with `u32 c` and a loop body that reads
+`*src` into `c`, stores it through `dst`, **reads `*src` into `c` a second time**, then advances
+both pointers.
+
+### The residual is one instruction, not three
+
+The artifact's breakdown is `insert 1, delete 0, replace 0, opMismatch 0, argMismatch 4`. asmlift's
+candidate is the same seven operations in the same order plus one extra register copy at the top:
+
+```
+adds r2, r0, #0   ← the insert
+ldrb r0, [r1]     strb r0, [r2]    adds r2, #1    adds r1, #1    cmp r0, #0    bne .-10    bx lr
+```
+
+The four `argMismatch`es are that copy's consequence: `c` lives in `r0` and `dst` in `r2`, the
+target's assignment the other way round. So the whole 5/8 is **one register-allocation decision**,
+not three independent gaps — which answers the obvious second question ("part of the residual must
+be a real capability gap") with a no.
+
+### The allocation decision is not asmlift's to make
+
+The tempting theory is that asmlift's own spelling causes it: the candidate opens `v1 = a1; v2 = a0;`
+— copies of the parameters into locals — and the extra instruction is a register copy. It is wrong,
+and the measurement that refutes it is cheap. Hand-write the honest spelling with **no** local
+copies, mutating the parameters directly:
+
+```c
+void StrCpy(u8 *dst, u8 *src) { u32 c; do { c = *src; *dst = c; dst++; src++; } while (c != 0); }
+```
+
+Its object is **byte-identical to asmlift's candidate's** — `cmp` on the whole `.o` file, not just
+the text. The local copies cost nothing; agbcc coalesces them and then makes the same choice. In the
+other direction, adding the copies to the published source (`u8 *dst = d0; u8 *src = s0;` with the
+re-read kept) still matches. The copies are free in both worlds; the re-read is the whole difference.
+
+### NECESSARY: 252 honest spellings, none of them reach the bytes
+
+A sweep over six types for `c` (`u8`, `u16`, `u32`, `s32`, `int`, `unsigned int`) × fourteen loop
+bodies carrying no redundant read (`do`/`while (1)`/`for (;;)`/`goto`, pre- and post-increment,
+fused `*dst++ = *src++`, both increment orders, `c != 0` and `c` and `c > 0` as the test) × three
+signatures (parameters mutated directly, parameters copied into locals in either order) — **252
+spellings, 252 compiles, 0 reaching the target bytes.** Every one of them emits the same eight
+instructions with the same leading copy.
+
+The control is the same sweep with the re-read restored: 48 spellings, **24 matching byte-exactly**
+— every 32-bit type, in all three loop forms, parameters or locals. The two arms of the sweep
+differ in one statement and in 24 outcomes.
+
+The sharpest form of the same measurement: take `bench fan --show best`'s published candidate
+verbatim, add one line `v0 = *v1;` after `*v2 = v0;`, and it compiles to the target bytes exactly.
+One line, and it is a line with nothing behind it in the object.
+
+### INVISIBLE: the second read is not in the machine code
+
+`ldrb` appears **once** in the target. agbcc eliminates the second read as a common subexpression —
+storing through `dst` does not, to its alias analysis, kill a load of `*src` — and then allocates
+registers on the post-CSE program, where `c`'s extra reference changes which of `r0`/`r2` it wins.
+The load is gone; only its effect on the allocator survives.
+
+So the lift sees one load and the IR holds one load. For asmlift to spell this row it would have to
+emit a memory read the machine demonstrably did not perform, chosen because doing so happens to
+move a register allocation. That is the direct inverse of the rule this repo already enforces in the
+other direction — a read the machine _did_ perform must survive into the spelling, even when the
+value is discarded (#183) — and it is unsound for the same reason: on device memory a fabricated
+read is an extra bus cycle, and nothing in a lifted function proves its pointers are not device
+memory.
+
+It is also a construct with essentially no inhabitants. Over the 252 functions in
+`apps/benchmark/dataset/real`, exactly one — this one — repeats an identical read statement inside
+a single straight-line block at a distance under 24 statements. (The 48 other repeated reads are all
+`af:Skin_Matrix_MulMatrix` recomputing four matrix rows, 24 statements apart, which is arithmetic
+rather than redundancy.)
+
+### What the quirk is NOT
+
+Three near neighbours that do not produce the target, each measured:
+
+- **A dead extra reference.** `c = c;` in the same position: eight instructions. The allocator is
+  not simply counting references to `c`.
+- **The re-read before the store.** `c = *src; c = *src; *dst = c;`: eight instructions. It has to
+  sit after the store.
+- **A re-read of the destination.** `c = *dst;` after the store leaves a real second `ldrb` in the
+  object — agbcc does not forward its own store. That one _is_ visible, so it is a different case
+  and not a quirk at all.
+
+Also measured: `u8`/`u16` for `c` do not match even with the re-read, and swapping `dst++`/`src++`
+under the re-read gives seven instructions with the two `adds` transposed — near, not equal.
+
+### A note on the m2c column
+
+m2c's `6/7` reads better than asmlift's `5/8` and is not: its source drops both pointer increments,
+so it copies one byte forever. It scores better by being two instructions shorter (`delete 2`), on a
+function it did not recover. The comparison is between a correct spelling that is one instruction
+long and an incorrect one that is two short.
+
+### What would change the verdict
+
+A general capability that produced this source from this object. It would have to decide, from
+seven instructions, that the compiler eliminated a load, and re-introduce it — a search over source
+redundancies scored by the compiler, unbounded in the number of places a redundancy could go, with
+one inhabitant in the corpus and no soundness argument for fabricating memory traffic. Nobody should
+build it because this row wants it. If it arrives for another reason, delete this entry and re-run
+the sweep.

--- a/docs/unmatchable-quirks.md
+++ b/docs/unmatchable-quirks.md
@@ -37,16 +37,34 @@ pnpm bench target <row-id> --out <dir>      # writes target.o, decomp.yaml, ctx.
 
 `decomp.yaml`'s `tools.asmlift.compiler` is the compile command, with `{{inputPath}}` the candidate
 `.c` and `{{outputPath}}` the `.o`; `ctx.i` is the prelude it is prepended to. Run it over each
-spelling and compare the function's own bytes — not the whole object, whose inter-function pad
-differs between the harness's assembly path and a hand one (`c046` against `0000` on this row):
+spelling and compare **the function's own bytes, cut to the symbol's size**:
 
 ```sh
-arm-none-eabi-objcopy -O binary --only-section=.text <o> - | xxd -p
+arm-none-eabi-objcopy -O binary --only-section=.text <o> /tmp/f.bin
+sz=$(arm-none-eabi-nm -S <o> | awk '$4=="<Symbol>"{print $2}')
+xxd -p -l $((0x$sz)) /tmp/f.bin
 ```
 
+Two traps, both measured on 2026-09-12 on this machine's toolchain (Arm GNU Toolchain 14.2.Rel1,
+`objcopy` 2.43.1 — the one the row's harness uses), and both of which make the comparison **lie**
+rather than fail:
+
+- **Never write `… <o> - | xxd -p`.** This `objcopy` does not honour `-` as stdout. It prints
+  nothing, exits **0**, and writes a file literally named `-` into the current directory. So every
+  comparison becomes `"" == ""`: every spelling "falsifies" the entry, on the one path this page
+  offers for overturning a verdict that closes a row. The stray file also leaves `?? -` in
+  `git status`, which is the mid-run-dirty condition that voids a bench run from the worktree an
+  agent following this page is standing in.
+- **`--only-section=.text` is not the function.** The inter-function pad lives inside `.text` and
+  differs between the harness's assembly path and a hand one. On this row the target's `.text` is
+  `0a78027001300131002af9d17047`**`0000`** while the hand-compiled spelling that is byte-identical
+  to it carries the same fourteen bytes followed by **`c046`**. Cut to the symbol's size
+  (`0000000e` here) and they are equal. Without the cut, the one spelling that _does_ match is the
+  one the recipe reports as a mismatch.
+
 The spelling asmlift actually publishes comes from `pnpm bench fan <row-id> --show best`, so the
-first thing to try is always **that source plus the candidate construct**: if the row is a quirk
-row, the delta is usually one line.
+first thing to try is always **that `candidate` plus the construct**: if the row is a quirk row, the
+delta is usually one line.
 
 ## `kleod:StrCpy:agbcc`
 
@@ -71,9 +89,12 @@ The target is seven Thumb instructions, `0a78 0270 0130 0131 002a f9d1 7047`:
 ldrb r2, [r1]    strb r2, [r0]    adds r0, #1    adds r1, #1    cmp r2, #0    bne .-10    bx lr
 ```
 
-The published source is `void StrCpy(u8 *dst, u8 *src)` with `u32 c` and a loop body that reads
-`*src` into `c`, stores it through `dst`, **reads `*src` into `c` a second time**, then advances
-both pointers.
+Two sources are in play below and `results.json` already names them, so this page uses its words
+rather than "published" for both. The **`refSource`** — the kleod ground truth — is
+`void StrCpy(u8 *dst, u8 *src)` with `u32 c` and a loop body that reads `*src` into `c`, stores it
+through `dst`, **reads `*src` into `c` a second time**, then advances both pointers. The
+**`candidate`** is what asmlift emits (`pnpm bench fan --show best`), which declares `s32 v0` and
+carries no second read. They differ by exactly the one line this page is about.
 
 ### The residual is one instruction, not three
 
@@ -103,7 +124,7 @@ void StrCpy(u8 *dst, u8 *src) { u32 c; do { c = *src; *dst = c; dst++; src++; } 
 
 Its object is **byte-identical to asmlift's candidate's** — `cmp` on the whole `.o` file, not just
 the text. The local copies cost nothing; agbcc coalesces them and then makes the same choice. In the
-other direction, adding the copies to the published source (`u8 *dst = d0; u8 *src = s0;` with the
+other direction, adding the copies to the `refSource` (`u8 *dst = d0; u8 *src = s0;` with the
 re-read kept) still matches. The copies are free in both worlds; the re-read is the whole difference.
 
 ### NECESSARY: 252 honest spellings, none of them reach the bytes
@@ -119,9 +140,10 @@ The control is the same sweep with the re-read restored: 48 spellings, **24 matc
 — every 32-bit type, in all three loop forms, parameters or locals. The two arms of the sweep
 differ in one statement and in 24 outcomes.
 
-The sharpest form of the same measurement: take `bench fan --show best`'s published candidate
-verbatim, add one line `v0 = *v1;` after `*v2 = v0;`, and it compiles to the target bytes exactly.
-One line, and it is a line with nothing behind it in the object.
+The sharpest form of the same measurement: take the `candidate` verbatim, add one line `v0 = *v1;`
+after `*v2 = v0;`, and it compiles to `0a78027001300131002af9d17047` — the target's fourteen bytes
+exactly (re-taken 2026-09-12 with the symbol-size cut above). One line, and it is a line with
+nothing behind it in the object.
 
 ### INVISIBLE: the second read is not in the machine code
 
@@ -138,11 +160,42 @@ value is discarded (#183) — and it is unsound for the same reason: on device m
 read is an extra bus cycle, and nothing in a lifted function proves its pointers are not device
 memory.
 
-It is also a construct with essentially no inhabitants. Over the 252 functions in
-`apps/benchmark/dataset/real`, exactly one — this one — repeats an identical read statement inside
-a single straight-line block at a distance under 24 statements. (The 48 other repeated reads are all
-`af:Skin_Matrix_MulMatrix` recomputing four matrix rows, 24 statements apart, which is arithmetic
-rather than redundancy.)
+### The inhabitant count, and what it is a count OF
+
+The construct also has almost no inhabitants — but the predicate has to be the CLASS, not a proxy
+for it, and the first version of this section stated a proxy. Say the class outright: **a repeated
+identical read statement, inside one straight-line run, with no intervening call.** Over the 252
+functions in `apps/benchmark/dataset/real` (6 projects × 42) it has **one** inhabitant, this row.
+Re-run it — split each `funcC` into straight-line runs at every brace and control keyword, split
+those into statements, and report a statement that (a) repeats verbatim, (b) has a memory access on
+its right-hand side, and (c) has no `ident(` between the two occurrences.
+
+Dropping clause (c) — which is what the earlier wording did, under a distance bound of "under 24
+statements" — returns **two**, and lifting the distance bound too returns **three**. Both extras are
+near-misses, and each is excluded by a measurement rather than by the bound (taken 2026-09-12):
+
+| near-miss                                  | repeats                                   | why it is not an inhabitant                                                                                                                                                                                                             |
+| ------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sa3:sub_806132C` (4 repeats, 15–16 apart) | `s->x = TO_WORLD_POS_RAW(…)` and its twin | A call sits between them, and agbcc does **not** CSE a load across a call: `*p = g; f(); *q = g;` keeps two `ldr` of `g` (`2168` … `2068`), while `*p = g; *q = g;` keeps one (`1268`, two `str`). The repeat is VISIBLE in the object. |
+| `af:Skin_Matrix_MulMatrix` (48, 24 apart)  | `cx = mfB->xx;` and its fifteen siblings  | An `ido7.1` row, not agbcc, and ido7.1 keeps both loads: `cx = b->xx; d->xx = cx*cx; cx = b->xx; d->yx = cx*cx;` disassembles to **two** `lwc1 $f0,0(a0)`, the single-read form to one. VISIBLE again.                                  |
+
+The bound "under 24" was doing the work of the second row and was set at exactly that row's
+distance, which is how a census stops meaning anything. It is gone.
+
+**And the clause that looks like it belongs here does not.** "No intervening may-aliasing store" is
+the obvious third condition, and it is wrong for agbcc: `c = p->a; q->b = c; c = p->a;` compiles
+byte-identically to the single-read form (`0068486008607047`, one `ldr`) even though `p` and `q` are
+the same struct type. agbcc CSEs straight through a may-aliasing store — which is precisely why this
+row is an inhabitant at all, since `*dst = c` sits between its two reads of `*src`.
+
+**The count is over READS; the Phase-1 bullet it backs is wider.** `/match-function` writes the
+outcome as "a redundant expression the compiler then eliminates", and a redundant _store_ is one
+too. `sa3:sub_804D360:agbcc` (`outcome: nonmatch`) has `s->qAnimDelay = 0;` twice in a row in its
+`funcC`, and that duplicate really is invisible: `s->a=1; s->b=0; s->b=0; s->a=2;` and the same
+without the repeat both compile to `00214160022101607047`. Nobody has shown that duplicate is what
+makes that row nonmatch — it is a far larger function with a fan of 8 — so it is not a second entry
+in this register. But the inhabitant count above buys "essentially no inhabitants" for repeated
+READS only, and should not be cited for the wider class.
 
 ### What the quirk is NOT
 
@@ -159,6 +212,19 @@ Three near neighbours that do not produce the target, each measured:
 Also measured: `u8`/`u16` for `c` do not match even with the re-read, and swapping `dst++`/`src++`
 under the re-read gives seven instructions with the two `adds` transposed — near, not equal.
 
+**And the extra reference is not the only thing that moves `c` into `r2`.** A test-at-top loop with
+no redundant read anywhere already produces the target's register assignment:
+
+```c
+void StrCpy(u8 *dst, u8 *src) { u32 c; while ((c = *src) != 0) { *dst = c; dst++; src++; } *dst = c; }
+→ 02e0 0270 0130 0131 0a78 002a f9d1 0270 7047
+```
+
+`0a78` is `ldrb r2, [r1]` and `002a` is `cmp r2, #0` — `c` in `r2`, `dst` in `r0`, exactly the
+target's assignment, with no `021c` copy. Only the rotation and the extra tail store are wrong. So
+the allocation flip is a function of loop SHAPE as well as of the extra reference, and loop shape is
+asmlift's business in a way that fabricating a load is not.
+
 ### A note on the m2c column
 
 m2c's `6/7` reads better than asmlift's `5/8` and is not: its source drops both pointer increments,
@@ -168,9 +234,21 @@ long and an incorrect one that is two short.
 
 ### What would change the verdict
 
-A general capability that produced this source from this object. It would have to decide, from
-seven instructions, that the compiler eliminated a load, and re-introduce it — a search over source
-redundancies scored by the compiler, unbounded in the number of places a redundancy could go, with
-one inhabitant in the corpus and no soundness argument for fabricating memory traffic. Nobody should
-build it because this row wants it. If it arrives for another reason, delete this entry and re-run
-the sweep.
+Two directions, and they are not equally unsound.
+
+**The one this entry rules out.** A general capability that produced this source from this object
+would have to decide, from seven instructions, that the compiler eliminated a load, and re-introduce
+it — a search over source redundancies scored by the compiler, unbounded in the number of places a
+redundancy could go, with one inhabitant in the corpus and no soundness argument for fabricating
+memory traffic. Nobody should build it because this row wants it.
+
+**The one a falsifier should push on first.** Loop rotation, per the `while ((c = *src) != 0)`
+probe above: that spelling needs no fabricated read and already wins the target's register
+assignment. Everything tried so far still costs more than it saves — twelve rotated and mid-exit
+forms (`for(;;){…;if(!c)break;}`, `while(1){…;if(c==0)return;}` and `goto`, each in
+`u32`/`s32`/`int`/`u8`) all re-emit the leading `021c` and give
+`021c08781070013201310028f9d17047`, and the test-at-top form above pays an extra tail store — but
+this is the axis where a falsification would not require the unsound part, and it is squarely
+asmlift's business.
+
+If either arrives, delete this entry and re-run the sweep.

--- a/docs/unmatchable-quirks.md
+++ b/docs/unmatchable-quirks.md
@@ -171,25 +171,23 @@ memory.
 
 ### The inhabitant count, and what it is a count OF
 
-The construct also has almost no inhabitants — but the predicate has to be the CLASS, not a proxy
-for it, and the first version of this section stated a proxy. Say the class outright: **a repeated
-identical read statement, inside one straight-line run, with no intervening call.** Over the 252
+The construct also has almost no inhabitants — but the predicate has to be the CLASS and not a proxy
+for it, so say the class outright: **a repeated identical read statement, inside one straight-line
+run, with no intervening call.** Over the 252
 functions in `apps/benchmark/dataset/real` (6 projects × 42) it has **one** inhabitant, this row.
 Re-run it — split each `funcC` into straight-line runs at every brace and control keyword, split
 those into statements, and report a statement that (a) repeats verbatim, (b) has a memory access on
 its right-hand side, and (c) has no `ident(` between the two occurrences.
 
-Dropping clause (c) — which is what the earlier wording did, under a distance bound of "under 24
-statements" — returns **two**, and lifting the distance bound too returns **three**. Both extras are
-near-misses, and each is excluded by a measurement rather than by the bound (taken 2026-09-12):
+Dropping clause (c) returns **two**; dropping it and admitting repeats at any distance returns
+**three**. Both extras are near-misses, and each is excluded by a measurement rather than by a
+distance bound — a bound tuned to the nearest non-inhabitant is how a census stops meaning anything,
+so there is none here (taken 2026-09-12):
 
 | near-miss                                  | repeats                                   | why it is not an inhabitant                                                                                                                                                                                                             |
 | ------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `sa3:sub_806132C` (4 repeats, 15–16 apart) | `s->x = TO_WORLD_POS_RAW(…)` and its twin | A call sits between them, and agbcc does **not** CSE a load across a call: `*p = g; f(); *q = g;` keeps two `ldr` of `g` (`2168` … `2068`), while `*p = g; *q = g;` keeps one (`1268`, two `str`). The repeat is VISIBLE in the object. |
 | `af:Skin_Matrix_MulMatrix` (48, 24 apart)  | `cx = mfB->xx;` and its fifteen siblings  | An `ido7.1` row, not agbcc, and ido7.1 keeps both loads: `cx = b->xx; d->xx = cx*cx; cx = b->xx; d->yx = cx*cx;` disassembles to **two** `lwc1 $f0,0(a0)`, the single-read form to one. VISIBLE again.                                  |
-
-The bound "under 24" was doing the work of the second row and was set at exactly that row's
-distance, which is how a census stops meaning anything. It is gone.
 
 **And the clause that looks like it belongs here does not.** "No intervening may-aliasing store" is
 the obvious third condition, and it is wrong for agbcc: `c = p->a; q->b = c; c = p->a;` compiles

--- a/docs/unmatchable-quirks.md
+++ b/docs/unmatchable-quirks.md
@@ -41,13 +41,14 @@ spelling and compare **the function's own bytes, cut to the symbol's size**:
 
 ```sh
 arm-none-eabi-objcopy -O binary --only-section=.text <o> /tmp/f.bin
+off=$(arm-none-eabi-nm -S <o> | awk '$4=="<Symbol>"{print $1}')
 sz=$(arm-none-eabi-nm -S <o> | awk '$4=="<Symbol>"{print $2}')
-xxd -p -l $((0x$sz)) /tmp/f.bin
+xxd -p -s $((0x$off)) -l $((0x$sz)) /tmp/f.bin
 ```
 
-Two traps, both measured on 2026-09-12 on this machine's toolchain (Arm GNU Toolchain 14.2.Rel1,
-`objcopy` 2.43.1 — the one the row's harness uses), and both of which make the comparison **lie**
-rather than fail:
+Three traps, all measured on 2026-09-12 on this machine's toolchain (Arm GNU Toolchain 14.2.Rel1,
+`objcopy` 2.43.1 — the one the row's harness uses), and all three of which make the comparison
+**lie** rather than fail:
 
 - **Never write `… <o> - | xxd -p`.** This `objcopy` does not honour `-` as stdout. It prints
   nothing, exits **0**, and writes a file literally named `-` into the current directory. So every
@@ -61,6 +62,14 @@ rather than fail:
   to it carries the same fourteen bytes followed by **`c046`**. Cut to the symbol's size
   (`0000000e` here) and they are equal. Without the cut, the one spelling that _does_ match is the
   one the recipe reports as a mismatch.
+- **Cut from the symbol's OFFSET, not from byte 0.** `-l $sz` alone is only the function when the
+  symbol is first in `.text`, which it is for a one-function candidate file and is not the moment
+  the file declares a helper above it. Compiling `void Pad(u8*, u8*)` ahead of the same `StrCpy`
+  spelling puts it at `nm -S` value `00000008`, and the offset-less cut returns
+  `0978017070470000021c087810700132` — `Pad`, its alignment pad, and the first eight bytes of the
+  function — against `021c08781070013201310028f9d17047` for the real one. Every spelling in such a
+  file then reports "does not reach the target bytes", which is the NECESSARY half passing for the
+  wrong reason: a sweep that proves nothing, reported as a verdict that closes a row.
 
 The spelling asmlift actually publishes comes from `pnpm bench fan <row-id> --show best`, so the
 first thing to try is always **that `candidate` plus the construct**: if the row is a quirk row, the


### PR DESCRIPTION
`/match-function StrCpy` ran to a **measured null**: `kleod:StrCpy:agbcc` stays `nonmatch 5/8`, no
decompiler code changed (`git diff origin/main...HEAD -- packages apps/benchmark/dataset` is empty),
and what ships is the evidence that the row is closed plus the gates that stop the next round from
re-opening it on prose alone.

## The verdict, and what was verified before writing it down

Baseline, taken with `pnpm bench baseline StrCpy` (2.1 s):

    kleod:StrCpy:agbcc  asmlift=nonmatch 5/8  m2c=nonmatch 6/7  fan=1 rank=3.6s
    baseline: CURRENT — nothing since 2a626ac5 changes what it measures

**fan = 1.** The whole candidate fan for the row is one spelling, so there is no ranking question,
only a generation one. The artifact breakdown is `insert 1, delete 0, replace 0, opMismatch 0,
argMismatch 4` — one allocation decision, not three gaps.

What the compiler said, every number taken by compiling against `pnpm bench target`'s `target.o`:

- **The param-copy theory is wrong.** `void StrCpy(u8*dst,u8*src){u32 c; do{c=*src;*dst=c;dst++;src++;}while(c);}`
  — no locals at all — compiles **byte-identical** to asmlift's candidate. Nobody should build a
  param-copy pruner for this row.
- **The re-read is necessary**: 252 quirk-free spellings (6 types × 14 loop bodies × 3 signatures)
  reach the target bytes **0** times; the same shapes *with* the source re-read, 48 spellings, are
  byte-exact **24** times. A later sweep added 12 rotated/mid-exit spellings (`for(;;){…break;}`,
  `while(1){…return;}`, `goto`, in `u32`/`s32`/`int`/`u8`) — all
  `021c08781070013201310028f9d17047`, none reaching the target.
- **Sharpest form**: `bench fan --show best`'s candidate plus one line `v0 = *v1;` is the target
  bytes exactly.
- **Invisible**: the target holds ONE `ldrb`. agbcc CSEs the second read away and allocates on the
  post-CSE program; asmlift's IR holds one load, so there is nothing to recover. Building the lever
  would mean fabricating a memory read the machine did not perform — the direct inverse of #183 —
  for **1 inhabitant in 252 real-tier dataset functions**.
- m2c's `6/7` is not closer: its source drops both increments (copies one byte forever) and scores
  better only by being two instructions short. Note the denominators differ (m2c 7, asmlift 8).

`docs/ranked-repro.md`'s three-vehicle table re-measures TRUE, re-taken at this branch's final
commit: project checkout `6/9`, `pnpm bench repro … --run` `5/8`, `pnpm bench fan` `5/8`
(`[asmlift source 8089925]`).

## What ships

- `c97863bf` `docs/unmatchable-quirks.md` — the register, the StrCpy proof, the recipe to falsify a
  row's entry, and the condition under which it must be re-opened.
- `e217e618` a command-file block that pronounces a row unmatchable **and** tells the agent to stop
  must link a `docs/…md`. **RED before the commit** (`match-function.md:97`).
- `df1b6d78` that gate examined **0 of 175 blocks** — replayed its own regexes: `blocks 175,
  withPrecedent 1, withStop 6, examined 0`. Re-keyed on the rule, markdown-link form only, `/i`, plus
  `expect(examined > 0)`. Ablated both ways (delete the link: old gate green 21/21, new gate red;
  reword the verdict away too: old green, new red on "examined no block at all").
- `7447128c` the falsification recipe `objcopy … -` wrote a file literally named `-` and exited 0;
  the census counted a proxy. Independent predicate over 252 rows: **2** hits under the old `< 24`
  bound, **3** unbounded — and the `af` repeats sit at *exactly* 24, i.e. the bound was
  reverse-engineered from the answer. Bound deleted; both near-misses now excluded by a compile
  (`sa3:sub_806132C` two `ldr` across a call, one without it; `af:Skin_Matrix_MulMatrix` two
  `lwc1 $f0,0(a0)`, one in the single-read form).
- `c731a473` a verdict that closes a row is falsified by the ARTIFACT, so the gate reads the
  register's table and fails on `asmlift.outcome === 'match'`. Mutation-tested three ways, all red.
- `6a3f61a9` `bench repro --run` died on a bare `ENOENT` when `node_modules/.bin/asmlift` is missing;
  it now names the cause (bin link, or an uninstalled pinned toolchain, with its path).
- `42815f45` the gate was STILL vacuous — held up by a `## Hard rules` decoy. Unit is now the
  BULLET, the corpus assertion a pinned inhabitant set rather than a count. **Five ablations, each
  run to a suite**: old gate green in 4 of 5, new gate red in 5 of 5.
- `03a19033` the register gate parsed row ids out of the whole page including the near-miss table
  (`["kleod:StrCpy:agbcc","sa3:sub_806132C:agbcc"]` → `["kleod:StrCpy:agbcc"]`).
- `fe7cc61b` `bench repro --tool m2c` printed asmlift's `5/8` for an m2c run, called a 0-byte
  `out.err` "no [ranked] line", and reported "exit 0 (byte-exact)" for a run that was neither.
- `dcbcaec5` the recipe cuts from byte 0, which is the function only in a one-function file. Found
  the inhabitant: a `Pad` above the same spelling → `nm -S` value `00000008`, offset-less cut
  `0978017070470000021c087810700132` against the real `021c08781070013201310028f9d17047`.
- `8089925c` comment audit: a gate's comment is its rule, not the record of its defeats. One FALSE
  comment found and fixed — "the cost table 170 lines above has one" is wrong in direction and
  distance (those gates are 125 lines BELOW), a positional reference that rotted inside its own
  branch.

## Moved rows: zero, and why no `pnpm bench run` is owed

`apps/benchmark/src/report/repro.ts` is the branch's only file under `MEASURED_PATHS`. It is **not**
under `SCORING_PATHS` (`apps/benchmark/src/provenance.ts:87`), which `provenance.ts:83-86` calls "the
harness AROUND the decompiler". That is the read; here is the measurement. A load probe was appended
to `repro.ts` and both paths run:

| run | marker |
| --- | --- |
| `pnpm bench run --only StrCpy` (real tier, 1 row measured, 6.3 s) | **absent** |
| `pnpm bench repro kleod:StrCpy:agbcc` | **present** |

So the one measured-path file this branch touches does not execute inside a bench; everything else is
`docs/`, `.claude/commands/` and `apps/benchmark/test/`. The probe's own run stamped the tree dirty
mid-run and is quotable as a reachability probe only, not as a measurement — the probe was reverted
and `apps/benchmark/results/` restored (`git status --porcelain` empty).

`scripts/check-artifact-provenance.sh`: *"the artifact is byte-identical to the base's — this branch
publishes no numbers of its own. UNKNOWN, not checked."*

## Gate counts

- `npx vitest run` (root superset of the three CI suites) — **233 files / 4342 tests**, exit 0.
- `pnpm test:matching` — **42 files / 394 tests**, **0 skips**, exit 0, 69.6 s. In no PR gate; run
  explicitly.
- `pnpm exec vitest run apps/benchmark/test` (the CI mirror, in neither `test:offline` nor `bench`) —
  **40 files / 1182 tests**.
- `pnpm test:offline` — 174 files / 3024 tests. `pnpm typecheck` clean. `pnpm format:check` clean.
  `pnpm lint` 0 errors / 134 pre-existing warnings, none in the changed files.
- Three earlier reviewer reports of red suites (`test:matching` "cannot certify anything",
  `shortcircuit-branch.test.ts` at 409 s / 641 s, 15 failures under `apps/benchmark/test`) were **not
  reproduced** when run serially and alone: 394 pass in 69.6 s, 23/23 in 7.5 s, 1182 pass. Those were
  contention artefacts of concurrent worktrees, not a flaky budget.

## Findings declined, each with its reason

- **Tag the verdict into the dataset as a feature.** Declined twice, the second time with the check
  rather than the read: `SCORING_PATHS` includes `apps/benchmark/dataset`, so a judgement tag moves
  this round from "owes zero bench" to "owes a full one" (~35–110 min) for a verdict that is not a C
  construct — and `@asmlift/bench-schema`'s vocabulary is C constructs. The *reachability* half of
  the same finding was fixed: `/attribute-function` Phase 2 now links the register.
- **Pin "never fabricate a load" through #193's IR oracle.** `irTraceOf` does not model `load` — its
  own comment names `load` the top blocker. The rule stays prose.
- **Move the register gate into `citations.test.ts` and drop the duplicate.** Declined for level, not
  cost (net −25 lines is real): that suite resolves citations by a regex over prose and says of
  itself that it checks nothing semantic; giving it a markdown TABLE parse to reach `outcome` puts
  the only table parse in the file with no table parse. The duplicate is kept with its reason in the
  code — an id that stops resolving leaves `outcome` undefined, which is not `'match'`, so without
  it the falsification check runs over an empty set.
- **A reviewer's proposed third census clause, "no intervening may-aliasing store".** REFUTED by
  compiling: `c = p->a; q->b = c; c = p->a;` compiles byte-identically to the single-read form
  (`0068486008607047`, one `ldr`). That is exactly why this row is an inhabitant — `*dst = c` sits
  between its two reads of `*src`. The clause would have re-broken the census the other way.
- **`dogfood-klonoa.md` admitted to the examined set.** Its block forbids the verdict rather than
  ending a round; admitting it would mean loosening `STOPS`, which is how the gate was defeated the
  second time. It links the register anyway.

## What this round did NOT do

No decompiler capability was built, no candidate was added or removed, no dataset row was added or
retagged, no artifact was regenerated, and no `pnpm bench run` was run as a gate. The runtime print
of a register verdict from `bench baseline` stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5bxiJ5KCo7S7padFmjsAx
